### PR TITLE
fix: keep package.json biome-formatted after changeset version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "biome format --write .",
     "harness": "npm run -w @seekstone/harness start --",
     "smoke": "node scripts/smoke-install.mjs",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && biome format --write .",
     "release": "changeset publish"
   },
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,9 +31,7 @@
     "seekstone": "./dist/index.js"
   },
   "main": "./dist/index.js",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
The `0.1.0` publish was blocked by the release workflow's lint gate: `changeset version` rewrote `packages/server/package.json` with a multi-line `"files": ["dist"]` array, which biome's formatter rejects.

- Re-formats `packages/server/package.json` (biome-clean).
- Makes `version-packages` run `biome format --write .` after `changeset version`, so future "Version Packages" PRs stay lint-clean and don't re-block the publish.

Merging this re-triggers the release workflow, which (no pending changesets, version already `0.1.0`) will publish `seekstone@0.1.0` with provenance.