### PR TITLE
ci: OIDC trusted publishing (fixes EOTP release failure)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      # OIDC trusted publishing requires npm >= 11.5.1.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install
 
@@ -60,6 +64,8 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
+          # No NODE_AUTH_TOKEN: npm authenticates via OIDC trusted publishing.
+          # Requires a Trusted Publisher configured for `seekstone` on npmjs.com
+          # (GitHub Actions, repo shaqmughal/seekstone, workflow release.yml).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -26,16 +26,12 @@ CI (the `CI` workflow) additionally enforces a **coverage gate** on the server's
 
 Settings → Actions → General → Workflow permissions → enable **"Allow GitHub Actions to create and approve pull requests"** (so Changesets can open the version PR).
 
-## Authentication
+## Authentication — OIDC trusted publishing (no token)
 
-Today the workflow authenticates with the `NPM_TOKEN` repo secret (a granular token scoped to `seekstone`) plus `id-token: write` + `NPM_CONFIG_PROVENANCE=true` for provenance.
+The workflow publishes via **OIDC trusted publishing**: no npm token is stored, and provenance is automatic. It needs `id-token: write` (set) and npm ≥ 11.5.1 (the workflow runs `npm install -g npm@latest`).
 
-### Recommended upgrade: OIDC trusted publishing (no token)
+**One-time setup on npmjs.com** (required before the first OIDC publish):
 
-npm granular tokens expire every 90 days. To remove the token (and the rotation chore) entirely, configure **trusted publishing**:
+- The `seekstone` package → **Settings → Trusted Publisher** → **GitHub Actions** → repository `shaqmughal/seekstone`, workflow filename `release.yml`.
 
-1. On npmjs.com → the `seekstone` package → **Settings → Trusted Publisher** → GitHub Actions, repo `shaqmughal/seekstone`, workflow `release.yml`.
-2. Ensure the workflow runs an OIDC-capable npm (`npm install -g npm@latest`).
-3. Remove `NODE_AUTH_TOKEN` from the publish step — npm uses OIDC automatically, and provenance is implicit.
-
-After that the `NPM_TOKEN` secret can be deleted.
+Once configured, the publish step authenticates automatically — there is no `NODE_AUTH_TOKEN`. The old `NPM_TOKEN` secret is no longer used and can be deleted.


### PR DESCRIPTION
Switches the release workflow to **OIDC trusted publishing**, which fixes the `EOTP` failure (npm's 2FA challenged the token in CI).

- Upgrades npm to >= 11.5.1 in the workflow (OIDC requirement).
- Drops `NODE_AUTH_TOKEN` — npm authenticates via GitHub OIDC; provenance stays automatic.
- Updates docs/RELEASING.md.

**Requires one-time npmjs.com setup before merge:** the `seekstone` package → Settings → Trusted Publisher → GitHub Actions → repo `shaqmughal/seekstone`, workflow `release.yml`.

`main` is already at 0.1.0 (changeset consumed). Once the trusted publisher is configured and this merges, the release workflow publishes `seekstone@0.1.0` via OIDC. The `NPM_TOKEN` secret can then be deleted.