### PR TITLE
ci: fix OIDC publish E404 (drop registry-url)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # NOTE: no `registry-url` here on purpose. setup-node's registry-url
+      # writes an ~/.npmrc with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`;
+      # with no token that line is empty and shadows OIDC (configured auth wins),
+      # causing an unauthenticated publish → E404. Omitting it lets npm's
+      # automatic OIDC trusted publishing handle auth against the default registry.
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
 
       # OIDC trusted publishing requires npm >= 11.5.1.
       - name: Upgrade npm


### PR DESCRIPTION
The OIDC release run failed with `E404 Not Found - PUT /seekstone`. Root cause: `setup-node`'s `registry-url` writes an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`; since we removed the token, that line is empty and **shadows OIDC** (configured auth takes precedence), so npm did an unauthenticated publish → 404 (no provenance/OIDC line appeared in the log).

Fix: remove `registry-url` from setup-node so no conflicting `.npmrc` is written; npm 11.6.2 then uses automatic OIDC trusted publishing against the default registry.

`main` is at 0.1.0 (changeset consumed). Merging re-runs the release workflow → should publish `seekstone@0.1.0` via OIDC with provenance.