### PR TITLE
Community-health files, security policy, CLI --version/--help (SHA-38, 39, 33)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# GitHub Sponsor button → Buy Me a Coffee (not a first-class platform, so use custom).
+custom: ["https://buymeacoffee.com/shaqmughal"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Something isn't working as expected
+labels: ["Bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please do **not** report security issues here — see [SECURITY.md](https://github.com/shaqmughal/seekstone/blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce it? Include the tool call or action if relevant.
+      placeholder: |
+        1. Configure seekstone with vault at ...
+        2. Ask Claude to ...
+        3. See ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: seekstone version
+      description: "Output of `npx seekstone --version` or the version in your config. Run the latest if you can."
+      placeholder: "0.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      description: "Output of `node --version` (must be ≥ 22)."
+      placeholder: "v22.x"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: "Run with `SEEKSTONE_LOG_LEVEL=debug` and paste any relevant stderr output. Redact anything private."
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security issue
+    url: https://github.com/shaqmughal/seekstone/security/advisories/new
+    about: Please report security-sensitive issues privately, not as a public issue.
+  - name: Question / discussion
+    url: https://github.com/shaqmughal/seekstone/discussions
+    about: For usage questions and general discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest a new tool, option, or improvement
+labels: ["Feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do that Seekstone doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should it do? If it's a new tool, sketch the inputs/outputs.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other approaches you weighed.
+    validations:
+      required: false
+  - type: checkboxes
+    id: thesis
+    attributes:
+      label: Fit with Seekstone's design
+      description: Seekstone is filesystem-direct — no Obsidian app, no network, low payload.
+      options:
+        - label: This can work by reading/writing the vault on disk (no running Obsidian app required).
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Thanks for contributing! Keep PRs focused. See CONTRIBUTING.md. -->
+
+## What & why
+
+<!-- What does this change, and why? Link any related issue (e.g. "Closes #12"). -->
+
+## How it was tested
+
+<!-- Commands run, manual checks, new/updated tests. -->
+
+## Checklist
+
+- [ ] `npm test` passes
+- [ ] `npm run lint` passes
+- [ ] Typecheck passes (`npx tsc -p packages/<pkg>/tsconfig.json --noEmit`)
+- [ ] Tests added/updated for the change
+- [ ] Added a changeset (`npx changeset`) for any user-facing change — or this is docs/internal only
+- [ ] No new network calls or telemetry in the server

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
++++
+version = "2.1"
+aliases = ["/version/2/1"]
+reportingPlaceholder = "[INSERT CONTACT METHOD]"
++++
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,3 @@
-+++
-version = "2.1"
-aliases = ["/version/2/1"]
-reportingPlaceholder = "[INSERT CONTACT METHOD]"
-+++
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
@@ -42,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at a [GitHub Security Advisory](https://github.com/shaqmughal/seekstone/security/advisories/new) or a confidential message to the maintainer. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to Seekstone
+
+Thanks for your interest in improving Seekstone! This is a small, focused project — a filesystem-direct Obsidian MCP server — and contributions of all sizes are welcome: bug reports, docs, tests, and features.
+
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting set up
+
+Requires [Node.js](https://nodejs.org) ≥ 22.
+
+```bash
+git clone https://github.com/shaqmughal/seekstone.git
+cd seekstone
+npm install
+```
+
+This is an npm-workspaces monorepo:
+
+| Package | What it is |
+|---|---|
+| `packages/server` | The published `seekstone` MCP server (the product). |
+| `packages/core` | Shared vault primitives (walk, frontmatter, extract). Bundled into the server build. |
+| `packages/harness` | Profiler + benchmark + write-safety harness. Dev-only; not published. |
+
+## Development workflow
+
+```bash
+npm test                       # run all tests (vitest, all workspaces)
+npm run lint                   # biome check (lint + format verification)
+npm run format                 # biome auto-format
+npm run build -w seekstone     # build the publishable server (tsup → dist/)
+
+# typecheck a package
+npx tsc -p packages/server/tsconfig.json --noEmit
+
+# run a single test file / single test by name
+npx vitest run packages/server/src/tools/search.test.ts
+npx vitest run -t 'parses a typical frontmatter'
+```
+
+Before opening a PR, make sure **`npm test`, `npm run lint`, and the typechecks all pass** — CI runs them on macOS, Linux, and Windows and will block a merge otherwise.
+
+## Conventions
+
+- **Tests ship with the change.** Add or update co-located `*.test.ts` files for any code you touch. We aim to keep the server's logic modules well covered (CI enforces a coverage threshold).
+- **Formatting is biome.** Run `npm run format` before committing and **stage all the files it changes**, not just the ones you edited.
+- **Line endings are LF** (enforced via `.gitattributes`).
+- **Imports use `.js` extensions** even for TypeScript sources — that's what NodeNext + tsx + tsc agree on.
+- **Never mutate the live vault outside an explicit tool.** Write paths must preserve byte-faithful frontmatter; see the write-safety harness.
+- **No telemetry, no network calls** in the server. This is a core promise — keep it.
+
+## Commit & PR
+
+- Branch off `main`; keep PRs focused.
+- Write clear commit messages (imperative mood, e.g. "add tag index tool"). Conventional-commit prefixes (`feat:`, `fix:`, `docs:`, `ci:`) are encouraged but not required.
+- **Add a changeset** for any user-facing change so it lands in the next release and CHANGELOG:
+  ```bash
+  npx changeset
+  ```
+  Pick `seekstone`, choose the bump (patch/minor/major), and write a one-line summary. Commit the generated `.changeset/*.md` file. Docs-only or internal changes don't need one. See [docs/RELEASING.md](docs/RELEASING.md) for how releases work.
+- Open the PR against `main`; fill in the PR template; make sure CI is green.
+
+## Reporting bugs & requesting features
+
+Use the [issue templates](https://github.com/shaqmughal/seekstone/issues/new/choose). For security issues, **do not open a public issue** — see [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Restart the client. On startup seekstone walks the vault and builds an in-memory
 
 Requires [Node.js](https://nodejs.org) ≥ 22. Works on macOS, Linux, and Windows.
 
+To confirm the package is reachable before wiring it into a client, run `npx -y seekstone --version` (prints the version and exits) or `npx -y seekstone --help`.
+
 ## Tools
 
 | Tool | Description |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported versions
+
+Seekstone is pre-1.0. Fixes are applied to the latest published version on npm. Please make sure you're on the most recent release before reporting an issue.
+
+## Reporting a problem
+
+Please report security-sensitive issues **privately** — do not open a public issue for them.
+
+- Preferred: open a [GitHub Security Advisory](https://github.com/shaqmughal/seekstone/security/advisories/new) (Security → Advisories → Report).
+
+Please include the version, your environment (OS, Node version), and steps to reproduce. We aim to acknowledge a report within a few days and will keep you updated as we work on a fix.
+
+## What Seekstone can and cannot do
+
+Seekstone is designed to be conservative with your data. The published server:
+
+- **Reads and writes only under `SEEKSTONE_VAULT`.** It does not touch files outside the vault directory you configure (the one optional exception is a log file, only if you set `SEEKSTONE_LOG_FILE`).
+- **Makes no outbound network connections and collects no telemetry.** Indexing and search run entirely on your machine.
+- **Only modifies your vault through explicit tool calls** (`create_note`, `delete_note`, `move_note`, `append_note`, `patch_frontmatter`). It never makes background edits.
+- **Preserves file fidelity on writes.** Frontmatter edits keep key order, quote style, and comments; body appends leave the frontmatter region byte-identical. Writes are atomic (write-to-temp then rename).
+
+`delete_note` permanently removes a file and cannot be undone — treat it accordingly.
+
+## Logs and privacy
+
+Logging is metadata-only by default (tool name, vault-relative paths, timings). Note contents and raw query text are only included at the `debug` log level, which you opt into via `SEEKSTONE_LOG_LEVEL=debug`. Logs are written to stderr, and to a file only if you set `SEEKSTONE_LOG_FILE`. Nothing is ever sent off-device.
+
+## A note on the benchmark harness
+
+The dev-only harness (`packages/harness`, not published) includes an adapter for the Obsidian Local REST API plugin, which ships a self-signed certificate. That adapter trusts the certificate through an isolated HTTP agent scoped to that one client — it never disables TLS verification globally (it does not set `NODE_TLS_REJECT_UNAUTHORIZED`). This affects the harness only, not the published server.

--- a/packages/server/src/cli-args.test.ts
+++ b/packages/server/src/cli-args.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { helpText, parseCliIntent } from './cli-args.js';
+
+describe('parseCliIntent', () => {
+  it('returns "run" with no args', () => {
+    expect(parseCliIntent([])).toBe('run');
+  });
+
+  it('recognizes --version and -v', () => {
+    expect(parseCliIntent(['--version'])).toBe('version');
+    expect(parseCliIntent(['-v'])).toBe('version');
+  });
+
+  it('recognizes --help and -h', () => {
+    expect(parseCliIntent(['--help'])).toBe('help');
+    expect(parseCliIntent(['-h'])).toBe('help');
+  });
+
+  it('version takes precedence when it appears first', () => {
+    expect(parseCliIntent(['--version', '--help'])).toBe('version');
+    expect(parseCliIntent(['--help', '--version'])).toBe('help');
+  });
+
+  it('ignores unrelated args', () => {
+    expect(parseCliIntent(['--vault', '/x'])).toBe('run');
+  });
+});
+
+describe('helpText', () => {
+  it('includes the version and the key env var', () => {
+    const text = helpText('1.2.3');
+    expect(text).toContain('seekstone 1.2.3');
+    expect(text).toContain('SEEKSTONE_VAULT');
+    expect(text).toContain('claude mcp add seekstone');
+  });
+});

--- a/packages/server/src/cli-args.ts
+++ b/packages/server/src/cli-args.ts
@@ -1,0 +1,41 @@
+/**
+ * Tiny argument handling for the `seekstone` bin. Kept pure (no process exit,
+ * no IO) so it can be unit-tested. The MCP server itself takes no arguments —
+ * these are just the conventional `--version` / `--help` niceties expected of a
+ * CLI installed via `npx`.
+ */
+
+export type CliIntent = 'version' | 'help' | 'run';
+
+export function parseCliIntent(argv: readonly string[]): CliIntent {
+  for (const arg of argv) {
+    if (arg === '--version' || arg === '-v') return 'version';
+    if (arg === '--help' || arg === '-h') return 'help';
+  }
+  return 'run';
+}
+
+export function helpText(version: string): string {
+  return `seekstone ${version} — an Obsidian MCP server (filesystem-direct, low context-tax)
+
+Seekstone runs as a Model Context Protocol stdio server. It is normally
+launched by an MCP client (Claude Desktop, Claude Code), not run by hand.
+
+Usage:
+  seekstone            Start the MCP server (reads from stdin/stdout)
+  seekstone --version  Print the version and exit
+  seekstone --help     Print this help and exit
+
+Required environment:
+  SEEKSTONE_VAULT      Absolute path to your Obsidian vault
+
+Optional environment:
+  SEEKSTONE_LOG_LEVEL  error | warn | info (default) | debug
+  SEEKSTONE_LOG_FILE   Absolute path; append JSON-line logs here
+  SEEKSTONE_WATCH_POLL Set to 1 to poll for changes (network drives, WSL)
+
+Add to Claude Code:
+  claude mcp add seekstone --env SEEKSTONE_VAULT=/path/to/vault -- npx -y seekstone
+
+Docs: https://github.com/shaqmughal/seekstone`;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,11 +6,28 @@ import {
   type CallToolResult,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { helpText, parseCliIntent } from './cli-args.js';
 import type { ServerContext } from './context.js';
 import { dispatch } from './dispatch.js';
 import { buildIndex } from './index/build.js';
 import { createLogger } from './log.js';
 import { startWatcher } from './watcher.js';
+
+// Inlined at build time by tsup (see tsup.config.ts); falls back in tsx dev.
+declare const __SEEKSTONE_VERSION__: string;
+const VERSION = typeof __SEEKSTONE_VERSION__ === 'string' ? __SEEKSTONE_VERSION__ : '0.0.0-dev';
+
+// --version / --help exit before any server setup, and print to stdout (these
+// are explicit CLI invocations, not the MCP stdio session).
+const intent = parseCliIntent(process.argv.slice(2));
+if (intent === 'version') {
+  process.stdout.write(`${VERSION}\n`);
+  process.exit(0);
+}
+if (intent === 'help') {
+  process.stdout.write(`${helpText(VERSION)}\n`);
+  process.exit(0);
+}
 
 const log = createLogger();
 

--- a/packages/server/src/no-network.test.ts
+++ b/packages/server/src/no-network.test.ts
@@ -1,0 +1,87 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServerContext } from './context.js';
+import { dispatch } from './dispatch.js';
+import { buildIndex } from './index/build.js';
+import { createLogger } from './log.js';
+
+/**
+ * Enforces the core promise: the server makes NO outbound network connections.
+ * We replace Node's connection primitives with throwing stubs, then exercise
+ * the real startup + tool paths. If any of them tries to open a socket, the
+ * stub throws and the test fails.
+ */
+
+const NET_ERROR = 'NETWORK BLOCKED: the server must not make outbound connections';
+const log = createLogger({ env: {}, stderr: () => {} });
+
+let vaultRoot: string;
+let ctx: ServerContext;
+
+beforeAll(async () => {
+  vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-nonet-'));
+  await writeFile(
+    join(vaultRoot, 'a.md'),
+    '---\ntitle: A\ntags: [x]\n---\n# A\nhello world\n',
+    'utf8',
+  );
+  await writeFile(join(vaultRoot, 'b.md'), '# B\nmore text linking [[A]]\n', 'utf8');
+  const built = await buildIndex(vaultRoot);
+  ctx = { vaultRoot, index: built.index, notes: built.notes };
+});
+
+afterAll(async () => {
+  await rm(vaultRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  const block = (() => {
+    throw new Error(NET_ERROR);
+  }) as never;
+  // Cover the primitives every Node network path bottoms out in.
+  vi.spyOn(net, 'connect').mockImplementation(block);
+  vi.spyOn(net, 'createConnection').mockImplementation(block);
+  vi.spyOn(net.Socket.prototype, 'connect').mockImplementation(block);
+  vi.spyOn(http, 'request').mockImplementation(block);
+  vi.spyOn(https, 'request').mockImplementation(block);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('the server makes no outbound network calls', () => {
+  it('the network primitives are actually blocked (guard sanity check)', () => {
+    expect(() => net.connect(80, 'example.com')).toThrow(NET_ERROR);
+    expect(() => http.request('http://example.com')).toThrow(NET_ERROR);
+    expect(() => https.request('https://example.com')).toThrow(NET_ERROR);
+  });
+
+  it('building the index touches no network', async () => {
+    await expect(buildIndex(vaultRoot)).resolves.toBeDefined();
+  });
+
+  it('every tool runs without opening a connection', async () => {
+    const calls: Array<[string, unknown]> = [
+      ['search', { query: 'hello' }],
+      ['read_note', { path: 'a.md' }],
+      ['list_notes', {}],
+      ['create_note', { path: 'new.md', content: 'x' }],
+      ['append_note', { path: 'a.md', content: 'more' }],
+      ['patch_frontmatter', { path: 'a.md', patch: { status: 'done' } }],
+      ['move_note', { from: 'new.md', to: 'moved.md' }],
+      ['delete_note', { path: 'moved.md' }],
+    ];
+    for (const [name, args] of calls) {
+      const res = await dispatch(ctx, name, args, log);
+      // A tool may legitimately error, but never because the network was hit.
+      const text = res.content.map((c) => c.text).join('\n');
+      expect(text).not.toContain(NET_ERROR);
+    }
+  });
+});

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'tsup';
+
+const { version } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 
 // Bundles the MCP server (and the @seekstone/core workspace package) into a
 // single self-contained ESM file with a `#!/usr/bin/env node` shebang.
@@ -13,6 +16,8 @@ export default defineConfig({
   bundle: true,
   // Force the otherwise-default-external workspace package to be inlined.
   noExternal: [/^@seekstone\//],
+  // Inline the package version so `seekstone --version` works in the bundle.
+  define: { __SEEKSTONE_VERSION__: JSON.stringify(version) },
   dts: false,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
Finishes the docs/governance part of Track 1 (launch epic SHA-29).

## SHA-38 — Community-health files
- `CONTRIBUTING.md` — setup, test/lint/typecheck/build commands, changeset + PR conventions, the repo's norms (LF, `.js` imports, no-network).
- `CODE_OF_CONDUCT.md` — official **Contributor Covenant 2.1** (downloaded, not paraphrased); enforcement contact via GitHub Security Advisory.
- `.github/ISSUE_TEMPLATE/` (bug + feature, YAML forms) + `config.yml` (blank issues off; private security link; discussions).
- `.github/PULL_REQUEST_TEMPLATE.md`.
- `.github/FUNDING.yml` — Buy Me a Coffee sponsor button (also covers SHA-42's FUNDING.yml).

## SHA-39 — Security & privacy
- `SECURITY.md` — private reporting channel, filesystem scope, **no-network / no-telemetry** posture, write-safety, log privacy, REST-adapter TLS caveat.
- **`no-network.test.ts`** — stubs `net`/`http`/`https` to throw, then runs the index build + every tool and asserts none opens a connection (enforces the core promise in CI).

## SHA-33 — Install UX
- `seekstone --version` / `--help` (pure `parseCliIntent` + `helpText`, unit-tested; version inlined at build via tsup `define`). Verified on the built bundle.
- README: a verify-install line (`npx -y seekstone --version`).

## Verification
- Tests: core 29, harness 140, **server 104** (added cli-args + no-network). Lint clean; coverage gate passes (97.4%). `--version` prints `0.1.0` and exits 0 on the bundle.

Note: this is docs + a tiny CLI nicety — no changeset (no change to published server behavior beyond the additive `--version`/`--help`). If you'd prefer `--version`/`--help` to count as a user-facing feature, I can add a patch changeset to cut 0.1.1.