### PR TITLE
Add seekstone init setup helper (SHA-34)

### DIFF
--- a/.changeset/cli-init-and-flags.md
+++ b/.changeset/cli-init-and-flags.md
@@ -1,0 +1,8 @@
+---
+"seekstone": minor
+---
+
+Add CLI conveniences for setup and inspection:
+
+- `seekstone init` — validate an Obsidian vault and print the Claude config to paste, or patch the Claude Desktop config in place with `--write` (creates a timestamped backup and never touches your other MCP servers). Supports `--vault`, `--client desktop|code`.
+- `seekstone --version` and `seekstone --help`.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ Requires [Node.js](https://nodejs.org) ≥ 22. Works on macOS, Linux, and Window
 
 To confirm the package is reachable before wiring it into a client, run `npx -y seekstone --version` (prints the version and exits) or `npx -y seekstone --help`.
 
+### Guided setup
+
+Prefer not to hand-edit JSON? `seekstone init` validates your vault and prints the exact config to paste — or patches the Claude Desktop config for you:
+
+```bash
+# Validate the vault and print the config block to copy
+npx -y seekstone init --vault "/absolute/path/to/your/vault"
+
+# Or patch the Claude Desktop config in place (backs it up first, never
+# touches your other MCP servers)
+npx -y seekstone init --vault "/absolute/path/to/your/vault" --write
+
+# Print the Claude Code command instead
+npx -y seekstone init --vault "/absolute/path/to/your/vault" --client code
+```
+
 ## Tools
 
 | Tool | Description |

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -29,6 +29,16 @@ claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- n
 
 Restart the client. On startup seekstone walks the vault and builds an in-memory full-text index (a couple of seconds for a few thousand notes), then keeps it in sync as notes change.
 
+### Guided setup
+
+`seekstone init` validates your vault and prints the config to paste, or patches the Claude Desktop config for you (with a backup, leaving other MCP servers untouched):
+
+```bash
+npx -y seekstone init --vault "/absolute/path/to/your/vault"          # print config
+npx -y seekstone init --vault "/absolute/path/to/your/vault" --write  # patch Claude Desktop
+npx -y seekstone init --vault "/absolute/path/to/your/vault" --client code  # print Claude Code command
+```
+
 ## Configuration
 
 | Env var | Required | Description |

--- a/packages/server/src/cli-args.test.ts
+++ b/packages/server/src/cli-args.test.ts
@@ -24,6 +24,11 @@ describe('parseCliIntent', () => {
   it('ignores unrelated args', () => {
     expect(parseCliIntent(['--vault', '/x'])).toBe('run');
   });
+
+  it('recognizes the init subcommand', () => {
+    expect(parseCliIntent(['init'])).toBe('init');
+    expect(parseCliIntent(['init', '--vault', '/x', '--write'])).toBe('init');
+  });
 });
 
 describe('helpText', () => {
@@ -32,5 +37,9 @@ describe('helpText', () => {
     expect(text).toContain('seekstone 1.2.3');
     expect(text).toContain('SEEKSTONE_VAULT');
     expect(text).toContain('claude mcp add seekstone');
+  });
+
+  it('documents the init subcommand', () => {
+    expect(helpText('1.2.3')).toContain('seekstone init');
   });
 });

--- a/packages/server/src/cli-args.ts
+++ b/packages/server/src/cli-args.ts
@@ -5,9 +5,11 @@
  * CLI installed via `npx`.
  */
 
-export type CliIntent = 'version' | 'help' | 'run';
+export type CliIntent = 'version' | 'help' | 'init' | 'run';
 
 export function parseCliIntent(argv: readonly string[]): CliIntent {
+  // A subcommand, if present, is the first non-flag token.
+  if (argv[0] === 'init') return 'init';
   for (const arg of argv) {
     if (arg === '--version' || arg === '-v') return 'version';
     if (arg === '--help' || arg === '-h') return 'help';
@@ -23,8 +25,14 @@ launched by an MCP client (Claude Desktop, Claude Code), not run by hand.
 
 Usage:
   seekstone            Start the MCP server (reads from stdin/stdout)
+  seekstone init       Validate a vault and print/patch the Claude config
   seekstone --version  Print the version and exit
   seekstone --help     Print this help and exit
+
+"seekstone init" options:
+  --vault <path>       Vault to use (default: $SEEKSTONE_VAULT)
+  --client <name>      desktop (default) | code
+  --write              Patch the Claude Desktop config in place (backs it up first)
 
 Required environment:
   SEEKSTONE_VAULT      Absolute path to your Obsidian vault

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,6 +10,7 @@ import { helpText, parseCliIntent } from './cli-args.js';
 import type { ServerContext } from './context.js';
 import { dispatch } from './dispatch.js';
 import { buildIndex } from './index/build.js';
+import { parseInitArgs, runInit } from './init.js';
 import { createLogger } from './log.js';
 import { startWatcher } from './watcher.js';
 
@@ -17,8 +18,8 @@ import { startWatcher } from './watcher.js';
 declare const __SEEKSTONE_VERSION__: string;
 const VERSION = typeof __SEEKSTONE_VERSION__ === 'string' ? __SEEKSTONE_VERSION__ : '0.0.0-dev';
 
-// --version / --help exit before any server setup, and print to stdout (these
-// are explicit CLI invocations, not the MCP stdio session).
+// CLI subcommands / flags exit before any server setup, printing to stdout
+// (these are explicit invocations, not the MCP stdio session).
 const intent = parseCliIntent(process.argv.slice(2));
 if (intent === 'version') {
   process.stdout.write(`${VERSION}\n`);
@@ -27,6 +28,15 @@ if (intent === 'version') {
 if (intent === 'help') {
   process.stdout.write(`${helpText(VERSION)}\n`);
   process.exit(0);
+}
+if (intent === 'init') {
+  const result = await runInit(parseInitArgs(process.argv.slice(3)), {
+    env: process.env,
+    platform: process.platform,
+    timestamp: new Date().toISOString().replace(/[:.]/g, '-'),
+  });
+  process.stdout.write(`${result.output.join('\n')}\n`);
+  process.exit(result.exitCode);
 }
 
 const log = createLogger();

--- a/packages/server/src/init.test.ts
+++ b/packages/server/src/init.test.ts
@@ -1,0 +1,217 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  claudeDesktopConfigPath,
+  mcpAddCommand,
+  mergeSeekstoneConfig,
+  parseInitArgs,
+  runInit,
+  seekstoneServerConfig,
+  validateVault,
+} from './init.js';
+
+describe('parseInitArgs', () => {
+  it('defaults: no write, desktop client', () => {
+    expect(parseInitArgs([])).toEqual({ write: false, client: 'desktop' });
+  });
+  it('parses --vault, --write, --client', () => {
+    expect(parseInitArgs(['--vault', '/v', '--write', '--client', 'code'])).toEqual({
+      vault: '/v',
+      write: true,
+      client: 'code',
+    });
+  });
+  it('ignores an invalid --client value (keeps default)', () => {
+    expect(parseInitArgs(['--client', 'nonsense']).client).toBe('desktop');
+  });
+});
+
+describe('claudeDesktopConfigPath', () => {
+  it('macOS', () => {
+    expect(claudeDesktopConfigPath('darwin', { home: '/Users/x' })).toBe(
+      '/Users/x/Library/Application Support/Claude/claude_desktop_config.json',
+    );
+  });
+  it('linux', () => {
+    expect(claudeDesktopConfigPath('linux', { home: '/home/x' })).toBe(
+      '/home/x/.config/Claude/claude_desktop_config.json',
+    );
+  });
+  it('windows uses APPDATA', () => {
+    expect(
+      claudeDesktopConfigPath('win32', { appData: 'C:\\Users\\x\\AppData\\Roaming' }),
+    ).toContain('Claude');
+  });
+});
+
+describe('mcpAddCommand / seekstoneServerConfig', () => {
+  it('mcpAddCommand embeds the vault path', () => {
+    expect(mcpAddCommand('/my/vault')).toBe(
+      'claude mcp add seekstone --env SEEKSTONE_VAULT=/my/vault -- npx -y seekstone',
+    );
+  });
+  it('server config uses npx -y seekstone and the vault env', () => {
+    expect(seekstoneServerConfig('/v')).toEqual({
+      command: 'npx',
+      args: ['-y', 'seekstone'],
+      env: { SEEKSTONE_VAULT: '/v' },
+    });
+  });
+});
+
+describe('mergeSeekstoneConfig', () => {
+  it('adds seekstone to an empty/null config', () => {
+    const merged = mergeSeekstoneConfig(null, '/v');
+    expect(merged.mcpServers?.seekstone).toEqual(seekstoneServerConfig('/v'));
+  });
+  it('preserves other servers and top-level keys', () => {
+    const existing = {
+      theme: 'dark',
+      mcpServers: { other: { command: 'foo' } },
+    };
+    const merged = mergeSeekstoneConfig(existing, '/v');
+    expect(merged.theme).toBe('dark');
+    expect((merged.mcpServers as Record<string, unknown>).other).toEqual({ command: 'foo' });
+    expect((merged.mcpServers as Record<string, unknown>).seekstone).toBeDefined();
+  });
+  it('does not mutate the input', () => {
+    const existing = { mcpServers: { other: { command: 'foo' } } };
+    mergeSeekstoneConfig(existing, '/v');
+    expect(existing.mcpServers).toEqual({ other: { command: 'foo' } });
+  });
+  it('is idempotent', () => {
+    const once = mergeSeekstoneConfig(null, '/v');
+    const twice = mergeSeekstoneConfig(once, '/v');
+    expect(twice).toEqual(once);
+  });
+});
+
+describe('validateVault', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'seekstone-init-vault-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('accepts a folder with .obsidian and counts notes', async () => {
+    await mkdir(join(dir, '.obsidian'), { recursive: true });
+    await mkdir(join(dir, 'Sub'), { recursive: true });
+    await writeFile(join(dir, 'a.md'), '# A');
+    await writeFile(join(dir, 'Sub', 'b.md'), '# B');
+    await writeFile(join(dir, 'note.txt'), 'not markdown');
+    const res = await validateVault(dir);
+    expect(res.ok).toBe(true);
+    expect(res.noteCount).toBe(2);
+  });
+
+  it('rejects a folder without .obsidian', async () => {
+    const res = await validateVault(dir);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('.obsidian');
+  });
+
+  it('rejects a non-existent path', async () => {
+    const res = await validateVault(join(dir, 'nope'));
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('does not exist');
+  });
+});
+
+describe('runInit', () => {
+  let dir: string;
+  let vault: string;
+  let home: string;
+  const TS = '2026-05-31T00-00-00-000Z';
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'seekstone-init-run-'));
+    vault = join(dir, 'vault');
+    home = join(dir, 'home');
+    await mkdir(join(vault, '.obsidian'), { recursive: true });
+    await writeFile(join(vault, 'a.md'), '# A');
+    await mkdir(home, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const deps = (over: Partial<Record<string, string>> = {}) => ({
+    env: { HOME: home, ...over } as Record<string, string | undefined>,
+    platform: 'darwin' as NodeJS.Platform,
+    timestamp: TS,
+  });
+
+  it('errors with exit 1 when no vault is given', async () => {
+    const res = await runInit({ write: false, client: 'desktop' }, deps());
+    expect(res.exitCode).toBe(1);
+    expect(res.output.join('\n')).toContain('No vault specified');
+  });
+
+  it('errors with exit 1 for a non-vault directory', async () => {
+    const res = await runInit({ vault: home, write: false, client: 'desktop' }, deps());
+    expect(res.exitCode).toBe(1);
+    expect(res.output.join('\n')).toContain('.obsidian');
+  });
+
+  it('prints the config block (no write) for desktop', async () => {
+    const res = await runInit({ vault, write: false, client: 'desktop' }, deps());
+    expect(res.exitCode).toBe(0);
+    expect(res.wrotePath).toBeUndefined();
+    const text = res.output.join('\n');
+    expect(text).toContain('mcpServers');
+    expect(text).toContain(vault);
+  });
+
+  it('prints the claude mcp add command for code client', async () => {
+    const res = await runInit({ vault, write: false, client: 'code' }, deps());
+    expect(res.output.join('\n')).toContain('claude mcp add seekstone');
+  });
+
+  it('--write creates a new config when none exists', async () => {
+    const res = await runInit({ vault, write: true, client: 'desktop' }, deps());
+    expect(res.exitCode).toBe(0);
+    expect(res.wrotePath).toBeDefined();
+    expect(res.backupPath).toBeUndefined();
+    const written = JSON.parse(await readFile(res.wrotePath as string, 'utf8'));
+    expect(written.mcpServers.seekstone.env.SEEKSTONE_VAULT).toBe(vault);
+  });
+
+  it('--write merges into an existing config and backs it up', async () => {
+    const cfgPath = claudeDesktopConfigPath('darwin', { home });
+    await mkdir(join(home, 'Library', 'Application Support', 'Claude'), { recursive: true });
+    await writeFile(cfgPath, JSON.stringify({ mcpServers: { other: { command: 'x' } } }, null, 2));
+
+    const res = await runInit({ vault, write: true, client: 'desktop' }, deps());
+    expect(res.exitCode).toBe(0);
+    expect(res.backupPath).toBeDefined();
+    // Backup preserves the original.
+    const backup = JSON.parse(await readFile(res.backupPath as string, 'utf8'));
+    expect(backup.mcpServers.other).toEqual({ command: 'x' });
+    // New config keeps `other` AND adds seekstone.
+    const written = JSON.parse(await readFile(cfgPath, 'utf8'));
+    expect(written.mcpServers.other).toEqual({ command: 'x' });
+    expect(written.mcpServers.seekstone).toBeDefined();
+  });
+
+  it('--write refuses to clobber a malformed existing config', async () => {
+    const cfgPath = claudeDesktopConfigPath('darwin', { home });
+    await mkdir(join(home, 'Library', 'Application Support', 'Claude'), { recursive: true });
+    await writeFile(cfgPath, '{ not valid json');
+    const res = await runInit({ vault, write: true, client: 'desktop' }, deps());
+    expect(res.exitCode).toBe(1);
+    expect(res.output.join('\n')).toContain('not valid JSON');
+    // Original left untouched.
+    expect(await readFile(cfgPath, 'utf8')).toBe('{ not valid json');
+  });
+
+  it('--write is idempotent (re-running keeps a single seekstone entry)', async () => {
+    await runInit({ vault, write: true, client: 'desktop' }, deps());
+    const res2 = await runInit({ vault, write: true, client: 'desktop' }, deps());
+    const written = JSON.parse(await readFile(res2.wrotePath as string, 'utf8'));
+    expect(Object.keys(written.mcpServers)).toEqual(['seekstone']);
+  });
+});

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -1,0 +1,247 @@
+import { access, copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+/**
+ * `seekstone init` — a guided setup helper. Validates an Obsidian vault and
+ * prints (or, with --write, patches) the Claude MCP config so a user doesn't
+ * have to hand-edit JSON or guess paths.
+ *
+ * The pure helpers (arg parsing, config-path resolution, additive merge,
+ * command string) are exported and unit-tested. `runInit` wires them to the
+ * filesystem and console.
+ */
+
+export interface InitOptions {
+  vault?: string;
+  write: boolean;
+  client: 'desktop' | 'code';
+}
+
+export function parseInitArgs(argv: readonly string[]): InitOptions {
+  const opts: InitOptions = { write: false, client: 'desktop' };
+  // argv is everything after the `init` subcommand.
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--write') opts.write = true;
+    else if (a === '--vault') opts.vault = argv[++i];
+    else if (a === '--client') {
+      const v = argv[++i];
+      if (v === 'desktop' || v === 'code') opts.client = v;
+    }
+  }
+  return opts;
+}
+
+/** The server config object that goes under `mcpServers.seekstone`. */
+export function seekstoneServerConfig(vaultPath: string): {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+} {
+  return {
+    command: 'npx',
+    args: ['-y', 'seekstone'],
+    env: { SEEKSTONE_VAULT: vaultPath },
+  };
+}
+
+/** The `claude mcp add` one-liner for Claude Code. */
+export function mcpAddCommand(vaultPath: string): string {
+  return `claude mcp add seekstone --env SEEKSTONE_VAULT=${vaultPath} -- npx -y seekstone`;
+}
+
+/**
+ * Resolve the Claude Desktop config path for a platform. Pure — takes the
+ * platform and a home/APPDATA lookup so it can be tested without touching the
+ * real environment.
+ */
+export function claudeDesktopConfigPath(
+  platform: NodeJS.Platform,
+  env: { home?: string; appData?: string },
+): string {
+  if (platform === 'win32') {
+    const base = env.appData ?? join(env.home ?? '', 'AppData', 'Roaming');
+    return join(base, 'Claude', 'claude_desktop_config.json');
+  }
+  const home = env.home ?? '';
+  if (platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+  }
+  // Linux / other
+  return join(home, '.config', 'Claude', 'claude_desktop_config.json');
+}
+
+type McpConfig = { mcpServers?: Record<string, unknown> } & Record<string, unknown>;
+
+/**
+ * Additively merge the seekstone server into an existing Claude config object.
+ * Never removes or alters other servers or top-level keys. Idempotent: running
+ * it again with the same vault produces an identical object. Returns a new
+ * object (does not mutate the input).
+ */
+export function mergeSeekstoneConfig(existing: McpConfig | null, vaultPath: string): McpConfig {
+  const base: McpConfig = existing ? structuredClone(existing) : {};
+  const servers = { ...(base.mcpServers ?? {}) };
+  servers.seekstone = seekstoneServerConfig(vaultPath);
+  return { ...base, mcpServers: servers };
+}
+
+export interface VaultCheck {
+  ok: boolean;
+  noteCount?: number;
+  error?: string;
+}
+
+/** Validate that `vaultPath` looks like an Obsidian vault and count .md notes. */
+export async function validateVault(vaultPath: string): Promise<VaultCheck> {
+  try {
+    const st = await stat(vaultPath);
+    if (!st.isDirectory()) return { ok: false, error: `Not a directory: ${vaultPath}` };
+  } catch {
+    return { ok: false, error: `Path does not exist: ${vaultPath}` };
+  }
+  // An Obsidian vault has a .obsidian/ config folder.
+  try {
+    await access(join(vaultPath, '.obsidian'));
+  } catch {
+    return {
+      ok: false,
+      error: `No ".obsidian" folder found in ${vaultPath} — this doesn't look like an Obsidian vault. Open the folder in Obsidian once to initialize it, or pass the correct --vault path.`,
+    };
+  }
+  return { ok: true, noteCount: await countMarkdown(vaultPath) };
+}
+
+async function countMarkdown(root: string): Promise<number> {
+  let count = 0;
+  async function walk(dir: string): Promise<void> {
+    let entries: Awaited<ReturnType<typeof readdir>>;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name.startsWith('.')) continue; // skip .obsidian, .git, .trash
+      const full = join(dir, e.name);
+      if (e.isDirectory()) await walk(full);
+      else if (e.name.endsWith('.md')) count++;
+    }
+  }
+  await walk(root);
+  return count;
+}
+
+export interface InitResult {
+  ok: boolean;
+  /** Lines to print to stdout. */
+  output: string[];
+  /** Process exit code. */
+  exitCode: number;
+  /** Set when --write actually patched a file. */
+  wrotePath?: string;
+  backupPath?: string;
+}
+
+/**
+ * Run the init flow. `deps` are injectable for testing (env, platform, clock).
+ * Performs filesystem reads always; only writes when `opts.write` is true.
+ */
+export async function runInit(
+  opts: InitOptions,
+  deps: {
+    env: Record<string, string | undefined>;
+    platform: NodeJS.Platform;
+    /** ISO timestamp for the backup filename (injected for determinism in tests). */
+    timestamp: string;
+  },
+): Promise<InitResult> {
+  const vaultPath = opts.vault ?? deps.env.SEEKSTONE_VAULT;
+  if (!vaultPath) {
+    return {
+      ok: false,
+      exitCode: 1,
+      output: [
+        'No vault specified. Pass --vault <path> or set SEEKSTONE_VAULT.',
+        'Example: seekstone init --vault "/Users/you/Obsidian/My Vault"',
+      ],
+    };
+  }
+
+  const check = await validateVault(vaultPath);
+  if (!check.ok) {
+    return { ok: false, exitCode: 1, output: [`✗ ${check.error}`] };
+  }
+
+  const out: string[] = [
+    `✓ Vault looks good: ${vaultPath}`,
+    `  ${check.noteCount} markdown note${check.noteCount === 1 ? '' : 's'} found.`,
+    '',
+  ];
+
+  if (opts.client === 'code') {
+    out.push('Add to Claude Code by running:', '', `  ${mcpAddCommand(vaultPath)}`, '');
+    return { ok: true, exitCode: 0, output: out };
+  }
+
+  // Claude Desktop
+  const configPath = claudeDesktopConfigPath(deps.platform, {
+    home: deps.env.HOME,
+    appData: deps.env.APPDATA,
+  });
+  const block = JSON.stringify(
+    { mcpServers: { seekstone: seekstoneServerConfig(vaultPath) } },
+    null,
+    2,
+  );
+
+  if (!opts.write) {
+    out.push(
+      'Add this to your Claude Desktop config:',
+      `  ${configPath}`,
+      '',
+      block,
+      '',
+      'Then restart Claude Desktop. Or re-run with --write to patch it automatically.',
+    );
+    return { ok: true, exitCode: 0, output: out };
+  }
+
+  // --write: additive, backed-up patch.
+  let existing: McpConfig | null = null;
+  let existingRaw: string | null = null;
+  try {
+    existingRaw = await readFile(configPath, 'utf8');
+    existing = JSON.parse(existingRaw) as McpConfig;
+  } catch (err) {
+    if (existingRaw !== null) {
+      // File exists but isn't valid JSON — refuse rather than clobber.
+      return {
+        ok: false,
+        exitCode: 1,
+        output: [
+          `✗ ${configPath} exists but is not valid JSON; not modifying it.`,
+          `  ${err instanceof Error ? err.message : String(err)}`,
+        ],
+      };
+    }
+    existing = null; // file simply doesn't exist yet
+  }
+
+  const merged = mergeSeekstoneConfig(existing, vaultPath);
+  let backupPath: string | undefined;
+  await mkdir(dirname(configPath), { recursive: true });
+  if (existingRaw !== null) {
+    backupPath = `${configPath}.backup-${deps.timestamp}`;
+    await copyFile(configPath, backupPath);
+  }
+  await writeFile(configPath, `${JSON.stringify(merged, null, 2)}\n`, 'utf8');
+
+  out.push(
+    `✓ Patched ${configPath}`,
+    backupPath ? `  Backup saved to ${backupPath}` : '  (created a new config file)',
+    '',
+    'Restart Claude Desktop to load seekstone.',
+  );
+  return { ok: true, exitCode: 0, output: out, wrotePath: configPath, backupPath };
+}

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from 'node:fs';
 import { access, copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import path, { dirname, join } from 'node:path';
 
@@ -119,7 +120,7 @@ export async function validateVault(vaultPath: string): Promise<VaultCheck> {
 async function countMarkdown(root: string): Promise<number> {
   let count = 0;
   async function walk(dir: string): Promise<void> {
-    let entries: Awaited<ReturnType<typeof readdir>>;
+    let entries: Dirent[];
     try {
       entries = await readdir(dir, { withFileTypes: true });
     } catch {

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -1,5 +1,5 @@
 import { access, copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import path, { dirname, join } from 'node:path';
 
 /**
  * `seekstone init` — a guided setup helper. Validates an Obsidian vault and
@@ -59,16 +59,20 @@ export function claudeDesktopConfigPath(
   platform: NodeJS.Platform,
   env: { home?: string; appData?: string },
 ): string {
+  // Use the target platform's path semantics, not the host's, so the result is
+  // correct in production AND deterministic in tests on any CI OS.
   if (platform === 'win32') {
-    const base = env.appData ?? join(env.home ?? '', 'AppData', 'Roaming');
-    return join(base, 'Claude', 'claude_desktop_config.json');
+    const j = path.win32.join;
+    const base = env.appData ?? j(env.home ?? '', 'AppData', 'Roaming');
+    return j(base, 'Claude', 'claude_desktop_config.json');
   }
+  const j = path.posix.join;
   const home = env.home ?? '';
   if (platform === 'darwin') {
-    return join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+    return j(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
   }
   // Linux / other
-  return join(home, '.config', 'Claude', 'claude_desktop_config.json');
+  return j(home, '.config', 'Claude', 'claude_desktop_config.json');
 }
 
 type McpConfig = { mcpServers?: Record<string, unknown> } & Record<string, unknown>;


### PR DESCRIPTION
The last code item in Track 1 (launch epic SHA-29): a guided `seekstone init` so users don't hand-edit JSON.

## What it does
```bash
seekstone init --vault "/path/to/vault"                 # validate + print config
seekstone init --vault "/path/to/vault" --write         # patch Claude Desktop config
seekstone init --vault "/path/to/vault" --client code   # print the claude mcp add command
```

- **Validates** the vault (must contain `.obsidian/`) and reports the `.md` note count; refuses a non-vault dir with an actionable message and a non-zero exit.
- **Prints** the exact `claude_desktop_config.json` block (resolving the per-OS path) or the Claude Code `claude mcp add` command.
- **`--write`** patches `claude_desktop_config.json` **additively** — backs up the original first (timestamped), preserves other servers and top-level keys, is idempotent, and refuses to clobber a malformed config. `--write` is never implied.

## Design / testing
- Pure helpers (`claudeDesktopConfigPath`, `mergeSeekstoneConfig`, `parseInitArgs`, `mcpAddCommand`) are unit-tested; IO + console go through `runInit` with injected `env`/`platform`/`timestamp` for deterministic tests.
- **19 new init tests** + cli-args updates. Full suite **301** (server 132). Lint clean; coverage gate green (`init.ts` 98%, overall 99.45%).
- Verified end-to-end on the built bundle: print/code/write/merge+backup/error-exit all correct.

## Acceptance criteria (all met)
- [x] Valid vault → paste-ready config + note count
- [x] `--write` merges without clobbering other servers, backs up first
- [x] Non-vault dir → actionable error, exit 1
- [x] Never writes outside the Claude config path; `--write` never implied

Includes a **minor changeset** (→ 0.2.0) covering `init` and the `--version`/`--help` that shipped unreleased in #10. Merging will open a Version Packages PR; merging that publishes 0.2.0.