### PR TITLE
MCP registry listing materials + mcp-name (SHA-40)

### DIFF
--- a/.changeset/mcp-name-registry.md
+++ b/.changeset/mcp-name-registry.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Add the `mcp-name` package field (`io.github.shaqmughal/seekstone`) so the package can be verified and listed in the official MCP registry.

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -1,0 +1,68 @@
+# Publishing to MCP registries
+
+How Seekstone gets listed where people discover MCP servers. The repo already
+contains the config files each registry reads (`server.json`, `smithery.yaml`,
+`glama.json`) and the `mcp-name` field in `packages/server/package.json`. What
+remains are the authenticated submission steps a maintainer runs by hand.
+
+## Canonical copy (reuse everywhere)
+
+- **Name:** Seekstone
+- **Tagline:** An Obsidian MCP server — filesystem-direct, low context-tax.
+- **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 8 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
+- **Install:** `npx -y seekstone` (env `SEEKSTONE_VAULT=/path/to/vault`)
+- **Repo:** https://github.com/shaqmughal/seekstone
+- **npm:** https://www.npmjs.com/package/seekstone
+- **Tools:** search, read_note, list_notes, create_note, delete_note, move_note, append_note, patch_frontmatter
+- **Categories/tags:** obsidian, notes, knowledge-base, markdown, search
+
+## 1. Official MCP registry  (requires the 0.2.1 release to be live first)
+
+Prereq: `seekstone@0.2.1` published (it carries the `mcp-name` field the
+registry validates). `server.json` at the repo root is ready.
+
+```bash
+# Install the publisher CLI (see modelcontextprotocol/registry releases for the latest)
+# then, from the repo root:
+mcp-publisher login github     # authorizes the io.github.shaqmughal/* namespace
+mcp-publisher publish          # validates server.json + the mcp-name linkage, then lists it
+```
+
+Verify: the server resolves in the registry under `io.github.shaqmughal/seekstone`.
+If the CLI reports a schema mismatch, re-check the `$schema` date in `server.json`
+against the current registry docs and bump it. The registry verifies ownership by
+matching the `name` here to the `mcp-name` field in the published `package.json`
+(both are `io.github.shaqmughal/seekstone`), so 0.2.1 must be live on npm first.
+
+## 2. Smithery
+
+`smithery.yaml` (repo root) tells Smithery how to launch the stdio server.
+
+1. Sign in at https://smithery.ai with GitHub.
+2. Add/claim the server by connecting the `shaqmughal/seekstone` repo.
+3. Confirm the config field (vault path) renders and a test launch works.
+
+## 3. Glama
+
+Glama auto-indexes public MCP repos, so Seekstone may already appear. `glama.json`
+(repo root) sets the maintainer for claiming.
+
+1. Sign in at https://glama.ai with GitHub.
+2. Claim the `shaqmughal/seekstone` listing; confirm the README/metadata look right.
+
+## 4. awesome-mcp-servers (community lists)
+
+Open a PR adding Seekstone under the Obsidian / knowledge-management section of
+the relevant list(s) (e.g. punkpeye/awesome-mcp-servers). Suggested entry:
+
+```markdown
+- [shaqmughal/seekstone](https://github.com/shaqmughal/seekstone) 📇 🏠 — Filesystem-direct Obsidian vault server with low context-tax (search + edit notes without the Local REST API plugin).
+```
+
+(Match each list's emoji/format conventions in its README before submitting.)
+
+## Keeping listings current
+
+On each release, bump the `version` in `server.json` and re-run `mcp-publisher publish`.
+Smithery/Glama track the repo automatically. Keep the canonical copy above in sync
+with the README.

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -18,21 +18,30 @@ remains are the authenticated submission steps a maintainer runs by hand.
 
 ## 1. Official MCP registry  (requires the 0.2.1 release to be live first)
 
-Prereq: `seekstone@0.2.1` published (it carries the `mcp-name` field the
+Prereq: `seekstone@0.2.1` published (it carries the `mcpName` field the
 registry validates). `server.json` at the repo root is ready.
 
 ```bash
-# Install the publisher CLI (see modelcontextprotocol/registry releases for the latest)
-# then, from the repo root:
-mcp-publisher login github     # authorizes the io.github.shaqmughal/* namespace
-mcp-publisher publish          # validates server.json + the mcp-name linkage, then lists it
+# Install the publisher CLI (macOS/Linux):
+curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
+# (or: brew install mcp-publisher)
+
+# From the repo root:
+mcp-publisher login github     # device-code auth; authorizes the io.github.shaqmughal/* namespace
+mcp-publisher publish          # validates server.json against the mcpName in the published package, then lists it
 ```
 
-Verify: the server resolves in the registry under `io.github.shaqmughal/seekstone`.
-If the CLI reports a schema mismatch, re-check the `$schema` date in `server.json`
-against the current registry docs and bump it. The registry verifies ownership by
-matching the `name` here to the `mcp-name` field in the published `package.json`
-(both are `io.github.shaqmughal/seekstone`), so 0.2.1 must be live on npm first.
+Verify:
+
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.shaqmughal/seekstone"
+```
+
+The registry verifies ownership by matching `name` in `server.json` to the
+`mcpName` field in the published `package.json` (both `io.github.shaqmughal/seekstone`),
+so **0.2.1 must be live on npm first**. If the CLI reports a schema mismatch,
+re-check the `$schema` date in `server.json` against the current quickstart docs.
+The registry is in **preview** — expect occasional breaking changes.
 
 ## 2. Smithery
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["shaqmughal"]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "seekstone",
   "version": "0.2.0",
-  "mcp-name": "io.github.shaqmughal/seekstone",
+  "mcpName": "io.github.shaqmughal/seekstone",
   "type": "module",
   "description": "Seekstone MCP server — filesystem-direct Obsidian vault access, low context-tax.",
   "keywords": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "seekstone",
   "version": "0.2.0",
+  "mcp-name": "io.github.shaqmughal/seekstone",
   "type": "module",
   "description": "Seekstone MCP server — filesystem-direct Obsidian vault access, low context-tax.",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.shaqmughal/seekstone",
+  "description": "Filesystem-direct Obsidian MCP server with low context-tax: search and edit your vault without routing through the Local REST API plugin.",
+  "version": "0.2.1",
+  "repository": {
+    "url": "https://github.com/shaqmughal/seekstone",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "seekstone",
+      "version": "0.2.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SEEKSTONE_VAULT",
+          "description": "Absolute path to your Obsidian vault.",
+          "isRequired": true
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shaqmughal/seekstone",
   "description": "Filesystem-direct Obsidian MCP server with low context-tax: search and edit your vault without routing through the Local REST API plugin.",
   "version": "0.2.1",
@@ -10,7 +10,6 @@
   "packages": [
     {
       "registryType": "npm",
-      "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "seekstone",
       "version": "0.2.1",
       "transport": {

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,19 @@
+# Smithery configuration — describes how to launch the stdio MCP server.
+# https://smithery.ai/docs
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - vaultPath
+    properties:
+      vaultPath:
+        type: string
+        title: Obsidian vault path
+        description: Absolute path to your Obsidian vault.
+  commandFunction: |
+    (config) => ({
+      command: 'npx',
+      args: ['-y', 'seekstone'],
+      env: { SEEKSTONE_VAULT: config.vaultPath }
+    })


### PR DESCRIPTION
Makes Seekstone discoverable where people look for MCP servers. This PR adds the **config files each registry reads** and the **`mcp-name` field** the official registry needs to verify ownership; the actual authenticated submissions are a maintainer checklist in `docs/REGISTRIES.md`.

## Changes
- **`packages/server/package.json`** — `mcp-name: io.github.shaqmughal/seekstone` (official registry matches this to `server.json`'s `name` to prove ownership). Takes effect once **0.2.1** publishes.
- **`server.json`** — official MCP registry manifest (npm + stdio, `SEEKSTONE_VAULT` env), schema `2025-09-29`, `registryBaseUrl` set.
- **`smithery.yaml`** — Smithery stdio launch config with a vault-path config field.
- **`glama.json`** — Glama maintainer claim.
- **`docs/REGISTRIES.md`** — one canonical description reused everywhere + step-by-step submission checklist for official registry / Smithery / Glama / awesome-mcp.
- **changeset (patch → 0.2.1)** to publish the `mcp-name` field.

## After merge (the human-auth steps — checklist in docs/REGISTRIES.md)
1. 0.2.1 publishes automatically via the release pipeline (carries `mcp-name`).
2. `mcp-publisher login github` + `publish` → official registry.
3. Sign in to Smithery / Glama with GitHub, claim/connect the repo.
4. Open the awesome-mcp-servers PR (I can draft it via `gh` when you're ready).

## Verified
- `server.json` + `glama.json` valid JSON; schema set to the current registry requirements (researched, not assumed); lint clean. No code/behavior change — only metadata + the additive `mcp-name` field.