### PR TITLE
fix: shorten server.json description to registry 100-char limit

### DIFF
--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -16,6 +16,8 @@ remains are the authenticated submission steps a maintainer runs by hand.
 - **Tools:** search, read_note, list_notes, create_note, delete_note, move_note, append_note, patch_frontmatter
 - **Categories/tags:** obsidian, notes, knowledge-base, markdown, search
 
+<!-- Note: the official registry caps server.json `description` at 100 characters. -->
+
 ## 1. Official MCP registry  (requires the 0.2.1 release to be live first)
 
 Prereq: `seekstone@0.2.1` published (it carries the `mcpName` field the

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shaqmughal/seekstone",
-  "description": "Filesystem-direct Obsidian MCP server with low context-tax: search and edit your vault without routing through the Local REST API plugin.",
+  "description": "Filesystem-direct Obsidian MCP server — search and edit your vault with low context-tax.",
   "version": "0.2.1",
   "repository": {
     "url": "https://github.com/shaqmughal/seekstone",


### PR DESCRIPTION
The official MCP registry rejected `mcp-publisher publish` with 422 — `description` must be ≤ 100 chars (ours was 132). Trimmed to 87 chars.

`server.json` is a repo-only file the publisher reads locally (not in the npm package), so **no release needed** — re-run `mcp-publisher publish` after this merges and you pull.

Also added a note in docs/REGISTRIES.md about the 100-char cap.