### PR TITLE
Add obsidian-mcp-seekstone discoverability shim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3532,6 +3532,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obsidian-mcp-seekstone": {
+      "resolved": "packages/obsidian-mcp-seekstone",
+      "link": true
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -6156,9 +6160,22 @@
         "seekstone-harness": "src/cli.ts"
       }
     },
+    "packages/obsidian-mcp-seekstone": {
+      "version": "0.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "seekstone": ">=0.2.1"
+      },
+      "bin": {
+        "obsidian-mcp-seekstone": "bin/seekstone.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "packages/server": {
       "name": "seekstone",
-      "version": "0.0.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "harness": "npm run -w @seekstone/harness start --",
+    "publish:shim": "npm publish -w obsidian-mcp-seekstone",
     "smoke": "node scripts/smoke-install.mjs",
     "version-packages": "changeset version && biome format --write .",
     "release": "changeset publish"

--- a/packages/obsidian-mcp-seekstone/LICENSE
+++ b/packages/obsidian-mcp-seekstone/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shaq Mughal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/obsidian-mcp-seekstone/README.md
+++ b/packages/obsidian-mcp-seekstone/README.md
@@ -1,0 +1,53 @@
+# obsidian-mcp-seekstone
+
+> **A discoverability alias for [seekstone](https://www.npmjs.com/package/seekstone)** — the filesystem-direct Obsidian MCP server.
+
+`obsidian-mcp-seekstone` and `seekstone` are the same server. This package exists so users searching npm for "obsidian mcp" can find it. The underlying code, tools, and documentation all live in [shaqmughal/seekstone](https://github.com/shaqmughal/seekstone).
+
+## Why seekstone?
+
+Seekstone reads your Obsidian vault **directly from disk** instead of routing through the Local REST API plugin. The practical difference: a search that returns ~1.75 MB / ~459,000 tokens via the REST plugin returns **~3 KB / ~800 tokens** via seekstone — a ~575× reduction. No Obsidian app, no plugin, no network calls.
+
+## Install
+
+**Claude Desktop** — `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "seekstone": {
+      "command": "npx",
+      "args": ["-y", "obsidian-mcp-seekstone"],
+      "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
+    }
+  }
+}
+```
+
+**Claude Code:**
+
+```bash
+claude mcp add seekstone --env SEEKSTONE_VAULT=/path/to/vault -- npx -y obsidian-mcp-seekstone
+```
+
+## Tools
+
+8 tools over stdio: `search`, `read_note`, `list_notes`, `create_note`, `delete_note`, `move_note`, `append_note`, `patch_frontmatter`.
+
+## Configuration
+
+| Variable | Required | Description |
+|---|---|---|
+| `SEEKSTONE_VAULT` | Yes | Absolute path to your Obsidian vault. |
+| `SEEKSTONE_LOG_LEVEL` | No | `error` \| `warn` \| `info` (default) \| `debug`. |
+| `SEEKSTONE_WATCH_POLL` | No | Set to `1` for network drives / WSL. |
+
+Works on macOS, Linux, and Windows (Node.js ≥ 22).
+
+## Source & docs
+
+Everything is in [shaqmughal/seekstone](https://github.com/shaqmughal/seekstone). Issues, PRs, and docs live there.
+
+## License
+
+MIT © Shaq Mughal

--- a/packages/obsidian-mcp-seekstone/bin/seekstone.js
+++ b/packages/obsidian-mcp-seekstone/bin/seekstone.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// obsidian-mcp-seekstone — discoverability alias for seekstone.
+// Passes all arguments and env through to the real server so
+// `npx -y obsidian-mcp-seekstone` is a drop-in for `npx -y seekstone`.
+import { createRequire } from 'node:module';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+let entry;
+try {
+  entry = require.resolve('seekstone');
+} catch {
+  process.stderr.write(
+    'obsidian-mcp-seekstone: seekstone is not installed.\n' + 'Run: npm install seekstone\n',
+  );
+  process.exit(1);
+}
+
+const child = spawn(process.execPath, [entry, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});

--- a/packages/obsidian-mcp-seekstone/bin/seekstone.js
+++ b/packages/obsidian-mcp-seekstone/bin/seekstone.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
+import { spawn } from 'node:child_process';
 // obsidian-mcp-seekstone — discoverability alias for seekstone.
 // Passes all arguments and env through to the real server so
 // `npx -y obsidian-mcp-seekstone` is a drop-in for `npx -y seekstone`.
 import { createRequire } from 'node:module';
-import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 let entry;

--- a/packages/obsidian-mcp-seekstone/package.json
+++ b/packages/obsidian-mcp-seekstone/package.json
@@ -1,5 +1,6 @@
 {
   "name": "obsidian-mcp-seekstone",
+  "type": "module",
   "version": "0.2.1",
   "description": "Filesystem-direct Obsidian MCP server — a discoverability alias for seekstone. Reads your vault directly from disk with ~575× smaller payloads than the REST plugin.",
   "keywords": [

--- a/packages/obsidian-mcp-seekstone/package.json
+++ b/packages/obsidian-mcp-seekstone/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "obsidian-mcp-seekstone",
+  "version": "0.2.1",
+  "description": "Filesystem-direct Obsidian MCP server — a discoverability alias for seekstone. Reads your vault directly from disk with ~575× smaller payloads than the REST plugin.",
+  "keywords": [
+    "obsidian",
+    "mcp",
+    "obsidian-mcp",
+    "model-context-protocol",
+    "obsidian-ai",
+    "vault",
+    "notes",
+    "markdown",
+    "pkm",
+    "personal-knowledge-management",
+    "knowledge-base",
+    "note-taking"
+  ],
+  "license": "MIT",
+  "author": "Shaq Mughal",
+  "homepage": "https://github.com/shaqmughal/seekstone#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shaqmughal/seekstone.git",
+    "directory": "packages/obsidian-mcp-seekstone"
+  },
+  "bugs": {
+    "url": "https://github.com/shaqmughal/seekstone/issues"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "bin": {
+    "obsidian-mcp-seekstone": "./bin/seekstone.js"
+  },
+  "files": ["bin", "README.md", "LICENSE"],
+  "dependencies": {
+    "seekstone": ">=0.2.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
Adds `packages/obsidian-mcp-seekstone` — a thin npm package so users searching "obsidian mcp" on npm or GitHub find Seekstone.

## What it is

A shim (not a separate server). The `bin/seekstone.js` just spawns the real installed `seekstone` binary via `child_process.spawn`, passing all args and env through. So:

```bash
npx -y obsidian-mcp-seekstone   # identical to: npx -y seekstone
```

## Why

Every competing Obsidian MCP server has "obsidian" or "mcp-obsidian" in its name or package. "seekstone" doesn't surface in an npm search for "obsidian mcp" — this shim does.

## Keywords added

`obsidian-mcp`, `obsidian-ai`, `pkm`, `personal-knowledge-management`, `note-taking` — terms that actually surface in search.

## What's NOT changed

- `seekstone` package is untouched (no rename, no disruption to the registry listing or install base).
- No release pipeline integration — the shim is published manually (`npm publish -w obsidian-mcp-seekstone`) immediately after each seekstone release.

## Verification

- `node packages/obsidian-mcp-seekstone/bin/seekstone.js --version` → prints the seekstone version ✓
- `npm pack -w obsidian-mcp-seekstone --dry-run` → 4 files (bin/, README, LICENSE, package.json) ✓
- Lint clean ✓