### PR TITLE
Surface obsidian-mcp-seekstone as the discoverable install name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 <p align="center"><em>An Obsidian MCP server — filesystem-direct, low context-tax.</em></p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/v/seekstone?color=cb3837&logo=npm" alt="npm" /></a>
+  <a href="https://www.npmjs.com/package/obsidian-mcp-seekstone"><img src="https://img.shields.io/npm/v/obsidian-mcp-seekstone?color=cb3837&logo=npm&label=obsidian-mcp-seekstone" alt="npm" /></a>
+  <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/v/seekstone?color=cb3837&logo=npm&label=seekstone" alt="npm (seekstone)" /></a>
   <a href="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml"><img src="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A522-339933?logo=node.js&logoColor=white" alt="Node.js ≥ 22" />
@@ -21,6 +22,15 @@ It runs as a standard [MCP](https://modelcontextprotocol.io) stdio server. No Ob
 
 ## Install
 
+Seekstone is published to npm under two names — use whichever you prefer:
+
+| Package | Best for |
+|---|---|
+| `obsidian-mcp-seekstone` | Searching npm/GitHub for "obsidian mcp" |
+| `seekstone` | Shorter name if you already know it |
+
+Both run the exact same server.
+
 **Claude Desktop** — add to `claude_desktop_config.json` (Settings → Developer → Edit Config):
 
 ```json
@@ -28,7 +38,7 @@ It runs as a standard [MCP](https://modelcontextprotocol.io) stdio server. No Ob
   "mcpServers": {
     "seekstone": {
       "command": "npx",
-      "args": ["-y", "seekstone"],
+      "args": ["-y", "obsidian-mcp-seekstone"],
       "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
     }
   }
@@ -38,14 +48,14 @@ It runs as a standard [MCP](https://modelcontextprotocol.io) stdio server. No Ob
 **Claude Code:**
 
 ```bash
-claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y seekstone
+claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y obsidian-mcp-seekstone
 ```
 
 Restart the client. On startup seekstone walks the vault and builds an in-memory full-text index (a couple of seconds for a few thousand notes), then keeps it in sync as notes change. The eight tools below are then available to Claude.
 
 Requires [Node.js](https://nodejs.org) ≥ 22. Works on macOS, Linux, and Windows.
 
-To confirm the package is reachable before wiring it into a client, run `npx -y seekstone --version` (prints the version and exits) or `npx -y seekstone --help`.
+To confirm the package is reachable before wiring it into a client, run `npx -y obsidian-mcp-seekstone --version` (prints the version and exits).
 
 ### Guided setup
 
@@ -53,14 +63,14 @@ Prefer not to hand-edit JSON? `seekstone init` validates your vault and prints t
 
 ```bash
 # Validate the vault and print the config block to copy
-npx -y seekstone init --vault "/absolute/path/to/your/vault"
+npx -y obsidian-mcp-seekstone init --vault "/absolute/path/to/your/vault"
 
 # Or patch the Claude Desktop config in place (backs it up first, never
 # touches your other MCP servers)
-npx -y seekstone init --vault "/absolute/path/to/your/vault" --write
+npx -y obsidian-mcp-seekstone init --vault "/absolute/path/to/your/vault" --write
 
 # Print the Claude Code command instead
-npx -y seekstone init --vault "/absolute/path/to/your/vault" --client code
+npx -y obsidian-mcp-seekstone init --vault "/absolute/path/to/your/vault" --client code
 ```
 
 ## Tools

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -1,79 +1,78 @@
 # Publishing to MCP registries
 
-How Seekstone gets listed where people discover MCP servers. The repo already
-contains the config files each registry reads (`server.json`, `smithery.yaml`,
-`glama.json`) and the `mcp-name` field in `packages/server/package.json`. What
-remains are the authenticated submission steps a maintainer runs by hand.
+How Seekstone gets listed where people discover MCP servers. The repo contains
+the config files each registry reads (`server.json`, `smithery.yaml`,
+`glama.json`) and the `mcpName` field in `packages/server/package.json`.
+
+## Two npm packages, one server
+
+| Package | npm | Purpose |
+|---|---|---|
+| `obsidian-mcp-seekstone` | [link](https://www.npmjs.com/package/obsidian-mcp-seekstone) | Discoverable via "obsidian mcp" search |
+| `seekstone` | [link](https://www.npmjs.com/package/seekstone) | Canonical short name |
+
+Both are published automatically by the release pipeline on every version bump.
 
 ## Canonical copy (reuse everywhere)
 
-- **Name:** Seekstone
+- **Name:** Seekstone (also: obsidian-mcp-seekstone)
 - **Tagline:** An Obsidian MCP server — filesystem-direct, low context-tax.
 - **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 8 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
-- **Install:** `npx -y seekstone` (env `SEEKSTONE_VAULT=/path/to/vault`)
+- **Install:** `npx -y obsidian-mcp-seekstone` (also: `npx -y seekstone`); env `SEEKSTONE_VAULT=/path/to/vault`
 - **Repo:** https://github.com/shaqmughal/seekstone
-- **npm:** https://www.npmjs.com/package/seekstone
+- **npm:** https://www.npmjs.com/package/obsidian-mcp-seekstone / https://www.npmjs.com/package/seekstone
 - **Tools:** search, read_note, list_notes, create_note, delete_note, move_note, append_note, patch_frontmatter
-- **Categories/tags:** obsidian, notes, knowledge-base, markdown, search
+- **Categories/tags:** obsidian, notes, knowledge-base, markdown, search, obsidian-mcp
 
 <!-- Note: the official registry caps server.json `description` at 100 characters. -->
 
-## 1. Official MCP registry  (requires the 0.2.1 release to be live first)
+## 1. Official MCP registry
 
-Prereq: `seekstone@0.2.1` published (it carries the `mcpName` field the
-registry validates). `server.json` at the repo root is ready.
+`server.json` lists both npm packages. After each release, re-publish to update the version:
 
 ```bash
 # Install the publisher CLI (macOS/Linux):
 curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
 # (or: brew install mcp-publisher)
 
-# From the repo root:
-mcp-publisher login github     # device-code auth; authorizes the io.github.shaqmughal/* namespace
-mcp-publisher publish          # validates server.json against the mcpName in the published package, then lists it
+mcp-publisher login github   # device-code auth (one-time per session)
+mcp-publisher publish        # reads server.json, validates against mcpName in published package
 ```
 
 Verify:
-
 ```bash
 curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.shaqmughal/seekstone"
 ```
 
-The registry verifies ownership by matching `name` in `server.json` to the
-`mcpName` field in the published `package.json` (both `io.github.shaqmughal/seekstone`),
-so **0.2.1 must be live on npm first**. If the CLI reports a schema mismatch,
-re-check the `$schema` date in `server.json` against the current quickstart docs.
-The registry is in **preview** — expect occasional breaking changes.
+The registry is in **preview** — if the CLI reports a schema mismatch, re-check the `$schema` date in `server.json`.
 
 ## 2. Smithery
 
-`smithery.yaml` (repo root) tells Smithery how to launch the stdio server.
+`smithery.yaml` (repo root) tells Smithery how to launch the server. It uses `obsidian-mcp-seekstone` as the install command so users who find it via Smithery get the discoverable name.
 
 1. Sign in at https://smithery.ai with GitHub.
-2. Add/claim the server by connecting the `shaqmughal/seekstone` repo.
-3. Confirm the config field (vault path) renders and a test launch works.
+2. Connect the `shaqmughal/seekstone` repo.
+3. Confirm the vault-path config field renders and a test launch works.
+
+Note: Smithery's UI is currently oriented toward hosted/remote servers. The `smithery.yaml` is in place; the listing may appear via auto-indexing.
 
 ## 3. Glama
 
-Glama auto-indexes public MCP repos, so Seekstone may already appear. `glama.json`
-(repo root) sets the maintainer for claiming.
+Glama auto-indexes public repos. Direct listing: https://glama.ai/mcp/servers/@shaqmughal/seekstone
+
+`glama.json` (repo root) sets the maintainer for claiming.
 
 1. Sign in at https://glama.ai with GitHub.
-2. Claim the `shaqmughal/seekstone` listing; confirm the README/metadata look right.
+2. Claim the `shaqmughal/seekstone` listing.
 
-## 4. awesome-mcp-servers (community lists)
+## 4. awesome-mcp-servers
 
-Open a PR adding Seekstone under the Obsidian / knowledge-management section of
-the relevant list(s) (e.g. punkpeye/awesome-mcp-servers). Suggested entry:
+PR open: https://github.com/punkpeye/awesome-mcp-servers/pull/7190
 
-```markdown
-- [shaqmughal/seekstone](https://github.com/shaqmughal/seekstone) 📇 🏠 — Filesystem-direct Obsidian vault server with low context-tax (search + edit notes without the Local REST API plugin).
-```
-
-(Match each list's emoji/format conventions in its README before submitting.)
+Entry uses `obsidian-mcp-seekstone` for discoverability. Update the PR if the entry needs refreshing.
 
 ## Keeping listings current
 
-On each release, bump the `version` in `server.json` and re-run `mcp-publisher publish`.
-Smithery/Glama track the repo automatically. Keep the canonical copy above in sync
-with the README.
+- **Official registry:** bump the version in `server.json` and re-run `mcp-publisher publish` after each release. The `version` field should always match the current `seekstone` npm version.
+- **Smithery / Glama:** track the repo automatically — no action needed on release.
+- **awesome-mcp-servers:** static PR; only needs updating if the description or install command changes.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,49 +1,55 @@
-# seekstone
+# seekstone / obsidian-mcp-seekstone
 
 **An Obsidian MCP server — filesystem-direct, low context-tax.**
 
-Seekstone reads your Obsidian vault **directly from disk** instead of routing through the Obsidian Local REST API plugin. The practical difference: a search that returns ~1.75 MB / ~459,000 tokens via the REST plugin returns **~3 KB / ~800 tokens** via seekstone — a ~575× reduction. Claude can search and read notes without burning its context window on a single tool call.
+Seekstone reads your Obsidian vault **directly from disk** instead of routing through the Local REST API plugin. The practical difference: a search that returns ~1.75 MB / ~459,000 tokens via the REST plugin returns **~3 KB / ~800 tokens** via seekstone — a ~575× reduction. No context window wasted on a single tool call.
 
-It runs as a standard [MCP](https://modelcontextprotocol.io) stdio server with no Obsidian app or plugin required — just point it at a vault directory.
+It runs as a standard [MCP](https://modelcontextprotocol.io) stdio server. No Obsidian app, no plugin, no network calls — just point it at a vault folder.
+
+**Two npm names, same server:**
+
+| Package | Best for |
+|---|---|
+| [`obsidian-mcp-seekstone`](https://www.npmjs.com/package/obsidian-mcp-seekstone) | Searching npm for "obsidian mcp" |
+| [`seekstone`](https://www.npmjs.com/package/seekstone) | Shorter name if you already know it |
 
 ## Install
 
-```jsonc
-// Claude Desktop — claude_desktop_config.json
+**Claude Desktop** — `claude_desktop_config.json`:
+
+```json
 {
   "mcpServers": {
     "seekstone": {
       "command": "npx",
-      "args": ["-y", "seekstone"],
+      "args": ["-y", "obsidian-mcp-seekstone"],
       "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
     }
   }
 }
 ```
 
-Or with Claude Code:
+**Claude Code:**
 
 ```bash
-claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y seekstone
+claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y obsidian-mcp-seekstone
 ```
-
-Restart the client. On startup seekstone walks the vault and builds an in-memory full-text index (a couple of seconds for a few thousand notes), then keeps it in sync as notes change.
 
 ### Guided setup
 
 `seekstone init` validates your vault and prints the config to paste, or patches the Claude Desktop config for you (with a backup, leaving other MCP servers untouched):
 
 ```bash
-npx -y seekstone init --vault "/absolute/path/to/your/vault"          # print config
-npx -y seekstone init --vault "/absolute/path/to/your/vault" --write  # patch Claude Desktop
-npx -y seekstone init --vault "/absolute/path/to/your/vault" --client code  # print Claude Code command
+npx -y obsidian-mcp-seekstone init --vault "/absolute/path/to/your/vault"          # print config
+npx -y obsidian-mcp-seekstone init --vault "/absolute/path/to/your/vault" --write  # patch Claude Desktop
+npx -y obsidian-mcp-seekstone init --vault "/absolute/path/to/your/vault" --client code
 ```
 
 ## Configuration
 
 | Env var | Required | Description |
 |---|---|---|
-| `SEEKSTONE_VAULT` | yes | Absolute path to the Obsidian vault. |
+| `SEEKSTONE_VAULT` | yes | Absolute path to your Obsidian vault. |
 | `SEEKSTONE_LOG_LEVEL` | no | `error` \| `warn` \| `info` (default) \| `debug`. |
 | `SEEKSTONE_LOG_FILE` | no | Absolute path; when set, JSON-line logs are appended here (size-rotated). |
 | `SEEKSTONE_WATCH_POLL` | no | Set to `1` to stat-poll for changes instead of native OS events — slower but reliable on network drives, WSL, and some containers. |

--- a/server.json
+++ b/server.json
@@ -10,6 +10,21 @@
   "packages": [
     {
       "registryType": "npm",
+      "identifier": "obsidian-mcp-seekstone",
+      "version": "0.2.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SEEKSTONE_VAULT",
+          "description": "Absolute path to your Obsidian vault.",
+          "isRequired": true
+        }
+      ]
+    },
+    {
+      "registryType": "npm",
       "identifier": "seekstone",
       "version": "0.2.1",
       "transport": {

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -14,6 +14,6 @@ startCommand:
   commandFunction: |
     (config) => ({
       command: 'npx',
-      args: ['-y', 'seekstone'],
+      args: ['-y', 'obsidian-mcp-seekstone'],
       env: { SEEKSTONE_VAULT: config.vaultPath }
     })


### PR DESCRIPTION
Makes `obsidian-mcp-seekstone` the leading install name everywhere Seekstone appears, while keeping `seekstone` as the canonical short alias.

## Changes

**Root `README.md`**
- Two npm badges (one per package name)
- Install table explaining both packages → same server
- All `npx -y seekstone` snippets → `npx -y obsidian-mcp-seekstone`

**`packages/server/README.md`** (npm landing page)
- Header now "seekstone / obsidian-mcp-seekstone"
- Two-name table near the top
- Install snippets use `obsidian-mcp-seekstone`

**`server.json`** (official MCP registry)
- Added `obsidian-mcp-seekstone` as a second package entry alongside `seekstone`
- Run `mcp-publisher publish` after merge to update the registry

**`smithery.yaml`**
- Launch command uses `obsidian-mcp-seekstone`

**`docs/REGISTRIES.md`**
- Updated canonical install copy, package table, and per-registry notes

**awesome-mcp-servers PR #7190**
- Updated entry to show `npx -y obsidian-mcp-seekstone` (also: `npx -y seekstone`)

## After merge
Run `mcp-publisher publish` from the repo root to push the updated `server.json` (with both packages) to the official MCP registry.