### PR TITLE
fix: add mcpName to obsidian-mcp-seekstone package.json

### DIFF
--- a/packages/obsidian-mcp-seekstone/package.json
+++ b/packages/obsidian-mcp-seekstone/package.json
@@ -1,5 +1,6 @@
 {
   "name": "obsidian-mcp-seekstone",
+  "mcpName": "io.github.shaqmughal/seekstone",
   "type": "module",
   "version": "0.2.1",
   "description": "Filesystem-direct Obsidian MCP server — a discoverability alias for seekstone. Reads your vault directly from disk with ~575× smaller payloads than the REST plugin.",


### PR DESCRIPTION
The official MCP registry validates that every npm package listed in `server.json` has `mcpName` set. `obsidian-mcp-seekstone` was missing it, causing `mcp-publisher publish` to return 400. Adds `"mcpName": "io.github.shaqmughal/seekstone"` to the shim package.

Also picks up the `mcpName` field in the next `npm publish` (it ships as part of the package tarball, same as `seekstone`'s field).