### PR TITLE
chore: release obsidian-mcp-seekstone with mcpName (→ 0.2.2)

### DIFF
--- a/.changeset/shim-mcpname.md
+++ b/.changeset/shim-mcpname.md
@@ -1,0 +1,5 @@
+---
+"obsidian-mcp-seekstone": patch
+---
+
+Add `mcpName` field required by the official MCP registry for package ownership verification.


### PR DESCRIPTION
Adds a changeset so the release pipeline publishes `obsidian-mcp-seekstone@0.2.2` with the `mcpName` field in the tarball.

The field was added to the repo in #20 but the registry validates against the **published** npm package (`0.2.1` predates the fix), so `mcp-publisher publish` still fails with 400. This bumps the shim to 0.2.2 so the field ships.

Since the packages are `linked` in Changesets, seekstone also bumps to 0.2.2 (patch — no user-visible change).