### PR TITLE
docs: add Buy Me a Coffee badge and Support section (SHA-42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml"><img src="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A522-339933?logo=node.js&logoColor=white" alt="Node.js ≥ 22" />
+  <a href="https://buymeacoffee.com/shaqmughal"><img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-%E2%98%95-FFDD00?logo=buymeacoffee&logoColor=black" alt="Buy me a coffee" /></a>
 </p>
 
 ---
@@ -225,6 +226,12 @@ npx tsx packages/harness/src/cli.ts safety --vault "$SEEKSTONE_VAULT"
 ```
 
 Harness env vars: `SEEKSTONE_REST_API_KEY` (from the Local REST API plugin) and `SEEKSTONE_REST_URL` (defaults to `https://127.0.0.1:27124`).
+
+---
+
+## Support
+
+Seekstone is free and open source. If it saves you context (and money), you can [buy me a coffee](https://buymeacoffee.com/shaqmughal).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds Buy Me a Coffee badge to the README badge row
- Adds a `## Support` section above License with a one-liner and the link
- `.github/FUNDING.yml` was already present and correct — no change needed

## Manual checks

- [ ] Badge image loads and links to https://buymeacoffee.com/shaqmughal
- [ ] GitHub repo header shows the Sponsor button
- [ ] `npm pack -w seekstone --dry-run` tarball contents unchanged (docs-only change)