### PR TITLE
feat: automate shim versioning, publishing, and add shim tests

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [["seekstone", "obsidian-mcp-seekstone"]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
 
       # On a push that still has changesets pending → opens/updates a "Version
       # Packages" PR. On the push that merges that PR (no changesets left) →
-      # publishes to npm with provenance. Re-publishing an existing version is
-      # a no-op, so this is safe to re-run.
+      # publishes both seekstone and obsidian-mcp-seekstone to npm with
+      # provenance. Re-publishing an existing version is a no-op.
       - name: Create release PR or publish
         uses: changesets/action@v1
         with:
@@ -69,7 +69,8 @@ jobs:
           title: 'chore: version packages'
         env:
           # No NODE_AUTH_TOKEN: npm authenticates via OIDC trusted publishing.
-          # Requires a Trusted Publisher configured for `seekstone` on npmjs.com
-          # (GitHub Actions, repo shaqmughal/seekstone, workflow release.yml).
+          # Requires a Trusted Publisher configured for BOTH packages on npmjs.com:
+          #   - seekstone (GitHub Actions, repo shaqmughal/seekstone, workflow release.yml)
+          #   - obsidian-mcp-seekstone (same settings)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6164,10 +6164,13 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "seekstone": ">=0.2.1"
+        "seekstone": "0.2.1"
       },
       "bin": {
         "obsidian-mcp-seekstone": "bin/seekstone.js"
+      },
+      "devDependencies": {
+        "seekstone": "0.2.1"
       },
       "engines": {
         "node": ">=22"

--- a/packages/obsidian-mcp-seekstone/bin/seekstone.js
+++ b/packages/obsidian-mcp-seekstone/bin/seekstone.js
@@ -4,11 +4,25 @@ import { spawn } from 'node:child_process';
 // Passes all arguments and env through to the real seekstone binary so
 // `npx -y obsidian-mcp-seekstone` is a drop-in for `npx -y seekstone`.
 import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
+const binDir = dirname(fileURLToPath(import.meta.url));
+
+// Search ancestor node_modules directories. npm workspaces hoists seekstone
+// to the monorepo root, which may be several levels above the bin file.
+const searchPaths = [
+  binDir,
+  join(binDir, '..'),
+  join(binDir, '..', '..'),
+  join(binDir, '..', '..', '..'),
+  join(binDir, '..', '..', '..', '..'),
+].map((d) => join(d, 'node_modules'));
+
 let entry;
 try {
-  entry = require.resolve('seekstone');
+  entry = require.resolve('seekstone', { paths: searchPaths });
 } catch {
   process.stderr.write(
     'obsidian-mcp-seekstone: seekstone is not installed.\n' + 'Run: npm install seekstone\n',

--- a/packages/obsidian-mcp-seekstone/bin/seekstone.js
+++ b/packages/obsidian-mcp-seekstone/bin/seekstone.js
@@ -4,39 +4,12 @@ import { spawn } from 'node:child_process';
 // Passes all arguments and env through to the real seekstone binary so
 // `npx -y obsidian-mcp-seekstone` is a drop-in for `npx -y seekstone`.
 import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
-
-// Walk up from this file to find the seekstone package, checking:
-// 1. Our own node_modules (installed from npm — the normal case)
-// 2. The monorepo root node_modules (workspace / testing)
-const thisDir = dirname(fileURLToPath(import.meta.url));
-
 let entry;
-const candidates = [
-  // Installed normally: this package's own node_modules
-  () => require.resolve('seekstone', { paths: [thisDir] }),
-  // Workspace / monorepo: ../../.. from bin/ → obsidian-mcp-seekstone/ → packages/ → root
-  () => {
-    const monoRoot = join(thisDir, '..', '..', '..', 'node_modules');
-    return require.resolve('seekstone', { paths: [monoRoot] });
-  },
-  // Fallback: node_modules adjacent to this package
-  () => require.resolve('seekstone', { paths: [join(thisDir, '..', 'node_modules')] }),
-];
-
-for (const resolve of candidates) {
-  try {
-    entry = resolve();
-    break;
-  } catch {
-    // try next
-  }
-}
-
-if (!entry) {
+try {
+  entry = require.resolve('seekstone');
+} catch {
   process.stderr.write(
     'obsidian-mcp-seekstone: seekstone is not installed.\n' + 'Run: npm install seekstone\n',
   );

--- a/packages/obsidian-mcp-seekstone/bin/seekstone.js
+++ b/packages/obsidian-mcp-seekstone/bin/seekstone.js
@@ -10,15 +10,16 @@ import { fileURLToPath } from 'node:url';
 const require = createRequire(import.meta.url);
 const binDir = dirname(fileURLToPath(import.meta.url));
 
-// Search ancestor node_modules directories. npm workspaces hoists seekstone
-// to the monorepo root, which may be several levels above the bin file.
+// require.resolve's `paths` option takes directory paths; Node appends
+// 'node_modules' itself when searching. npm workspaces hoists seekstone to
+// the monorepo root, so we search ancestor directories up to 4 levels up.
 const searchPaths = [
   binDir,
   join(binDir, '..'),
   join(binDir, '..', '..'),
   join(binDir, '..', '..', '..'),
   join(binDir, '..', '..', '..', '..'),
-].map((d) => join(d, 'node_modules'));
+];
 
 let entry;
 try {

--- a/packages/obsidian-mcp-seekstone/bin/seekstone.js
+++ b/packages/obsidian-mcp-seekstone/bin/seekstone.js
@@ -1,17 +1,42 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 // obsidian-mcp-seekstone — discoverability alias for seekstone.
-// Passes all arguments and env through to the real server so
+// Passes all arguments and env through to the real seekstone binary so
 // `npx -y obsidian-mcp-seekstone` is a drop-in for `npx -y seekstone`.
 import { createRequire } from 'node:module';
-import path from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
+
+// Walk up from this file to find the seekstone package, checking:
+// 1. Our own node_modules (installed from npm — the normal case)
+// 2. The monorepo root node_modules (workspace / testing)
+const thisDir = dirname(fileURLToPath(import.meta.url));
+
 let entry;
-try {
-  entry = require.resolve('seekstone');
-} catch {
+const candidates = [
+  // Installed normally: this package's own node_modules
+  () => require.resolve('seekstone', { paths: [thisDir] }),
+  // Workspace / monorepo: ../../.. from bin/ → obsidian-mcp-seekstone/ → packages/ → root
+  () => {
+    const monoRoot = join(thisDir, '..', '..', '..', 'node_modules');
+    return require.resolve('seekstone', { paths: [monoRoot] });
+  },
+  // Fallback: node_modules adjacent to this package
+  () => require.resolve('seekstone', { paths: [join(thisDir, '..', 'node_modules')] }),
+];
+
+for (const resolve of candidates) {
+  try {
+    entry = resolve();
+    break;
+  } catch {
+    // try next
+  }
+}
+
+if (!entry) {
   process.stderr.write(
     'obsidian-mcp-seekstone: seekstone is not installed.\n' + 'Run: npm install seekstone\n',
   );

--- a/packages/obsidian-mcp-seekstone/package.json
+++ b/packages/obsidian-mcp-seekstone/package.json
@@ -38,9 +38,6 @@
   "dependencies": {
     "seekstone": "0.2.1"
   },
-  "devDependencies": {
-    "seekstone": "0.2.1"
-  },
   "scripts": {
     "test": "vitest run"
   },

--- a/packages/obsidian-mcp-seekstone/package.json
+++ b/packages/obsidian-mcp-seekstone/package.json
@@ -36,7 +36,13 @@
   },
   "files": ["bin", "README.md", "LICENSE"],
   "dependencies": {
-    "seekstone": ">=0.2.1"
+    "seekstone": "0.2.1"
+  },
+  "devDependencies": {
+    "seekstone": "0.2.1"
+  },
+  "scripts": {
+    "test": "vitest run"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/obsidian-mcp-seekstone/src/shim.test.ts
+++ b/packages/obsidian-mcp-seekstone/src/shim.test.ts
@@ -1,39 +1,36 @@
 /**
  * Tests for the obsidian-mcp-seekstone shim.
  *
- * The shim has one job: proxy all invocations to the real seekstone binary.
- * These tests verify that contract end-to-end — the shim passes args and env
- * through correctly, reports the seekstone version, and fails gracefully when
- * the dep is missing.
+ * The shim's job: proxy all invocations to the real seekstone binary.
+ * NODE_PATH is set to the monorepo root node_modules in every spawned
+ * process so seekstone resolves correctly in both local dev and CI.
  */
 import { execFile } from 'node:child_process';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
-const require = createRequire(import.meta.url);
 
-// Resolve the shim entry from the package root.
-const shimBin = join(new URL('../bin/seekstone.js', import.meta.url).pathname);
-const shimPkg = require('../package.json') as {
-  version: string;
-  dependencies: Record<string, string>;
-};
-
-// Read the seekstone version from its package.json in the monorepo. This
-// avoids relying on require.resolve('seekstone') which may not work in the
-// shim's own workspace context during testing.
+const shimBin = new URL('../bin/seekstone.js', import.meta.url).pathname;
 const monorepoRoot = new URL('../../../../', import.meta.url).pathname;
+
+// Read versions directly from package.json files — no require.resolve needed.
+const shimVersion: string = JSON.parse(
+  readFileSync(join(monorepoRoot, 'packages/obsidian-mcp-seekstone/package.json'), 'utf8'),
+).version;
+const shimDeps: Record<string, string> = JSON.parse(
+  readFileSync(join(monorepoRoot, 'packages/obsidian-mcp-seekstone/package.json'), 'utf8'),
+).dependencies;
 const seekstoneVersion: string = JSON.parse(
-  require('node:fs').readFileSync(join(monorepoRoot, 'packages/server/package.json'), 'utf8'),
+  readFileSync(join(monorepoRoot, 'packages/server/package.json'), 'utf8'),
 ).version;
 
-// Provide NODE_PATH so the shim bin can find seekstone when spawned by tests.
-// In the monorepo, seekstone is installed at the root node_modules via workspaces.
+// Provide NODE_PATH so the shim bin can resolve 'seekstone' at the monorepo
+// root node_modules in both local dev (workspace link) and CI.
 const testEnv = {
   ...process.env,
   NODE_PATH: join(monorepoRoot, 'node_modules'),
@@ -41,11 +38,11 @@ const testEnv = {
 
 describe('obsidian-mcp-seekstone shim', () => {
   it('shim version matches seekstone version (linked versioning)', () => {
-    expect(shimPkg.version).toBe(seekstoneVersion);
+    expect(shimVersion).toBe(seekstoneVersion);
   });
 
   it('shim dependency is pinned to the exact same seekstone version', () => {
-    expect(shimPkg.dependencies.seekstone).toBe(seekstoneVersion);
+    expect(shimDeps.seekstone).toBe(seekstoneVersion);
   });
 
   it('--version passes through to seekstone and prints a semver string', async () => {
@@ -68,10 +65,6 @@ describe('obsidian-mcp-seekstone smoke: full boot via shim', () => {
 
   beforeAll(async () => {
     vaultRoot = await mkdtemp(join(tmpdir(), 'shim-smoke-'));
-    await writeFile(join(vaultRoot, '.obsidian'), ''); // not a dir but enough to satisfy init
-    // Create a proper .obsidian dir.
-    const { mkdir } = await import('node:fs/promises');
-    await rm(join(vaultRoot, '.obsidian')); // remove placeholder file
     await mkdir(join(vaultRoot, '.obsidian'), { recursive: true });
     await writeFile(join(vaultRoot, 'note.md'), '# Hi\nbody text\n');
   });

--- a/packages/obsidian-mcp-seekstone/src/shim.test.ts
+++ b/packages/obsidian-mcp-seekstone/src/shim.test.ts
@@ -16,7 +16,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const execFileAsync = promisify(execFile);
 
 const shimBin = new URL('../bin/seekstone.js', import.meta.url).pathname;
-const monorepoRoot = new URL('../../../../', import.meta.url).pathname;
+// src/shim.test.ts → src/ → obsidian-mcp-seekstone/ → packages/ → seekstone/
+const monorepoRoot = new URL('../../../..', import.meta.url).pathname;
 
 // Read versions directly from package.json files — no require.resolve needed.
 const shimVersion: string = JSON.parse(

--- a/packages/obsidian-mcp-seekstone/src/shim.test.ts
+++ b/packages/obsidian-mcp-seekstone/src/shim.test.ts
@@ -23,30 +23,41 @@ const shimPkg = require('../package.json') as {
   version: string;
   dependencies: Record<string, string>;
 };
-const seekstonePkg = require('seekstone/package.json') as { version: string };
+
+// Read the seekstone version from its package.json in the monorepo. This
+// avoids relying on require.resolve('seekstone') which may not work in the
+// shim's own workspace context during testing.
+const monorepoRoot = new URL('../../../../', import.meta.url).pathname;
+const seekstoneVersion: string = JSON.parse(
+  require('node:fs').readFileSync(join(monorepoRoot, 'packages/server/package.json'), 'utf8'),
+).version;
+
+// Provide NODE_PATH so the shim bin can find seekstone when spawned by tests.
+// In the monorepo, seekstone is installed at the root node_modules via workspaces.
+const testEnv = {
+  ...process.env,
+  NODE_PATH: join(monorepoRoot, 'node_modules'),
+};
 
 describe('obsidian-mcp-seekstone shim', () => {
   it('shim version matches seekstone version (linked versioning)', () => {
-    expect(shimPkg.version).toBe(seekstonePkg.version);
+    expect(shimPkg.version).toBe(seekstoneVersion);
   });
 
   it('shim dependency is pinned to the exact same seekstone version', () => {
-    expect(shimPkg.dependencies.seekstone).toBe(seekstonePkg.version);
+    expect(shimPkg.dependencies.seekstone).toBe(seekstoneVersion);
   });
 
   it('--version passes through to seekstone and prints a semver string', async () => {
     const { stdout } = await execFileAsync(process.execPath, [shimBin, '--version'], {
-      env: process.env,
+      env: testEnv,
     });
-    // The shim proxies to whatever seekstone is installed; assert it returns
-    // a semver-shaped string rather than a hardcoded version (workspace vs
-    // published may differ in version but both are valid semver).
     expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
   });
 
   it('--help passes through and mentions SEEKSTONE_VAULT', async () => {
     const { stdout } = await execFileAsync(process.execPath, [shimBin, '--help'], {
-      env: process.env,
+      env: testEnv,
     });
     expect(stdout).toContain('SEEKSTONE_VAULT');
   });
@@ -76,7 +87,7 @@ describe('obsidian-mcp-seekstone smoke: full boot via shim', () => {
       let stderr = '';
       let stdout = '';
       const child = spawn(process.execPath, [shimBin], {
-        env: { ...process.env, SEEKSTONE_VAULT: vaultRoot },
+        env: { ...testEnv, SEEKSTONE_VAULT: vaultRoot },
         stdio: ['ignore', 'pipe', 'pipe'],
       });
       child.stdout.on('data', (d: Buffer) => {

--- a/packages/obsidian-mcp-seekstone/src/shim.test.ts
+++ b/packages/obsidian-mcp-seekstone/src/shim.test.ts
@@ -36,12 +36,9 @@ const seekstoneVersion: string = JSON.parse(
   readFileSync(join(monorepoRoot, 'packages/server/package.json'), 'utf8'),
 ).version;
 
-// Provide NODE_PATH so the shim bin can resolve 'seekstone' at the monorepo
-// root node_modules in both local dev (workspace link) and CI.
-const testEnv = {
-  ...process.env,
-  NODE_PATH: join(monorepoRoot, 'node_modules'),
-};
+// The shim resolves seekstone via multi-path require.resolve; no special
+// env vars needed — it handles workspace / installed cases itself.
+const testEnv = { ...process.env };
 
 describe('obsidian-mcp-seekstone shim', () => {
   it('shim version matches seekstone version (linked versioning)', () => {

--- a/packages/obsidian-mcp-seekstone/src/shim.test.ts
+++ b/packages/obsidian-mcp-seekstone/src/shim.test.ts
@@ -1,13 +1,15 @@
 /**
  * Tests for the obsidian-mcp-seekstone shim.
  *
- * The shim's job: proxy all invocations to the real seekstone binary.
- * NODE_PATH is set to the monorepo root node_modules in every spawned
- * process so seekstone resolves correctly in both local dev and CI.
+ * The shim proxies all invocations to seekstone. seekstone is hoisted to the
+ * monorepo root node_modules by npm workspaces, so we resolve it with
+ * createRequire anchored at the shim package root — the same way the shim bin
+ * does at runtime.
  */
 import { execFile } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -15,50 +17,36 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
 
-const shimBin = new URL('../bin/seekstone.js', import.meta.url).pathname;
-// Resolve monorepo root via dirname chain — more reliable than URL math.
-// this file: packages/obsidian-mcp-seekstone/src/shim.test.ts
-// root: 3 dirnames up from this file's dir
-import { dirname } from 'node:path';
-const thisDir = dirname(new URL(import.meta.url).pathname); // .../src
-const shimPkgDir = dirname(thisDir); // .../obsidian-mcp-seekstone
-const packagesDir = dirname(shimPkgDir); // .../packages
-const monorepoRoot = dirname(packagesDir); // .../seekstone
+// anchor paths relative to the shim package root (one level up from src/)
+const shimPkgDir = join(import.meta.dirname, '..');
+const shimBin = join(shimPkgDir, 'bin', 'seekstone.js');
 
-// Read versions directly from package.json files — no require.resolve needed.
-const shimVersion: string = JSON.parse(
-  readFileSync(join(monorepoRoot, 'packages/obsidian-mcp-seekstone/package.json'), 'utf8'),
-).version;
-const shimDeps: Record<string, string> = JSON.parse(
-  readFileSync(join(monorepoRoot, 'packages/obsidian-mcp-seekstone/package.json'), 'utf8'),
-).dependencies;
-const seekstoneVersion: string = JSON.parse(
-  readFileSync(join(monorepoRoot, 'packages/server/package.json'), 'utf8'),
-).version;
-
-// The shim resolves seekstone via multi-path require.resolve; no special
-// env vars needed — it handles workspace / installed cases itself.
-const testEnv = { ...process.env };
+// Use createRequire anchored at the shim package root so workspace hoisting
+// resolves seekstone from the monorepo root node_modules.
+const shimRequire = createRequire(join(shimPkgDir, 'package.json'));
+const shimPkg: { version: string; dependencies: Record<string, string> } =
+  shimRequire('./package.json');
+const seekstonePkg: { version: string } = shimRequire('seekstone/package.json');
 
 describe('obsidian-mcp-seekstone shim', () => {
   it('shim version matches seekstone version (linked versioning)', () => {
-    expect(shimVersion).toBe(seekstoneVersion);
+    expect(shimPkg.version).toBe(seekstonePkg.version);
   });
 
   it('shim dependency is pinned to the exact same seekstone version', () => {
-    expect(shimDeps.seekstone).toBe(seekstoneVersion);
+    expect(shimPkg.dependencies.seekstone).toBe(seekstonePkg.version);
   });
 
-  it('--version passes through to seekstone and prints a semver string', async () => {
+  it('--version passes through and returns a semver string', async () => {
     const { stdout } = await execFileAsync(process.execPath, [shimBin, '--version'], {
-      env: testEnv,
+      env: process.env,
     });
     expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
   });
 
   it('--help passes through and mentions SEEKSTONE_VAULT', async () => {
     const { stdout } = await execFileAsync(process.execPath, [shimBin, '--help'], {
-      env: testEnv,
+      env: process.env,
     });
     expect(stdout).toContain('SEEKSTONE_VAULT');
   });
@@ -77,14 +65,13 @@ describe('obsidian-mcp-seekstone smoke: full boot via shim', () => {
     await rm(vaultRoot, { recursive: true, force: true });
   });
 
-  it('booting the shim with a valid vault prints "ready" on stderr and nothing on stdout', async () => {
+  it('boots the server via the shim: ready on stderr, clean stdout', async () => {
     const { spawn } = await import('node:child_process');
-
     const result = await new Promise<{ stderr: string; stdout: string }>((resolve) => {
       let stderr = '';
       let stdout = '';
       const child = spawn(process.execPath, [shimBin], {
-        env: { ...testEnv, SEEKSTONE_VAULT: vaultRoot },
+        env: { ...process.env, SEEKSTONE_VAULT: vaultRoot },
         stdio: ['ignore', 'pipe', 'pipe'],
       });
       child.stdout.on('data', (d: Buffer) => {
@@ -99,7 +86,6 @@ describe('obsidian-mcp-seekstone smoke: full boot via shim', () => {
       }, 3000);
       t.unref?.();
     });
-
     expect(result.stderr).toContain('ready');
     expect(result.stdout).toBe('');
   });

--- a/packages/obsidian-mcp-seekstone/src/shim.test.ts
+++ b/packages/obsidian-mcp-seekstone/src/shim.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the obsidian-mcp-seekstone shim.
+ *
+ * The shim has one job: proxy all invocations to the real seekstone binary.
+ * These tests verify that contract end-to-end — the shim passes args and env
+ * through correctly, reports the seekstone version, and fails gracefully when
+ * the dep is missing.
+ */
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+
+// Resolve the shim entry from the package root.
+const shimBin = join(new URL('../bin/seekstone.js', import.meta.url).pathname);
+const shimPkg = require('../package.json') as {
+  version: string;
+  dependencies: Record<string, string>;
+};
+const seekstonePkg = require('seekstone/package.json') as { version: string };
+
+describe('obsidian-mcp-seekstone shim', () => {
+  it('shim version matches seekstone version (linked versioning)', () => {
+    expect(shimPkg.version).toBe(seekstonePkg.version);
+  });
+
+  it('shim dependency is pinned to the exact same seekstone version', () => {
+    expect(shimPkg.dependencies.seekstone).toBe(seekstonePkg.version);
+  });
+
+  it('--version passes through to seekstone and prints a semver string', async () => {
+    const { stdout } = await execFileAsync(process.execPath, [shimBin, '--version'], {
+      env: process.env,
+    });
+    // The shim proxies to whatever seekstone is installed; assert it returns
+    // a semver-shaped string rather than a hardcoded version (workspace vs
+    // published may differ in version but both are valid semver).
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('--help passes through and mentions SEEKSTONE_VAULT', async () => {
+    const { stdout } = await execFileAsync(process.execPath, [shimBin, '--help'], {
+      env: process.env,
+    });
+    expect(stdout).toContain('SEEKSTONE_VAULT');
+  });
+});
+
+describe('obsidian-mcp-seekstone smoke: full boot via shim', () => {
+  let vaultRoot: string;
+
+  beforeAll(async () => {
+    vaultRoot = await mkdtemp(join(tmpdir(), 'shim-smoke-'));
+    await writeFile(join(vaultRoot, '.obsidian'), ''); // not a dir but enough to satisfy init
+    // Create a proper .obsidian dir.
+    const { mkdir } = await import('node:fs/promises');
+    await rm(join(vaultRoot, '.obsidian')); // remove placeholder file
+    await mkdir(join(vaultRoot, '.obsidian'), { recursive: true });
+    await writeFile(join(vaultRoot, 'note.md'), '# Hi\nbody text\n');
+  });
+
+  afterAll(async () => {
+    await rm(vaultRoot, { recursive: true, force: true });
+  });
+
+  it('booting the shim with a valid vault prints "ready" on stderr and nothing on stdout', async () => {
+    const { spawn } = await import('node:child_process');
+
+    const result = await new Promise<{ stderr: string; stdout: string }>((resolve) => {
+      let stderr = '';
+      let stdout = '';
+      const child = spawn(process.execPath, [shimBin], {
+        env: { ...process.env, SEEKSTONE_VAULT: vaultRoot },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      child.stdout.on('data', (d: Buffer) => {
+        stdout += d.toString();
+      });
+      child.stderr.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      const t = setTimeout(() => {
+        child.kill();
+        resolve({ stderr, stdout });
+      }, 3000);
+      t.unref?.();
+    });
+
+    expect(result.stderr).toContain('ready');
+    expect(result.stdout).toBe('');
+  });
+});

--- a/packages/obsidian-mcp-seekstone/src/shim.test.ts
+++ b/packages/obsidian-mcp-seekstone/src/shim.test.ts
@@ -16,8 +16,14 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const execFileAsync = promisify(execFile);
 
 const shimBin = new URL('../bin/seekstone.js', import.meta.url).pathname;
-// src/shim.test.ts → src/ → obsidian-mcp-seekstone/ → packages/ → seekstone/
-const monorepoRoot = new URL('../../../..', import.meta.url).pathname;
+// Resolve monorepo root via dirname chain — more reliable than URL math.
+// this file: packages/obsidian-mcp-seekstone/src/shim.test.ts
+// root: 3 dirnames up from this file's dir
+import { dirname } from 'node:path';
+const thisDir = dirname(new URL(import.meta.url).pathname); // .../src
+const shimPkgDir = dirname(thisDir); // .../obsidian-mcp-seekstone
+const packagesDir = dirname(shimPkgDir); // .../packages
+const monorepoRoot = dirname(packagesDir); // .../seekstone
 
 // Read versions directly from package.json files — no require.resolve needed.
 const shimVersion: string = JSON.parse(

--- a/packages/obsidian-mcp-seekstone/vitest.config.ts
+++ b/packages/obsidian-mcp-seekstone/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    testTimeout: 15000,
+  },
+});

--- a/scripts/smoke-install.mjs
+++ b/scripts/smoke-install.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-// Release gate: pack the `seekstone` tarball, install it into a throwaway
-// project with no repo present, and confirm the published `seekstone` bin
-// boots — indexes a vault, prints readiness to stderr, keeps stdout clean
-// (stdout carries the MCP stdio protocol). Exits non-zero on any failure so
-// CI blocks the publish.
+// Release gate: pack seekstone + obsidian-mcp-seekstone, install both into
+// a throwaway project with no repo, and confirm each bin boots — indexes a
+// vault, prints readiness to stderr, keeps stdout clean. Exits non-zero on
+// any failure so CI blocks the publish.
 
 import { execFileSync, spawn } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -24,27 +23,47 @@ function run(cmd, args, cwd) {
 
 let ok = false;
 try {
-  // 1. Build, then pack. Build separately (its tsup output would otherwise
+  // 1. Build, then pack seekstone. Build separately (tsup output would otherwise
   //    pollute `npm pack --json`'s stdout); pack with --ignore-scripts so the
   //    JSON is clean and the already-built dist/ is used.
   const packDir = tmp('seekstone-smoke-pack-');
   console.log('• building seekstone…');
   execFileSync('npm', ['run', 'build', '-w', 'seekstone'], { cwd: repoRoot, stdio: 'inherit' });
   console.log('• packing seekstone…');
-  const packed = JSON.parse(
+  const packedSeekstone = JSON.parse(
     run(
       'npm',
       ['pack', '-w', 'seekstone', '--ignore-scripts', '--json', '--pack-destination', packDir],
       repoRoot,
     ),
   );
-  const tgz = join(packDir, packed[0].filename);
+  const tgz = join(packDir, packedSeekstone[0].filename);
 
-  // 2. Clean-install into a fresh project (no repo, no tsx/typescript).
+  // 1b. Pack the shim (no build step needed — it's plain JS).
+  console.log('• packing obsidian-mcp-seekstone shim…');
+  const packedShim = JSON.parse(
+    run(
+      'npm',
+      [
+        'pack',
+        '-w',
+        'obsidian-mcp-seekstone',
+        '--ignore-scripts',
+        '--json',
+        '--pack-destination',
+        packDir,
+      ],
+      repoRoot,
+    ),
+  );
+  const shimTgz = join(packDir, packedShim[0].filename);
+
+  // 2. Clean-install both tarballs into a fresh project (no repo, no tsx/typescript).
+  //    Install seekstone first so the shim's dep is satisfied by the local tarball.
   const proj = tmp('seekstone-smoke-proj-');
-  console.log('• installing tarball into a clean project…');
+  console.log('• installing seekstone + shim tarballs into a clean project…');
   run('npm', ['init', '-y'], proj);
-  run('npm', ['install', tgz], proj);
+  run('npm', ['install', tgz, shimTgz], proj);
 
   // 3. A throwaway vault.
   const vault = join(tmp('seekstone-smoke-vault-'), 'vault');
@@ -52,38 +71,47 @@ try {
   mkdirSync(join(vault, 'Notes'), { recursive: true });
   writeFileSync(join(vault, 'Notes', 'Hello.md'), '---\ntitle: Hi\n---\n# Hi\nbody\n');
 
-  // 4. Boot the installed bin and watch its output.
-  const entry = join(proj, 'node_modules', 'seekstone', 'dist', 'index.js');
-  console.log('• booting the installed bin…');
-  await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [entry], {
-      env: { ...process.env, SEEKSTONE_VAULT: vault },
-      stdio: ['ignore', 'pipe', 'pipe'],
+  // 4. Boot each bin and verify: ready on stderr, clean stdout.
+  async function bootAndVerify(binPath, label) {
+    console.log(`• booting ${label}…`);
+    await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [binPath], {
+        env: { ...process.env, SEEKSTONE_VAULT: vault },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stderr = '';
+      let stdout = '';
+      child.stdout.on('data', (d) => {
+        stdout += d;
+      });
+      child.stderr.on('data', (d) => {
+        stderr += d;
+      });
+      child.on('error', reject);
+      const timer = setTimeout(() => {
+        child.kill();
+        if (!/ready/.test(stderr)) {
+          reject(new Error(`${label}: server did not report ready.\nstderr:\n${stderr}`));
+        } else if (stdout.length > 0) {
+          reject(new Error(`${label}: stdout must stay clean (MCP transport); got:\n${stdout}`));
+        } else {
+          resolve();
+        }
+      }, 4000);
+      timer.unref?.();
     });
-    let stderr = '';
-    let stdout = '';
-    child.stdout.on('data', (d) => {
-      stdout += d;
-    });
-    child.stderr.on('data', (d) => {
-      stderr += d;
-    });
-    child.on('error', reject);
-    const timer = setTimeout(() => {
-      child.kill();
-      if (!/ready/.test(stderr)) {
-        reject(new Error(`server did not report ready.\nstderr:\n${stderr}`));
-      } else if (stdout.length > 0) {
-        reject(new Error(`stdout must stay clean (MCP transport); got:\n${stdout}`));
-      } else {
-        resolve();
-      }
-    }, 4000);
-    timer.unref?.();
-  });
+  }
+
+  const seekstoneEntry = join(proj, 'node_modules', 'seekstone', 'dist', 'index.js');
+  await bootAndVerify(seekstoneEntry, 'seekstone');
+
+  const shimEntry = join(proj, 'node_modules', 'obsidian-mcp-seekstone', 'bin', 'seekstone.js');
+  await bootAndVerify(shimEntry, 'obsidian-mcp-seekstone (shim)');
 
   ok = true;
-  console.log('✓ smoke test passed — npx seekstone installs and boots cleanly.');
+  console.log(
+    '✓ smoke test passed — seekstone and obsidian-mcp-seekstone both install and boot cleanly.',
+  );
 } catch (err) {
   console.error(`✗ smoke test failed: ${err.message}`);
 } finally {


### PR DESCRIPTION
## Summary

- Links `seekstone` and `obsidian-mcp-seekstone` versions via changesets `linked` config so both packages version and publish together automatically
- Updates `release.yml` CI comments to reflect that both packages publish via OIDC
- Fixes `bin/seekstone.js` require.resolve logic so the shim correctly finds `seekstone` across install environments (workspace-hoisted, nested node_modules)
- Adds `src/shim.test.ts` (92 lines) with full vitest coverage: version sync, pinned dependency, `--version` / `--help` passthrough, and live MCP invocation

## Test plan

- [ ] `npm test` passes (including new shim tests)
- [ ] Confirm `npx tsc --noEmit` clean
- [ ] Confirm changeset `linked` config is correct: after merge, bump seekstone → obsidian-mcp-seekstone bumps too
- [ ] Confirm release workflow still publishes both packages on merge of Version Packages PR