### PR TITLE
fix(shim): robust require.resolve + add passthrough and smoke tests (SHA-73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Build server
+        run: npm run build -w seekstone
+
       - name: Typecheck
         run: |
           npx tsc -p packages/core/tsconfig.json --noEmit

--- a/packages/obsidian-mcp-seekstone/bin/seekstone.js
+++ b/packages/obsidian-mcp-seekstone/bin/seekstone.js
@@ -1,16 +1,29 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 // obsidian-mcp-seekstone — discoverability alias for seekstone.
-// Passes all arguments and env through to the real server so
+// Passes all arguments and env through to the real seekstone binary so
 // `npx -y obsidian-mcp-seekstone` is a drop-in for `npx -y seekstone`.
 import { createRequire } from 'node:module';
-import path from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
+const binDir = dirname(fileURLToPath(import.meta.url));
+
+// require.resolve's `paths` option takes directory paths; Node appends
+// 'node_modules' itself when searching. npm workspaces hoists seekstone to
+// the monorepo root, so we search ancestor directories up to 4 levels up.
+const searchPaths = [
+  binDir,
+  join(binDir, '..'),
+  join(binDir, '..', '..'),
+  join(binDir, '..', '..', '..'),
+  join(binDir, '..', '..', '..', '..'),
+];
+
 let entry;
 try {
-  entry = require.resolve('seekstone');
+  entry = require.resolve('seekstone', { paths: searchPaths });
 } catch {
   process.stderr.write(
     'obsidian-mcp-seekstone: seekstone is not installed.\n' + 'Run: npm install seekstone\n',

--- a/packages/obsidian-mcp-seekstone/package.json
+++ b/packages/obsidian-mcp-seekstone/package.json
@@ -41,6 +41,9 @@
     "obsidian-mcp-seekstone": "./bin/seekstone.js"
   },
   "files": ["bin", "README.md", "LICENSE"],
+  "scripts": {
+    "test": "vitest run"
+  },
   "dependencies": {
     "seekstone": ">=0.2.1"
   },

--- a/packages/obsidian-mcp-seekstone/src/shim.test.ts
+++ b/packages/obsidian-mcp-seekstone/src/shim.test.ts
@@ -1,0 +1,66 @@
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const shimPkgDir = join(import.meta.dirname, '..');
+const shimBin = join(shimPkgDir, 'bin', 'seekstone.js');
+
+describe('obsidian-mcp-seekstone shim', () => {
+  it('--version passes through and returns a semver string', async () => {
+    const { stdout } = await execFileAsync(process.execPath, [shimBin, '--version'], {
+      env: process.env,
+    });
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('--help passes through and mentions SEEKSTONE_VAULT', async () => {
+    const { stdout } = await execFileAsync(process.execPath, [shimBin, '--help'], {
+      env: process.env,
+    });
+    expect(stdout).toContain('SEEKSTONE_VAULT');
+  });
+});
+
+describe('obsidian-mcp-seekstone smoke: full boot via shim', () => {
+  let vaultRoot: string;
+
+  beforeAll(async () => {
+    vaultRoot = await mkdtemp(join(tmpdir(), 'shim-smoke-'));
+    await mkdir(join(vaultRoot, '.obsidian'), { recursive: true });
+    await writeFile(join(vaultRoot, 'note.md'), '# Hi\nbody text\n');
+  });
+
+  afterAll(async () => {
+    await rm(vaultRoot, { recursive: true, force: true });
+  });
+
+  it('boots the server via the shim: ready on stderr, clean stdout', async () => {
+    const { spawn } = await import('node:child_process');
+    const result = await new Promise<{ stderr: string; stdout: string }>((resolve) => {
+      let stderr = '';
+      let stdout = '';
+      const child = spawn(process.execPath, [shimBin], {
+        env: { ...process.env, SEEKSTONE_VAULT: vaultRoot },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      child.stdout.on('data', (d: Buffer) => {
+        stdout += d.toString();
+      });
+      child.stderr.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      const t = setTimeout(() => {
+        child.kill();
+        resolve({ stderr, stdout });
+      }, 3000);
+      t.unref?.();
+    });
+    expect(result.stderr).toContain('ready');
+    expect(result.stdout).toBe('');
+  });
+});

--- a/packages/obsidian-mcp-seekstone/vitest.config.ts
+++ b/packages/obsidian-mcp-seekstone/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    testTimeout: 15000,
+  },
+});


### PR DESCRIPTION
## Summary

- Fixes `bin/seekstone.js` to search ancestor `node_modules` directories so `seekstone` resolves correctly in workspace-hoisted (monorepo dev) and CI environments — not just end-user installs
- Adds `src/shim.test.ts` with 3 tests: `--version` passthrough, `--help` passthrough, and a full boot smoke test via the shim binary
- Adds `vitest.config.ts` with 15s timeout for the smoke test
- Wires `test` script into `package.json` so `npm test` picks up shim tests automatically

## What was deliberately left out

Linked versioning (`"linked": [["seekstone", "obsidian-mcp-seekstone"]]`) and the version-sync tests are deferred — that's a release strategy decision tracked separately in SHA-73.

## Test plan

- [ ] `npm test` passes (146 + 3 shim tests)
- [ ] `npm run lint` clean