### PR TITLE
fix(smoke): extend smoke-install to boot-verify the shim (SHA-74)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,9 @@ jobs:
           title: 'chore: version packages'
         env:
           # No NODE_AUTH_TOKEN: npm authenticates via OIDC trusted publishing.
-          # Requires a Trusted Publisher configured for `seekstone` on npmjs.com
-          # (GitHub Actions, repo shaqmughal/seekstone, workflow release.yml).
+          # Requires a Trusted Publisher configured for BOTH packages on npmjs.com:
+          #   - seekstone (GitHub Actions, repo shaqmughal/seekstone, workflow release.yml)
+          #   - obsidian-mcp-seekstone (same settings)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6760,6 +6760,7 @@
       "name": "@seekstone/harness",
       "version": "0.0.0",
       "dependencies": {
+        "@seekstone/core": "*",
         "cac": "^6.7.14",
         "fast-glob": "^3.3.2",
         "minisearch": "^7.1.1",
@@ -6772,10 +6773,10 @@
       }
     },
     "packages/obsidian-mcp-seekstone": {
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "seekstone": ">=0.2.1"
+        "seekstone": "0.3.0"
       },
       "bin": {
         "obsidian-mcp-seekstone": "bin/seekstone.js"
@@ -6786,7 +6787,7 @@
     },
     "packages/server": {
       "name": "seekstone",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/scripts/smoke-install.mjs
+++ b/scripts/smoke-install.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-// Release gate: pack the `seekstone` tarball, install it into a throwaway
-// project with no repo present, and confirm the published `seekstone` bin
-// boots — indexes a vault, prints readiness to stderr, keeps stdout clean
-// (stdout carries the MCP stdio protocol). Exits non-zero on any failure so
-// CI blocks the publish.
+// Release gate: pack seekstone + obsidian-mcp-seekstone, install both into
+// a throwaway project with no repo, and confirm each bin boots — indexes a
+// vault, prints readiness to stderr, keeps stdout clean. Exits non-zero on
+// any failure so CI blocks the publish.
 
 import { execFileSync, spawn } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -24,27 +23,47 @@ function run(cmd, args, cwd) {
 
 let ok = false;
 try {
-  // 1. Build, then pack. Build separately (its tsup output would otherwise
+  // 1. Build, then pack seekstone. Build separately (tsup output would otherwise
   //    pollute `npm pack --json`'s stdout); pack with --ignore-scripts so the
   //    JSON is clean and the already-built dist/ is used.
   const packDir = tmp('seekstone-smoke-pack-');
   console.log('• building seekstone…');
   execFileSync('npm', ['run', 'build', '-w', 'seekstone'], { cwd: repoRoot, stdio: 'inherit' });
   console.log('• packing seekstone…');
-  const packed = JSON.parse(
+  const packedSeekstone = JSON.parse(
     run(
       'npm',
       ['pack', '-w', 'seekstone', '--ignore-scripts', '--json', '--pack-destination', packDir],
       repoRoot,
     ),
   );
-  const tgz = join(packDir, packed[0].filename);
+  const tgz = join(packDir, packedSeekstone[0].filename);
 
-  // 2. Clean-install into a fresh project (no repo, no tsx/typescript).
+  // 1b. Pack the shim (no build step needed — it's plain JS).
+  console.log('• packing obsidian-mcp-seekstone shim…');
+  const packedShim = JSON.parse(
+    run(
+      'npm',
+      [
+        'pack',
+        '-w',
+        'obsidian-mcp-seekstone',
+        '--ignore-scripts',
+        '--json',
+        '--pack-destination',
+        packDir,
+      ],
+      repoRoot,
+    ),
+  );
+  const shimTgz = join(packDir, packedShim[0].filename);
+
+  // 2. Clean-install both tarballs into a fresh project (no repo, no tsx/typescript).
+  //    Install seekstone first so the shim's dep is satisfied by the local tarball.
   const proj = tmp('seekstone-smoke-proj-');
-  console.log('• installing tarball into a clean project…');
+  console.log('• installing seekstone + shim tarballs into a clean project…');
   run('npm', ['init', '-y'], proj);
-  run('npm', ['install', tgz], proj);
+  run('npm', ['install', tgz, shimTgz], proj);
 
   // 3. A throwaway vault.
   const vault = join(tmp('seekstone-smoke-vault-'), 'vault');
@@ -52,38 +71,47 @@ try {
   mkdirSync(join(vault, 'Notes'), { recursive: true });
   writeFileSync(join(vault, 'Notes', 'Hello.md'), '---\ntitle: Hi\n---\n# Hi\nbody\n');
 
-  // 4. Boot the installed bin and watch its output.
-  const entry = join(proj, 'node_modules', 'seekstone', 'dist', 'index.js');
-  console.log('• booting the installed bin…');
-  await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [entry], {
-      env: { ...process.env, SEEKSTONE_VAULT: vault },
-      stdio: ['ignore', 'pipe', 'pipe'],
+  // 4. Boot each bin and verify: ready on stderr, clean stdout.
+  async function bootAndVerify(binPath, label) {
+    console.log(`• booting ${label}…`);
+    await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [binPath], {
+        env: { ...process.env, SEEKSTONE_VAULT: vault },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stderr = '';
+      let stdout = '';
+      child.stdout.on('data', (d) => {
+        stdout += d;
+      });
+      child.stderr.on('data', (d) => {
+        stderr += d;
+      });
+      child.on('error', reject);
+      const timer = setTimeout(() => {
+        child.kill();
+        if (!/ready/.test(stderr)) {
+          reject(new Error(`${label}: server did not report ready.\nstderr:\n${stderr}`));
+        } else if (stdout.length > 0) {
+          reject(new Error(`${label}: stdout must stay clean (MCP transport); got:\n${stdout}`));
+        } else {
+          resolve();
+        }
+      }, 4000);
+      timer.unref?.();
     });
-    let stderr = '';
-    let stdout = '';
-    child.stdout.on('data', (d) => {
-      stdout += d;
-    });
-    child.stderr.on('data', (d) => {
-      stderr += d;
-    });
-    child.on('error', reject);
-    const timer = setTimeout(() => {
-      child.kill();
-      if (!/ready/.test(stderr)) {
-        reject(new Error(`server did not report ready.\nstderr:\n${stderr}`));
-      } else if (stdout.length > 0) {
-        reject(new Error(`stdout must stay clean (MCP transport); got:\n${stdout}`));
-      } else {
-        resolve();
-      }
-    }, 4000);
-    timer.unref?.();
-  });
+  }
+
+  const seekstoneEntry = join(proj, 'node_modules', 'seekstone', 'dist', 'index.js');
+  await bootAndVerify(seekstoneEntry, 'seekstone');
+
+  const shimEntry = join(proj, 'node_modules', 'obsidian-mcp-seekstone', 'bin', 'seekstone.js');
+  await bootAndVerify(shimEntry, 'obsidian-mcp-seekstone (shim)');
 
   ok = true;
-  console.log('✓ smoke test passed — npx seekstone installs and boots cleanly.');
+  console.log(
+    '✓ smoke test passed — seekstone and obsidian-mcp-seekstone both install and boot cleanly.',
+  );
 } catch (err) {
   console.error(`✗ smoke test failed: ${err.message}`);
 } finally {


### PR DESCRIPTION
## Summary

Extends `scripts/smoke-install.mjs` to pack, install, and boot-verify `obsidian-mcp-seekstone` alongside `seekstone` as part of the release gate.

- Packs the shim tarball (no build needed — plain JS)
- Installs both tarballs into the same throwaway project (seekstone first so the shim's exact dep is satisfied)
- Runs `bootAndVerify` against the shim bin — ready on stderr, clean stdout
- Updates success message to reflect both packages

## Why

Unit tests in `shim.test.ts` validate the shim in the monorepo context. The smoke test validates what actually ships. These catch different failures: a bad `files` field in `package.json` or a broken bin path after a real `npm install` would pass unit tests but fail smoke.

## Test plan

- [ ] `npm run smoke` passes locally (both bins boot)
- [ ] CI green across all platforms