### PR TITLE
feat(harness): mcpvault adapter + cross-adapter comparison report (SHA-75)

### DIFF
--- a/packages/harness/src/bench/adapters/mcpvault.ts
+++ b/packages/harness/src/bench/adapters/mcpvault.ts
@@ -1,0 +1,211 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { type Interface, createInterface } from 'node:readline';
+import type { Backend, BackendResponse, ListEntry, SearchHit } from '../backend.js';
+
+/**
+ * Backend adapter for mcpvault by bitbonsai (@bitbonsai/mcpvault).
+ *
+ * mcpvault is a filesystem-direct MCP server that reads the vault without
+ * Obsidian running, making it the closest architectural peer to seekstone.
+ * This adapter spawns it as a subprocess and communicates via MCP JSON-RPC
+ * over stdio — the same transport Claude uses — so payload bytes reflect
+ * exactly what an LLM client would receive.
+ *
+ * Tool mapping:
+ *   search_notes    → search(query)
+ *   read_note       → read(path)
+ *   write_note      → write(path, content)
+ *   list_directory  → list(path?)
+ */
+
+export interface McpvaultAdapterOptions {
+  /** Absolute path to the vault root. Passed as positional arg to mcpvault. */
+  vaultRoot: string;
+  /**
+   * Command to invoke mcpvault. Defaults to `npx @bitbonsai/mcpvault`.
+   * Override via SEEKSTONE_MCPVAULT_CMD env var for a pre-installed binary.
+   */
+  cmd?: string[];
+}
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: number;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id?: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+interface McpToolResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}
+
+export class McpvaultAdapter implements Backend {
+  readonly name = 'mcpvault';
+  readonly description = 'mcpvault @bitbonsai (filesystem-direct, MCP stdio subprocess)';
+
+  private readonly proc: ChildProcess;
+  private readonly rl: Interface;
+  private nextId = 1;
+  private readonly pending = new Map<
+    number,
+    { resolve: (v: JsonRpcResponse) => void; reject: (e: Error) => void }
+  >();
+
+  private readonly stdin: NodeJS.WritableStream;
+
+  private constructor(proc: ChildProcess, rl: Interface) {
+    this.proc = proc;
+    this.rl = rl;
+    this.stdin = proc.stdin as NodeJS.WritableStream;
+  }
+
+  static async build(opts: McpvaultAdapterOptions): Promise<McpvaultAdapter> {
+    const cmdParts = opts.cmd ??
+      process.env.SEEKSTONE_MCPVAULT_CMD?.split(' ') ?? ['npx', '--yes', '@bitbonsai/mcpvault'];
+
+    const [bin, ...args] = cmdParts;
+    const proc = spawn(bin ?? 'npx', [...args, opts.vaultRoot], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const rl = createInterface({ input: proc.stdout as NodeJS.ReadableStream });
+    const adapter = new McpvaultAdapter(proc, rl);
+
+    // Route incoming lines to pending request callbacks.
+    rl.on('line', (line) => {
+      if (!line.trim()) return;
+      let msg: JsonRpcResponse;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (msg.id == null) return; // notification, ignore
+      const waiter = adapter.pending.get(msg.id as number);
+      if (!waiter) return;
+      adapter.pending.delete(msg.id as number);
+      if (msg.error) {
+        waiter.reject(new Error(`mcpvault error ${msg.error.code}: ${msg.error.message}`));
+      } else {
+        waiter.resolve(msg);
+      }
+    });
+
+    // MCP initialize handshake.
+    await adapter.request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'seekstone-harness', version: '1.0' },
+    });
+    adapter.notify('notifications/initialized', {});
+
+    return adapter;
+  }
+
+  async close(): Promise<void> {
+    this.rl.close();
+    this.proc.kill();
+    await new Promise<void>((resolve) => this.proc.once('exit', () => resolve()));
+  }
+
+  async search(query: string): Promise<BackendResponse<SearchHit[]>> {
+    const text = await this.callTool('search_notes', {
+      query,
+      limit: 10,
+      searchContent: true,
+      searchFrontmatter: false,
+    });
+
+    let hits: SearchHit[] = [];
+    try {
+      // mcpvault returns minified JSON with abbreviated keys:
+      // [{ p: path, t: title, ex: excerpt, mc: matchCount, ln: lineNumber }]
+      const raw = JSON.parse(text) as Array<{
+        p?: string;
+        t?: string;
+        ex?: string;
+        mc?: number;
+        score?: number;
+      }>;
+      hits = raw.map((h) => ({
+        path: h.p ?? '',
+        score: h.score,
+        snippet: h.ex,
+      }));
+    } catch {
+      // non-JSON response (e.g. "No results found") — empty hits
+    }
+
+    return { result: hits, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async read(path: string): Promise<BackendResponse<string>> {
+    const text = await this.callTool('read_note', { path });
+    // Response is JSON: { fm: {...}, content: "body text" }
+    let content = text;
+    try {
+      const parsed = JSON.parse(text) as { content?: string; fm?: unknown };
+      // Extract just the body for consistency with the fs adapter (raw markdown body).
+      // payloadBytes still measures the full response (fm + content) — that's the real context tax.
+      content = parsed.content ?? text;
+    } catch {
+      // plain text fallback
+    }
+    return { result: content, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async write(path: string, content: string): Promise<BackendResponse<void>> {
+    await this.callTool('write_note', { path, content, mode: 'overwrite' });
+    const buf = Buffer.from(content, 'utf8');
+    return { result: undefined, payloadBytes: buf.byteLength };
+  }
+
+  async list(path = '/'): Promise<BackendResponse<ListEntry[]>> {
+    const text = await this.callTool('list_directory', { path });
+    let result: ListEntry[] = [];
+    try {
+      const parsed = JSON.parse(text) as { dirs?: string[]; files?: string[] };
+      const prefix = path === '/' ? '' : `${path}/`;
+      result = [
+        ...(parsed.dirs ?? []).map((d) => ({ path: `${prefix}${d}`, isDirectory: true })),
+        ...(parsed.files ?? []).map((f) => ({ path: `${prefix}${f}`, isDirectory: false })),
+      ];
+    } catch {
+      // ignore parse errors
+    }
+    return { result, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  // ── Internal helpers ────────────────────────────────────────────────────
+
+  private async callTool(name: string, args: Record<string, unknown>): Promise<string> {
+    const resp = await this.request('tools/call', { name, arguments: args });
+    const tool = resp.result as McpToolResult;
+    if (tool?.isError) {
+      throw new Error(`mcpvault tool ${name} error: ${tool.content?.[0]?.text ?? 'unknown'}`);
+    }
+    return tool?.content?.[0]?.text ?? '';
+  }
+
+  private request(method: string, params: unknown): Promise<JsonRpcResponse> {
+    const id = this.nextId++;
+    const msg: JsonRpcRequest = { jsonrpc: '2.0', id, method, params };
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.stdin.write(`${JSON.stringify(msg)}\n`);
+    });
+  }
+
+  private notify(method: string, params: unknown): void {
+    const msg: JsonRpcRequest = { jsonrpc: '2.0', method, params };
+    this.stdin.write(`${JSON.stringify(msg)}\n`);
+  }
+}

--- a/packages/harness/src/bench/compare.ts
+++ b/packages/harness/src/bench/compare.ts
@@ -1,0 +1,201 @@
+import type { BenchmarkSummary } from './runner.js';
+
+/**
+ * Generates a cross-adapter comparison markdown table from multiple
+ * BenchmarkSummary objects. Designed to be the "headline" artifact —
+ * the table you'd drop into a blog post or README to show seekstone
+ * beats the competition on payload bytes and latency.
+ */
+export function renderComparisonMarkdown(summaries: BenchmarkSummary[]): string {
+  const first = summaries[0];
+  if (!first) return '# Benchmark Comparison\n\nNo data.\n';
+
+  const lines: string[] = [];
+  lines.push('# Obsidian MCP Server Benchmark Comparison');
+  lines.push('');
+  lines.push(
+    `> Generated ${first.snapshotDate.slice(0, 10)} · ${first.runs} runs · ${first.machine.platform}/${first.machine.arch} · Node ${first.machine.node}`,
+  );
+  lines.push('');
+
+  // ── Payload bytes comparison ──────────────────────────────────────────────
+  lines.push('## Payload bytes (context tax)');
+  lines.push('');
+  lines.push('Bytes returned per operation — what the LLM actually receives. Lower is better.');
+  lines.push('');
+
+  // Search payload table
+  const allQueryIds = [...new Set(summaries.flatMap((s) => s.search.map((q) => q.id)))];
+
+  lines.push('### Search payload bytes (mean across runs)');
+  lines.push('');
+  const searchHeader = ['Query', ...summaries.map((s) => s.backend.name)];
+  lines.push(`| ${searchHeader.join(' | ')} |`);
+  lines.push(`| ${searchHeader.map(() => '---').join(' | ')} |`);
+
+  for (const id of allQueryIds) {
+    const cells = summaries.map((s) => {
+      const q = s.search.find((sq) => sq.id === id);
+      if (!q) return '—';
+      return formatBytes(q.stats.payloadBytesMean);
+    });
+    const qLabel = first.search.find((q) => q.id === id)?.query ?? id;
+    lines.push(`| \`${qLabel}\` | ${cells.join(' | ')} |`);
+  }
+  lines.push('');
+
+  // Read payload table
+  const hasSmall = summaries.some((s) => s.read.small != null);
+  const hasLarge = summaries.some((s) => s.read.large != null);
+
+  if (hasSmall || hasLarge) {
+    lines.push('### Read payload bytes');
+    lines.push('');
+    lines.push(`| File | ${summaries.map((s) => s.backend.name).join(' | ')} |`);
+    lines.push(`| --- | ${summaries.map(() => '---').join(' | ')} |`);
+
+    if (hasSmall) {
+      const cells = summaries.map((s) =>
+        s.read.small ? formatBytes(s.read.small.stats.payloadBytesMean) : '—',
+      );
+      const label = summaries.find((s) => s.read.small)?.read.small?.path ?? 'small';
+      lines.push(`| \`${truncatePath(label)}\` (small) | ${cells.join(' | ')} |`);
+    }
+
+    if (hasLarge) {
+      const cells = summaries.map((s) =>
+        s.read.large ? formatBytes(s.read.large.stats.payloadBytesMean) : '—',
+      );
+      const label = summaries.find((s) => s.read.large)?.read.large?.path ?? 'large';
+      lines.push(`| \`${truncatePath(label)}\` (large) | ${cells.join(' | ')} |`);
+    }
+    lines.push('');
+  }
+
+  // ── Latency comparison ────────────────────────────────────────────────────
+  lines.push('## Latency (ms)');
+  lines.push('');
+  lines.push('`cold` = first run (index build + first query). `warm` = median of subsequent runs.');
+  lines.push('');
+
+  lines.push('### Search latency (ms)');
+  lines.push('');
+  const latHeader = [
+    'Query',
+    ...summaries.flatMap((s) => [`${s.backend.name} cold`, `${s.backend.name} warm`]),
+  ];
+  lines.push(`| ${latHeader.join(' | ')} |`);
+  lines.push(`| ${latHeader.map(() => '---').join(' | ')} |`);
+
+  for (const id of allQueryIds) {
+    const cells = summaries.flatMap((s) => {
+      const q = s.search.find((sq) => sq.id === id);
+      if (!q) return ['—', '—'];
+      return [
+        `${q.stats.coldMs.toFixed(1)}`,
+        q.stats.warm.median != null ? `${q.stats.warm.median.toFixed(1)}` : '—',
+      ];
+    });
+    const qLabel = first.search.find((q) => q.id === id)?.query ?? id;
+    lines.push(`| \`${qLabel}\` | ${cells.join(' | ')} |`);
+  }
+  lines.push('');
+
+  if (hasSmall || hasLarge) {
+    lines.push('### Read latency (ms)');
+    lines.push('');
+    lines.push(
+      `| File | ${summaries.flatMap((s) => [`${s.backend.name} cold`, `${s.backend.name} warm`]).join(' | ')} |`,
+    );
+    lines.push(`| --- | ${summaries.flatMap(() => ['---', '---']).join(' | ')} |`);
+
+    if (hasSmall) {
+      const cells = summaries.flatMap((s) => {
+        if (!s.read.small) return ['—', '—'];
+        return [
+          `${s.read.small.stats.coldMs.toFixed(1)}`,
+          s.read.small.stats.warm?.median != null
+            ? `${s.read.small.stats.warm.median.toFixed(1)}`
+            : '—',
+        ];
+      });
+      const label = summaries.find((s) => s.read.small)?.read.small?.path ?? 'small';
+      lines.push(`| \`${truncatePath(label)}\` (small) | ${cells.join(' | ')} |`);
+    }
+
+    if (hasLarge) {
+      const cells = summaries.flatMap((s) => {
+        if (!s.read.large) return ['—', '—'];
+        return [
+          `${s.read.large.stats.coldMs.toFixed(1)}`,
+          s.read.large.stats.warm?.median != null
+            ? `${s.read.large.stats.warm.median.toFixed(1)}`
+            : '—',
+        ];
+      });
+      const label = summaries.find((s) => s.read.large)?.read.large?.path ?? 'large';
+      lines.push(`| \`${truncatePath(label)}\` (large) | ${cells.join(' | ')} |`);
+    }
+    lines.push('');
+  }
+
+  // ── Multiplier summary ────────────────────────────────────────────────────
+  const baseline = summaries.find((s) => s.backend.name === 'fs') ?? first;
+  const others = summaries.filter((s) => s !== baseline);
+
+  if (others.length > 0) {
+    lines.push('## Payload size multiplier vs seekstone (fs)');
+    lines.push('');
+    lines.push(`Baseline: **${baseline.backend.name}** (${baseline.backend.description})`);
+    lines.push('');
+    lines.push(`| Adapter | Search payload (×) | Read small (×) | Read large (×) |`);
+    lines.push(`| --- | --- | --- | --- |`);
+
+    const baseSearchMean = avgSearchPayload(baseline);
+    const baseSmallMean = baseline.read.small?.stats.payloadBytesMean ?? null;
+    const baseLargeMean = baseline.read.large?.stats.payloadBytesMean ?? null;
+
+    for (const s of others) {
+      const searchMult =
+        baseSearchMean > 0 ? `${(avgSearchPayload(s) / baseSearchMean).toFixed(1)}×` : '—';
+      const smallMult =
+        baseSmallMean && s.read.small?.stats.payloadBytesMean
+          ? `${(s.read.small.stats.payloadBytesMean / baseSmallMean).toFixed(1)}×`
+          : '—';
+      const largeMult =
+        baseLargeMean && s.read.large?.stats.payloadBytesMean
+          ? `${(s.read.large.stats.payloadBytesMean / baseLargeMean).toFixed(1)}×`
+          : '—';
+      lines.push(`| **${s.backend.name}** | ${searchMult} | ${smallMult} | ${largeMult} |`);
+    }
+    lines.push('');
+  }
+
+  // ── Adapter descriptions ──────────────────────────────────────────────────
+  lines.push('## Adapters');
+  lines.push('');
+  for (const s of summaries) {
+    lines.push(`- **${s.backend.name}**: ${s.backend.description}`);
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function avgSearchPayload(s: BenchmarkSummary): number {
+  const means = s.search.map((q) => q.stats.payloadBytesMean).filter((v) => v > 0);
+  if (means.length === 0) return 0;
+  return means.reduce((a, b) => a + b, 0) / means.length;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function truncatePath(p: string, maxLen = 40): string {
+  if (p.length <= maxLen) return p;
+  return `…${p.slice(-(maxLen - 1))}`;
+}

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env -S npx tsx
 import { mkdir, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { cac } from 'cac';
+import { McpvaultAdapter } from './bench/adapters/mcpvault.js';
+import { renderComparisonMarkdown } from './bench/compare.js';
 import {
   FsAdapter,
   RestAdapter,
@@ -129,6 +132,29 @@ cli
     }
   });
 
+// ---------- compare ----------
+cli
+  .command('compare', 'Generate a cross-adapter comparison report from benchmark JSON files.')
+  .option('--reports <files>', 'Comma-separated paths to benchmark-*.json files.')
+  .option('--out <dir>', 'Output directory.', { default: 'reports' })
+  .action(async (opts) => {
+    const paths = needArg(opts.reports as string, 'reports')
+      .split(',')
+      .map((p: string) => resolve(p.trim()));
+    const summaries = await Promise.all(
+      paths.map(async (p: string) => {
+        const raw = await readFile(p, 'utf8');
+        return JSON.parse(raw) as import('./bench/runner.js').BenchmarkSummary;
+      }),
+    );
+    const outDir = resolve(opts.out);
+    await mkdir(outDir, { recursive: true });
+    const md = renderComparisonMarkdown(summaries);
+    const outPath = join(outDir, 'comparison.md');
+    await writeFile(outPath, md);
+    console.log(`compare: wrote ${outPath}`);
+  });
+
 cli.help();
 cli.version('0.0.0');
 cli.parse();
@@ -159,6 +185,15 @@ async function buildBackend(
     process.stderr.write(`fs: index ready.\n`);
     return adapter;
   }
-  console.error(`Unknown backend: ${name}. Known: rest, fs.`);
+  if (name === 'mcpvault') {
+    const root = resolve(
+      needArg(vaultRoot, 'vault (--vault or SEEKSTONE_VAULT for mcpvault backend)'),
+    );
+    process.stderr.write(`mcpvault: starting subprocess for ${root}…\n`);
+    const adapter = await McpvaultAdapter.build({ vaultRoot: root });
+    process.stderr.write(`mcpvault: ready.\n`);
+    return adapter;
+  }
+  console.error(`Unknown backend: ${name}. Known: rest, fs, mcpvault.`);
   process.exit(2);
 }


### PR DESCRIPTION
## Summary

Adds the infrastructure to benchmark seekstone against its top competitor: **mcpvault** by bitbonsai (1,300 stars, filesystem-direct, closest architectural peer).

### New: `McpvaultAdapter`

Spawns `@bitbonsai/mcpvault` as a stdio MCP subprocess and communicates via MCP JSON-RPC — the same transport Claude uses. Payload bytes are measured from `content[0].text` in the MCP response, so numbers reflect exactly what an LLM client receives.

Tool mapping: `search_notes` → `search`, `read_note` → `read`, `write_note` → `write`, `list_directory` → `list`.

### New: `compare` CLI command + `renderComparisonMarkdown`

Reads multiple `benchmark-*.json` files and produces `reports/comparison.md` with:
- Side-by-side payload bytes table (search + read, per query)
- Side-by-side latency table (cold + warm per adapter)
- Multiplier table showing how much larger each competitor's payload is vs seekstone

### Usage

```bash
# Run each adapter against the same vault + query set
npm run harness -- bench --backend fs       --vault $SEEKSTONE_VAULT --stats reports/vault-stats.json
npm run harness -- bench --backend mcpvault --vault $SEEKSTONE_VAULT --stats reports/vault-stats.json
npm run harness -- bench --backend rest     --vault $SEEKSTONE_VAULT --stats reports/vault-stats.json

# Generate comparison report
npm run harness -- compare \
  --reports reports/benchmark-fs.json,reports/benchmark-mcpvault.json,reports/benchmark-rest.json
```

## Test plan

- [ ] `npm test` passes (195 tests)
- [ ] `npm run lint` clean
- [ ] `npx tsc -p packages/harness/tsconfig.json --noEmit` clean
- [ ] Manually run `bench --backend mcpvault` against a real vault to validate the adapter connects and returns results