### PR TITLE
feat: seekstone init --client code --write auto-configures Claude Code (SHA-77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Add to `claude_desktop_config.json` (Settings → Developer → Edit Config):
 
 ### Option 4 — Claude Code
 
+Auto-detects your vault and configures Claude Code in one command:
+
+```bash
+npx -y obsidian-mcp-seekstone init --client code --write
+```
+
+Or manually, if you prefer to specify the vault path explicitly:
+
 ```bash
 claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y obsidian-mcp-seekstone
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ npx -y obsidian-mcp-seekstone init --write
 # Specify vault explicitly if you have multiple
 npx -y obsidian-mcp-seekstone init --vault "/path/to/vault"
 
-# Generate the Claude Code command instead
+# Auto-configure Claude Code in one step (auto-detects vault, runs claude mcp add)
+npx -y obsidian-mcp-seekstone init --client code --write
+
+# Or just print the Claude Code command without running it
 npx -y obsidian-mcp-seekstone init --client code
 ```
 

--- a/packages/server/src/init.test.ts
+++ b/packages/server/src/init.test.ts
@@ -232,6 +232,46 @@ describe('runInit', () => {
     expect(res.output.join('\n')).toContain('claude mcp add seekstone');
   });
 
+  it('--write --client code calls spawnClaudeMcp with correct args', async () => {
+    const calls: string[][] = [];
+    const spawnClaudeMcp = (args: string[]) => {
+      calls.push(args);
+      return { ok: true };
+    };
+    const res = await runInit(
+      { vault, write: true, client: 'code' },
+      { ...deps(), spawnClaudeMcp },
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.ranClaudeMcpAdd).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([
+      'mcp',
+      'add',
+      'seekstone',
+      '--env',
+      `SEEKSTONE_VAULT=${vault}`,
+      '--',
+      'npx',
+      '-y',
+      'seekstone',
+    ]);
+    expect(res.output.join('\n')).toContain('seekstone added to Claude Code');
+  });
+
+  it('--write --client code falls back gracefully when claude is not on PATH', async () => {
+    const spawnClaudeMcp = (_args: string[]) => ({ ok: false, error: 'command not found: claude' });
+    const res = await runInit(
+      { vault, write: true, client: 'code' },
+      { ...deps(), spawnClaudeMcp },
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.ranClaudeMcpAdd).toBeUndefined();
+    const text = res.output.join('\n');
+    expect(text).toContain('Could not run');
+    expect(text).toContain('claude mcp add seekstone');
+  });
+
   it('--write creates a new config when none exists', async () => {
     const res = await runInit({ vault, write: true, client: 'desktop' }, deps());
     expect(res.exitCode).toBe(0);

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import type { Dirent } from 'node:fs';
 import { access, copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import path, { dirname, join } from 'node:path';
@@ -196,9 +197,11 @@ export interface InitResult {
   output: string[];
   /** Process exit code. */
   exitCode: number;
-  /** Set when --write actually patched a file. */
+  /** Set when --write patched Claude Desktop config. */
   wrotePath?: string;
   backupPath?: string;
+  /** Set when --write --client code successfully ran `claude mcp add`. */
+  ranClaudeMcpAdd?: boolean;
 }
 
 /**
@@ -214,6 +217,11 @@ export async function runInit(
     timestamp: string;
     /** Injectable for testing; defaults to fs/promises readFile. */
     readFile?: (p: string, enc: 'utf8') => Promise<string>;
+    /**
+     * Injectable for testing; defaults to execFileSync('claude', args).
+     * Returns ok:true on success, ok:false with an error string on failure.
+     */
+    spawnClaudeMcp?: (args: string[]) => { ok: boolean; error?: string };
   },
 ): Promise<InitResult> {
   const rf = deps.readFile ?? readFile;
@@ -276,6 +284,49 @@ export async function runInit(
   ];
 
   if (opts.client === 'code') {
+    if (opts.write) {
+      const spawn =
+        deps.spawnClaudeMcp ??
+        ((args: string[]) => {
+          try {
+            execFileSync('claude', args, { stdio: 'inherit' });
+            return { ok: true };
+          } catch (err) {
+            return { ok: false, error: err instanceof Error ? err.message : String(err) };
+          }
+        });
+
+      const mcpArgs = [
+        'mcp',
+        'add',
+        'seekstone',
+        '--env',
+        `SEEKSTONE_VAULT=${vaultPath}`,
+        '--',
+        'npx',
+        '-y',
+        'seekstone',
+      ];
+      const result = spawn(mcpArgs);
+
+      if (result.ok) {
+        out.push('✓ seekstone added to Claude Code.', '', 'Restart Claude Code to load seekstone.');
+        return { ok: true, exitCode: 0, output: out, ranClaudeMcpAdd: true };
+      }
+
+      // claude not on PATH or command failed — fall back to manual instructions.
+      out.push(
+        '⚠ Could not run `claude mcp add` automatically.',
+        result.error ? `  ${result.error}` : '',
+        '',
+        'Run this command manually instead:',
+        '',
+        `  ${mcpAddCommand(vaultPath)}`,
+        '',
+      );
+      return { ok: false, exitCode: 1, output: out };
+    }
+
     out.push('Add to Claude Code by running:', '', `  ${mcpAddCommand(vaultPath)}`, '');
     return { ok: true, exitCode: 0, output: out };
   }


### PR DESCRIPTION
## Summary

Makes `--write` work for `--client code`, reducing Claude Code install from 5 steps to 2.

**Before:**
1. Run `npx -y seekstone init --client code`
2. Read the output
3. Copy the `claude mcp add ...` command
4. Paste and run it
5. Restart Claude Code

**After:**
1. Run `npx -y seekstone init --client code --write`
2. Restart Claude Code

Vault is auto-detected from Obsidian's registry — no path editing required.

## Changes

- `init.ts`: when `--write --client code`, spawns `claude mcp add seekstone ...` as a subprocess. Falls back gracefully to printing the manual command if `claude` is not on PATH.
- `init.test.ts`: 2 new tests — success path (verifies exact args passed to spawn) and fallback path (claude not on PATH).
- `README.md`: Option 4 now shows the one-command flow as the primary path.

## Test plan

- [ ] `npm test` passes (197 tests)
- [ ] `npm run lint` clean
- [ ] CI green across all platforms