### PR TITLE
fix(ci): attach seekstone.mcpb to both release tags (SHA-78)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           VERSION=$(node -p "require('./packages/server/package.json').version")
+          OMCP_VERSION=$(node -p "require('./packages/obsidian-mcp-seekstone/package.json').version")
           gh release upload "seekstone@${VERSION}" seekstone.mcpb --clobber
+          gh release upload "obsidian-mcp-seekstone@${OMCP_VERSION}" seekstone.mcpb --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- The CI was only uploading `seekstone.mcpb` to the `seekstone@*` release tag
- GitHub marks `obsidian-mcp-seekstone@*` as Latest (created last by changesets)
- That release had no assets, so users following Option 1 in the README couldn't find the file
- Now uploads to both tags on every release

## Hotfix already applied

`seekstone.mcpb` has been manually uploaded to `obsidian-mcp-seekstone@0.3.0` to unblock current users. This PR ensures future releases never have the same gap.

## Test plan

- [ ] Merge and trigger a release — confirm `seekstone.mcpb` appears as an asset on both `seekstone@*` and `obsidian-mcp-seekstone@*` release tags
- [ ] Visit `releases/latest` and confirm the asset is present

Fixes SHA-78