### PR TITLE
fix(mcpb): fully bundle all deps + fix ESM require('process') crash (SHA-79)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           VERSION=$(node -p "require('./packages/server/package.json').version")
+          OMCP_VERSION=$(node -p "require('./packages/obsidian-mcp-seekstone/package.json').version")
           gh release upload "seekstone@${VERSION}" seekstone.mcpb --clobber
+          gh release upload "obsidian-mcp-seekstone@${OMCP_VERSION}" seekstone.mcpb --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/server/tsup.mcpb.config.ts
+++ b/packages/server/tsup.mcpb.config.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { defineConfig } from 'tsup';
+
+const { version } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+
+// Self-contained bundle for .mcpb distribution. Claude Desktop runs this with
+// its built-in Node.js in an isolated directory — no node_modules available.
+// Everything must be inlined; nothing can remain external.
+//
+// Banner trick: yaml's node build is CJS and calls require('process'). tsup's
+// ESM __require shim checks `typeof require !== "undefined"` at init time.
+// Injecting `var require = createRequire(...)` in the banner runs BEFORE that
+// check, so __require wires itself to the real Node.js require — which handles
+// built-ins — instead of the throwing stub.
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  platform: 'node',
+  target: 'node22',
+  outDir: 'dist',
+  bundle: true,
+  noExternal: [/.*/],
+  banner: {
+    js: `import { createRequire } from 'module'; var require = createRequire(import.meta.url);`,
+  },
+  define: { __SEEKSTONE_VERSION__: JSON.stringify(version) },
+  dts: false,
+  sourcemap: true,
+  clean: true,
+});

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -29,9 +29,10 @@ manifest.version = version;
 await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 console.log(`Stamped manifest.json with version ${version}`);
 
-// 3. Build the server.
-console.log('Building server...');
-execSync('npm run build -w seekstone', { stdio: 'inherit', cwd: root });
+// 3. Build a fully-bundled version for the mcpb (all deps inlined — no node_modules
+//    available when Claude Desktop runs it with built-in Node.js).
+console.log('Building server (mcpb — all deps bundled)...');
+execSync('npx tsup --config tsup.mcpb.config.ts', { stdio: 'inherit', cwd: serverDir });
 
 // 4. Pack into seekstone.mcpb.
 console.log('Packing...');


### PR DESCRIPTION
## Problem

The `.mcpb` from Option 1 crashed immediately when Claude Desktop launched it — server disconnected within ~200ms, no tools available. Two bugs in sequence:

**Bug 1 — deps not bundled:**
The regular tsup build leaves runtime deps external (correct for npm). But `.mcpb` runs in an isolated dir with no `node_modules`:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@modelcontextprotocol/sdk'
```

**Bug 2 — `require('process')` in ESM bundle:**
After fixing bug 1 with `noExternal: [/.*/]`, yaml's node build (CJS) calls `require('process')`. tsup's ESM `__require` shim has no `require` in scope, so it throws:
```
Error: Dynamic require of "process" is not supported
```

## Fix

**New `packages/server/tsup.mcpb.config.ts`:**
- `noExternal: [/.*/]` — inlines all deps
- `banner` injects `var require = createRequire(import.meta.url)` before the bundle, so tsup's `__require` shim wires to the real Node.js resolver (handles built-ins) instead of the throwing stub

**`scripts/build-mcpb.mjs`:**
- Uses `npx tsup --config tsup.mcpb.config.ts` for the mcpb build — regular npm build is unchanged

## Verification

Extracted bundle in isolation, no `node_modules`:
```
INFO building index vault=...
INFO index ready notes=1943 buildMs=1317
INFO ready tools=8 transport=stdio
```
Process stays alive. Hotfix `.mcpb` already uploaded to `obsidian-mcp-seekstone@0.3.0`.

## Test plan
- [ ] CI green on all 3 platforms
- [ ] After merge, `npm run build:mcpb` produces a working bundle (test by extracting and running `node dist/index.js` without node_modules)

Fixes SHA-79