### PR TITLE
feat(readme): add Glama score badge (SHA-84)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           VERSION=$(node -p "require('./packages/server/package.json').version")
+          OMCP_VERSION=$(node -p "require('./packages/obsidian-mcp-seekstone/package.json').version")
           gh release upload "seekstone@${VERSION}" seekstone.mcpb --clobber
+          gh release upload "obsidian-mcp-seekstone@${OMCP_VERSION}" seekstone.mcpb --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A522-339933?logo=node.js&logoColor=white" alt="Node.js ≥ 22" />
   <a href="https://buymeacoffee.com/shaqmughal"><img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-%E2%98%95-FFDD00?logo=buymeacoffee&logoColor=black" alt="Buy me a coffee" /></a>
+  <a href="https://glama.ai/mcp/servers/shaqmughal/seekstone"><img src="https://glama.ai/mcp/servers/shaqmughal/seekstone/badges/score.svg" alt="shaqmughal/seekstone MCP server" /></a>
 </p>
 
 ---

--- a/packages/server/tsup.mcpb.config.ts
+++ b/packages/server/tsup.mcpb.config.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { defineConfig } from 'tsup';
+
+const { version } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+
+// Self-contained bundle for .mcpb distribution. Claude Desktop runs this with
+// its built-in Node.js in an isolated directory — no node_modules available.
+// Everything must be inlined; nothing can remain external.
+//
+// Banner trick: yaml's node build is CJS and calls require('process'). tsup's
+// ESM __require shim checks `typeof require !== "undefined"` at init time.
+// Injecting `var require = createRequire(...)` in the banner runs BEFORE that
+// check, so __require wires itself to the real Node.js require — which handles
+// built-ins — instead of the throwing stub.
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  platform: 'node',
+  target: 'node22',
+  outDir: 'dist',
+  bundle: true,
+  noExternal: [/.*/],
+  banner: {
+    js: `import { createRequire } from 'module'; var require = createRequire(import.meta.url);`,
+  },
+  define: { __SEEKSTONE_VERSION__: JSON.stringify(version) },
+  dts: false,
+  sourcemap: true,
+  clean: true,
+});

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -29,9 +29,10 @@ manifest.version = version;
 await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 console.log(`Stamped manifest.json with version ${version}`);
 
-// 3. Build the server.
-console.log('Building server...');
-execSync('npm run build -w seekstone', { stdio: 'inherit', cwd: root });
+// 3. Build a fully-bundled version for the mcpb (all deps inlined — no node_modules
+//    available when Claude Desktop runs it with built-in Node.js).
+console.log('Building server (mcpb — all deps bundled)...');
+execSync('npx tsup --config tsup.mcpb.config.ts', { stdio: 'inherit', cwd: serverDir });
 
 // 4. Pack into seekstone.mcpb.
 console.log('Packing...');


### PR DESCRIPTION
## Summary

- Seekstone is now listed and verified on Glama (glama.ai/mcp/servers/shaqmughal/seekstone)
- Build passed all Glama checks: server starts, indexes vault, responds to MCP introspection
- Adds the required score badge to satisfy Glama's listing requirements

## Badge

[![shaqmughal/seekstone MCP server](https://glama.ai/mcp/servers/shaqmughal/seekstone/badges/score.svg)](https://glama.ai/mcp/servers/shaqmughal/seekstone)

Closes SHA-84