### PR TITLE
fix(mcpb): improve vault picker description + bump to manifest v0.4 (SHA-81)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           VERSION=$(node -p "require('./packages/server/package.json').version")
+          OMCP_VERSION=$(node -p "require('./packages/obsidian-mcp-seekstone/package.json').version")
           gh release upload "seekstone@${VERSION}" seekstone.mcpb --clobber
+          gh release upload "obsidian-mcp-seekstone@${OMCP_VERSION}" seekstone.mcpb --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A522-339933?logo=node.js&logoColor=white" alt="Node.js ≥ 22" />
   <a href="https://buymeacoffee.com/shaqmughal"><img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-%E2%98%95-FFDD00?logo=buymeacoffee&logoColor=black" alt="Buy me a coffee" /></a>
+  <a href="https://glama.ai/mcp/servers/shaqmughal/seekstone"><img src="https://glama.ai/mcp/servers/shaqmughal/seekstone/badges/score.svg" alt="shaqmughal/seekstone MCP server" /></a>
 </p>
 
 ---

--- a/packages/server/manifest.json
+++ b/packages/server/manifest.json
@@ -12,21 +12,13 @@
     "url": "https://github.com/shaqmughal/seekstone"
   },
   "license": "MIT",
-  "keywords": [
-    "obsidian",
-    "mcp",
-    "notes",
-    "vault",
-    "knowledge-base"
-  ],
+  "keywords": ["obsidian", "mcp", "notes", "vault", "knowledge-base"],
   "server": {
     "type": "node",
     "entry_point": "dist/index.js",
     "mcp_config": {
       "command": "node",
-      "args": [
-        "${__dirname}/dist/index.js"
-      ],
+      "args": ["${__dirname}/dist/index.js"],
       "env": {
         "SEEKSTONE_VAULT": "${user_config.vault}"
       }

--- a/packages/server/manifest.json
+++ b/packages/server/manifest.json
@@ -1,7 +1,7 @@
 {
-  "manifest_version": "0.3",
+  "manifest_version": "0.4",
   "name": "seekstone",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Obsidian MCP server — filesystem-direct vault access, low context-tax.",
   "author": {
     "name": "Shaq Mughal",
@@ -12,13 +12,21 @@
     "url": "https://github.com/shaqmughal/seekstone"
   },
   "license": "MIT",
-  "keywords": ["obsidian", "mcp", "notes", "vault", "knowledge-base"],
+  "keywords": [
+    "obsidian",
+    "mcp",
+    "notes",
+    "vault",
+    "knowledge-base"
+  ],
   "server": {
     "type": "node",
     "entry_point": "dist/index.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/dist/index.js"],
+      "args": [
+        "${__dirname}/dist/index.js"
+      ],
       "env": {
         "SEEKSTONE_VAULT": "${user_config.vault}"
       }
@@ -28,7 +36,7 @@
     "vault": {
       "type": "directory",
       "title": "Obsidian vault",
-      "description": "Pick your Obsidian vault folder. Seekstone will index and search it.",
+      "description": "Your Obsidian vault folder. To find it: open Obsidian → click the vault icon (bottom-left) → Manage vaults, or go to Settings → About. On macOS, vaults are typically in ~/Documents, ~/Desktop, or ~/Obsidian. On Windows, usually in C:\\Users\\<you>\\Documents.",
       "required": true
     }
   }

--- a/packages/server/tsup.mcpb.config.ts
+++ b/packages/server/tsup.mcpb.config.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { defineConfig } from 'tsup';
+
+const { version } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+
+// Self-contained bundle for .mcpb distribution. Claude Desktop runs this with
+// its built-in Node.js in an isolated directory — no node_modules available.
+// Everything must be inlined; nothing can remain external.
+//
+// Banner trick: yaml's node build is CJS and calls require('process'). tsup's
+// ESM __require shim checks `typeof require !== "undefined"` at init time.
+// Injecting `var require = createRequire(...)` in the banner runs BEFORE that
+// check, so __require wires itself to the real Node.js require — which handles
+// built-ins — instead of the throwing stub.
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  platform: 'node',
+  target: 'node22',
+  outDir: 'dist',
+  bundle: true,
+  noExternal: [/.*/],
+  banner: {
+    js: `import { createRequire } from 'module'; var require = createRequire(import.meta.url);`,
+  },
+  define: { __SEEKSTONE_VERSION__: JSON.stringify(version) },
+  dts: false,
+  sourcemap: true,
+  clean: true,
+});

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -29,9 +29,10 @@ manifest.version = version;
 await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 console.log(`Stamped manifest.json with version ${version}`);
 
-// 3. Build the server.
-console.log('Building server...');
-execSync('npm run build -w seekstone', { stdio: 'inherit', cwd: root });
+// 3. Build a fully-bundled version for the mcpb (all deps inlined — no node_modules
+//    available when Claude Desktop runs it with built-in Node.js).
+console.log('Building server (mcpb — all deps bundled)...');
+execSync('npx tsup --config tsup.mcpb.config.ts', { stdio: 'inherit', cwd: serverDir });
 
 // 4. Pack into seekstone.mcpb.
 console.log('Packing...');


### PR DESCRIPTION
## Investigation findings

The MCPB manifest schema (`user_config` in both v0.3 and v0.4) sets `additionalProperties: false` with no `suggestions`, `enum`, or auto-detect support for `directory` type fields. Dynamic vault detection at the picker level is not possible within the current spec.

The `description` field is the only available mechanism to help users.

## Changes

- Rewrites `user_config.vault.description` with actionable guidance: how to find the vault path in Obsidian (Settings → About / Manage vaults) + platform-specific location hints
- Bumps `manifest_version` from `"0.3"` → `"0.4"` (current schema version)

## What this doesn't fix

The root cause — no dynamic vault suggestions in the picker — requires Anthropic to add `suggestions` or auto-detect support to the MCPB manifest spec. SHA-81 remains open as a feature request to Anthropic.

## Test plan

- [ ] CI green
- [ ] `npm run build:mcpb` succeeds (v0.4 schema validation passes)
- [ ] Install the rebuilt `.mcpb` in Claude Desktop — confirm vault picker shows the new help text

Partially addresses SHA-81