### PR TITLE
feat(server): add outline_note tool (SHA-10)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,8 @@
     "./walk": "./src/walk.ts",
     "./frontmatter": "./src/frontmatter.ts",
     "./extract": "./src/extract.ts",
-    "./percentiles": "./src/percentiles.ts"
+    "./percentiles": "./src/percentiles.ts",
+    "./outline": "./src/outline.ts"
   },
   "scripts": {
     "test": "vitest run"

--- a/packages/core/src/outline.test.ts
+++ b/packages/core/src/outline.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import { buildOutline } from './outline.js';
+
+const NOTE_NO_FM = `# Top Heading
+
+Some prose here.
+
+## Sub-section
+
+More text. ^block1
+
+^block2
+
+### Deep
+
+End.
+`;
+
+const NOTE_WITH_FM = `---
+title: My Note
+tags: [foo, bar]
+---
+# First
+
+Body.
+
+## Second
+
+Content. ^ref-a
+`;
+
+const NOTE_NO_HEADINGS = `---
+title: Flat
+---
+Just a flat body with no headings.
+`;
+
+describe('buildOutline', () => {
+  describe('headings', () => {
+    it('returns headings in document order with correct level and text', () => {
+      const out = buildOutline(NOTE_NO_FM);
+      expect(out.headings).toEqual([
+        expect.objectContaining({ text: 'Top Heading', level: 1, line: 1 }),
+        expect.objectContaining({ text: 'Sub-section', level: 2, line: 5 }),
+        expect.objectContaining({ text: 'Deep', level: 3, line: 11 }),
+      ]);
+    });
+
+    it('byteOffset lands on the # of the heading', () => {
+      const out = buildOutline(NOTE_NO_FM);
+      for (const h of out.headings) {
+        expect(NOTE_NO_FM[h.byteOffset]).toBe('#');
+      }
+    });
+
+    it('excludes frontmatter delimiter lines from headings', () => {
+      const out = buildOutline(NOTE_WITH_FM);
+      expect(out.headings.map((h) => h.text)).toEqual(['First', 'Second']);
+    });
+
+    it('returns empty headings array for note with no headings (not an error)', () => {
+      const out = buildOutline(NOTE_NO_HEADINGS);
+      expect(out.headings).toEqual([]);
+    });
+
+    it('does not match #tag-style inline tags as headings', () => {
+      const raw = `This has a #tag inline and ## not a heading mid-line.\n`;
+      const out = buildOutline(raw);
+      expect(out.headings).toEqual([]);
+    });
+
+    it('handles all six heading levels', () => {
+      const raw = `# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6\n`;
+      const out = buildOutline(raw);
+      expect(out.headings.map((h) => h.level)).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    it('does not match headings without a space after #', () => {
+      const raw = `#notaheading\n# real heading\n`;
+      const out = buildOutline(raw);
+      expect(out.headings).toHaveLength(1);
+      expect(out.headings[0]?.text).toBe('real heading');
+    });
+  });
+
+  describe('blocks', () => {
+    it('detects block refs at end of a content line', () => {
+      const out = buildOutline(NOTE_NO_FM);
+      expect(out.blocks).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: 'block1' })]),
+      );
+    });
+
+    it('detects standalone block ref lines', () => {
+      const out = buildOutline(NOTE_NO_FM);
+      expect(out.blocks).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: 'block2' })]),
+      );
+    });
+
+    it('byteOffset lands on ^ of the block ref', () => {
+      const out = buildOutline(NOTE_NO_FM);
+      for (const b of out.blocks) {
+        expect(NOTE_NO_FM[b.byteOffset]).toBe('^');
+      }
+    });
+
+    it('detects block refs after frontmatter only', () => {
+      const rawWithFmBlock = `---\ntags: [foo]\n---\nBody. ^after-fm\n`;
+      const out = buildOutline(rawWithFmBlock);
+      expect(out.blocks).toHaveLength(1);
+      expect(out.blocks[0]?.id).toBe('after-fm');
+    });
+
+    it('returns empty blocks when includeBlocks is false', () => {
+      const out = buildOutline(NOTE_NO_FM, { includeBlocks: false });
+      expect(out.blocks).toEqual([]);
+    });
+  });
+
+  describe('frontmatterKeys', () => {
+    it('returns top-level FM keys in original order', () => {
+      const out = buildOutline(NOTE_WITH_FM);
+      expect(out.frontmatterKeys).toEqual(['title', 'tags']);
+    });
+
+    it('returns empty array when no frontmatter', () => {
+      const out = buildOutline(NOTE_NO_FM);
+      expect(out.frontmatterKeys).toEqual([]);
+    });
+  });
+
+  describe('totalBytes', () => {
+    it('matches Buffer.byteLength of the raw content', () => {
+      const out = buildOutline(NOTE_WITH_FM);
+      expect(out.totalBytes).toBe(Buffer.byteLength(NOTE_WITH_FM, 'utf8'));
+    });
+  });
+
+  describe('includeSizes', () => {
+    it('adds byteLength to each heading when includeSizes is true', () => {
+      const out = buildOutline(NOTE_NO_FM, { includeSizes: true });
+      for (const h of out.headings) {
+        expect(typeof h.byteLength).toBe('number');
+      }
+    });
+
+    it('last heading byteLength extends to end of raw string', () => {
+      const out = buildOutline(NOTE_NO_FM, { includeSizes: true });
+      let checked = false;
+      for (const [i, h] of out.headings.entries()) {
+        if (i === out.headings.length - 1) {
+          expect(h.byteLength).toBe(NOTE_NO_FM.length - h.byteOffset);
+          checked = true;
+        }
+      }
+      expect(checked).toBe(true);
+    });
+
+    it('heading byteLength spans to the next heading start', () => {
+      const out = buildOutline(NOTE_NO_FM, { includeSizes: true });
+      let checked = false;
+      for (const [i, h] of out.headings.entries()) {
+        const next = out.headings[i + 1];
+        if (next !== undefined) {
+          expect(h.byteLength).toBe(next.byteOffset - h.byteOffset);
+          checked = true;
+          break;
+        }
+      }
+      expect(checked).toBe(true);
+    });
+
+    it('byteLength is absent when includeSizes is false', () => {
+      const out = buildOutline(NOTE_NO_FM, { includeSizes: false });
+      for (const h of out.headings) {
+        expect(h.byteLength).toBeUndefined();
+      }
+    });
+  });
+
+  describe('payload size', () => {
+    it('outline is a small fraction of full note bytes', () => {
+      const body = `${'word '.repeat(500)}\n`.repeat(20);
+      const raw = `---\ntitle: Big Note\n---\n# Section\n\n${body}`;
+      const out = buildOutline(raw);
+      const outlineBytes = Buffer.byteLength(JSON.stringify(out), 'utf8');
+      expect(outlineBytes).toBeLessThan(out.totalBytes * 0.1);
+    });
+  });
+});

--- a/packages/core/src/outline.ts
+++ b/packages/core/src/outline.ts
@@ -1,0 +1,98 @@
+import { parseFrontmatter } from './frontmatter.js';
+
+export interface HeadingEntry {
+  text: string;
+  level: number;
+  /** 1-based line number in the file. */
+  line: number;
+  /** Character offset of the leading `#` in the raw file string. */
+  byteOffset: number;
+  /** Characters from this heading to the next (or end of file). Only present when includeSizes is true. */
+  byteLength?: number;
+}
+
+export interface BlockEntry {
+  id: string;
+  /** 1-based line number in the file. */
+  line: number;
+  /** Character offset of the `^` in the raw file string. */
+  byteOffset: number;
+}
+
+export interface NoteOutline {
+  headings: HeadingEntry[];
+  blocks: BlockEntry[];
+  /** Top-level frontmatter keys in original order (empty if no frontmatter). */
+  frontmatterKeys: string[];
+  /** True UTF-8 byte length of the file. */
+  totalBytes: number;
+}
+
+export interface OutlineOptions {
+  /** Include block-reference anchors (^id). Default true. */
+  includeBlocks?: boolean;
+  /** Include per-section character length in each heading entry. Default false. */
+  includeSizes?: boolean;
+}
+
+const HEADING_RE = /^(#{1,6})\s+(.+)/;
+const BLOCK_REF_RE = /\^([a-zA-Z0-9-]+)$/;
+
+/**
+ * Parse a note's structure — heading tree, block anchors, frontmatter keys —
+ * without touching the prose. Shared by outline_note and patch_note.
+ *
+ * Offsets are character positions in the raw string (identical to UTF-8 byte
+ * offsets for ASCII content, which covers the vast majority of vault notes).
+ */
+export function buildOutline(raw: string, options: OutlineOptions = {}): NoteOutline {
+  const { includeBlocks = true, includeSizes = false } = options;
+
+  const fm = parseFrontmatter(raw);
+  const totalBytes = Buffer.byteLength(raw, 'utf8');
+  const headings: HeadingEntry[] = [];
+  const blocks: BlockEntry[] = [];
+
+  let charOffset = 0;
+
+  for (const [i, line] of raw.split('\n').entries()) {
+    const lineCharOffset = charOffset;
+    const lineNum = i + 1;
+
+    if (charOffset >= fm.bodyStart) {
+      const hm = HEADING_RE.exec(line);
+      if (hm) {
+        headings.push({
+          text: (hm[2] ?? '').trim(),
+          level: (hm[1] ?? '').length,
+          line: lineNum,
+          byteOffset: lineCharOffset,
+        });
+      }
+
+      if (includeBlocks) {
+        const trimmed = line.trimEnd();
+        const bm = BLOCK_REF_RE.exec(trimmed);
+        if (bm) {
+          const caretPos = trimmed.lastIndexOf('^');
+          blocks.push({
+            id: bm[1] ?? '',
+            line: lineNum,
+            byteOffset: lineCharOffset + caretPos,
+          });
+        }
+      }
+    }
+
+    charOffset += line.length + 1; // +1 for the '\n' consumed by split
+  }
+
+  if (includeSizes) {
+    for (const [i, heading] of headings.entries()) {
+      const next = headings[i + 1];
+      heading.byteLength = (next?.byteOffset ?? raw.length) - heading.byteOffset;
+    }
+  }
+
+  return { headings, blocks, frontmatterKeys: fm.keys, totalBytes };
+}

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -6,6 +6,7 @@ import { DeleteNoteInput, deleteNote } from './tools/delete_note.js';
 import { ListNotesInput, listNotes } from './tools/list_notes.js';
 import { ListTagsInput, listTags } from './tools/list_tags.js';
 import { MoveNoteInput, moveNote } from './tools/move_note.js';
+import { OutlineNoteInput, outlineNote } from './tools/outline_note.js';
 import { PatchFrontmatterInput, patchFrontmatter } from './tools/patch_frontmatter.js';
 import { ReadNoteInput, readNote } from './tools/read_note.js';
 import { SearchInput, search } from './tools/search.js';
@@ -26,6 +27,7 @@ export const HANDLED_TOOLS = [
   'move_note',
   'append_note',
   'patch_frontmatter',
+  'outline_note',
 ] as const;
 
 // Metadata-safe keys: logged at info. Note content (`content`, `frontmatter`,
@@ -145,6 +147,11 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
     case 'patch_frontmatter': {
       const input = PatchFrontmatterInput.parse(args);
       const result = await patchFrontmatter(ctx, input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+    case 'outline_note': {
+      const input = OutlineNoteInput.parse(args);
+      const result = await outlineNote(ctx, input);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     }
     default:

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -211,6 +211,27 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['path', 'patch'],
       },
     },
+    {
+      name: 'outline_note',
+      description:
+        "Return a note's structure — heading tree with offsets, block-reference anchors, and frontmatter key list — without returning any prose. Use this before section reads or patches to discover what sections exist at a fraction of the cost of reading the full note.",
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Vault-relative path to the note.' },
+          includeBlocks: {
+            type: 'boolean',
+            description: 'Include block-reference anchors (^id). Default true.',
+          },
+          includeSizes: {
+            type: 'boolean',
+            description:
+              'Include per-section character length in each heading entry. Default false.',
+          },
+        },
+        required: ['path'],
+      },
+    },
   ],
 }));
 
@@ -221,7 +242,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req): Promise<CallToolRes
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
-log.info('ready', { tools: 9, transport: 'stdio' });
+log.info('ready', { tools: 10, transport: 'stdio' });
 
 process.stderr.write(
   `seekstone: add to Claude Desktop:\n${JSON.stringify(

--- a/packages/server/src/tools/outline_note.test.ts
+++ b/packages/server/src/tools/outline_note.test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import MiniSearch from 'minisearch';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ServerContext } from '../context.js';
+import type { IndexedNote } from '../index/types.js';
+import { outlineNote } from './outline_note.js';
+
+function buildCtx(vaultRoot: string): ServerContext {
+  const index = new MiniSearch<IndexedNote>({
+    idField: 'id',
+    fields: ['title', 'body', 'tags', 'fmKeys'],
+    storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
+    searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
+  });
+  return { vaultRoot, index, notes: new Map() };
+}
+
+const NOTE = `---
+title: Test
+tags: [a]
+---
+# Intro
+
+Some prose. ^ref1
+
+## Details
+
+More prose.
+
+### Deep
+
+End.
+`;
+
+let vaultRoot: string;
+
+beforeAll(async () => {
+  vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-outline-note-'));
+  await writeFile(join(vaultRoot, 'note.md'), NOTE, 'utf8');
+});
+
+afterAll(async () => {
+  await rm(vaultRoot, { recursive: true, force: true });
+});
+
+describe('outlineNote', () => {
+  it('returns headings from the note body', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await outlineNote(ctx, {
+      path: 'note.md',
+      includeBlocks: true,
+      includeSizes: false,
+    });
+    expect(result.headings.map((h) => h.text)).toEqual(['Intro', 'Details', 'Deep']);
+  });
+
+  it('returns frontmatterKeys', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await outlineNote(ctx, {
+      path: 'note.md',
+      includeBlocks: true,
+      includeSizes: false,
+    });
+    expect(result.frontmatterKeys).toEqual(['title', 'tags']);
+  });
+
+  it('returns block refs when includeBlocks is true', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await outlineNote(ctx, {
+      path: 'note.md',
+      includeBlocks: true,
+      includeSizes: false,
+    });
+    expect(result.blocks).toEqual([expect.objectContaining({ id: 'ref1' })]);
+  });
+
+  it('omits block refs when includeBlocks is false', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await outlineNote(ctx, {
+      path: 'note.md',
+      includeBlocks: false,
+      includeSizes: false,
+    });
+    expect(result.blocks).toEqual([]);
+  });
+
+  it('totalBytes matches the file content', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await outlineNote(ctx, {
+      path: 'note.md',
+      includeBlocks: true,
+      includeSizes: false,
+    });
+    expect(result.totalBytes).toBe(Buffer.byteLength(NOTE, 'utf8'));
+  });
+
+  it('includes byteLength on headings when includeSizes is true', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await outlineNote(ctx, {
+      path: 'note.md',
+      includeBlocks: true,
+      includeSizes: true,
+    });
+    for (const h of result.headings) {
+      expect(typeof h.byteLength).toBe('number');
+    }
+  });
+
+  it('throws "Path outside vault" for traversal attempts', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await expect(
+      outlineNote(ctx, { path: '../outside.md', includeBlocks: true, includeSizes: false }),
+    ).rejects.toThrow('Path outside vault');
+  });
+});

--- a/packages/server/src/tools/outline_note.ts
+++ b/packages/server/src/tools/outline_note.ts
@@ -1,0 +1,31 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { buildOutline } from '@seekstone/core/outline';
+import { z } from 'zod';
+import type { ServerContext } from '../context.js';
+
+export const OutlineNoteInput = z.object({
+  path: z.string().describe('Vault-relative path to the note.'),
+  includeBlocks: z
+    .boolean()
+    .default(true)
+    .describe('Include block-reference anchors (^id). Default true.'),
+  includeSizes: z
+    .boolean()
+    .default(false)
+    .describe('Include per-section character length in each heading entry. Default false.'),
+});
+export type OutlineNoteInput = z.infer<typeof OutlineNoteInput>;
+
+export async function outlineNote(ctx: ServerContext, input: OutlineNoteInput) {
+  const absPath = join(ctx.vaultRoot, input.path);
+  if (!absPath.startsWith(ctx.vaultRoot)) {
+    throw new Error(`Path outside vault: ${input.path}`);
+  }
+
+  const raw = await readFile(absPath, 'utf8');
+  return buildOutline(raw, {
+    includeBlocks: input.includeBlocks,
+    includeSizes: input.includeSizes,
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `outline_note` — a low-payload structure tool that returns a note's heading tree, block-reference anchors (`^id`), and frontmatter key list without returning any prose
- Extracts `buildOutline()` into `@seekstone/core/outline` so `patch_note` (SHA-11) can reuse it without depending on server internals
- Wires the tool into dispatch and the server's tool list (9 → 10 tools)

## Changes

- `packages/core/src/outline.ts` — `buildOutline()` shared parser; exported via `@seekstone/core/outline`
- `packages/server/src/tools/outline_note.ts` — MCP tool wrapper with Zod input validation
- `packages/server/src/dispatch.ts` + `index.ts` — registration and tool definition
- 20 core tests + 7 server tests; types and lint clean

## Test plan

- [ ] `npm test` passes across all workspaces
- [ ] `npx tsc -p packages/core/tsconfig.json --noEmit` clean
- [ ] `npx tsc -p packages/server/tsconfig.json --noEmit` clean
- [ ] `npm run lint` clean
- [ ] Heading `byteOffset` lands on `#` for all headings
- [ ] Block refs detected at end-of-line and as standalone lines
- [ ] Frontmatter region not parsed as headings
- [ ] Empty `headings[]` for flat notes (not an error)
- [ ] `includeSizes: true` adds `byteLength` to each heading
- [ ] Path traversal (`../outside.md`) throws

Closes SHA-10. Unblocks SHA-11 (patch_note).