### PR TITLE
feat(server): add patch_note tool (SHA-11)

### DIFF
--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -8,6 +8,7 @@ import { ListTagsInput, listTags } from './tools/list_tags.js';
 import { MoveNoteInput, moveNote } from './tools/move_note.js';
 import { OutlineNoteInput, outlineNote } from './tools/outline_note.js';
 import { PatchFrontmatterInput, patchFrontmatter } from './tools/patch_frontmatter.js';
+import { PatchNoteInput, patchNote } from './tools/patch_note.js';
 import { ReadNoteInput, readNote } from './tools/read_note.js';
 import { SearchInput, search } from './tools/search.js';
 
@@ -28,6 +29,7 @@ export const HANDLED_TOOLS = [
   'append_note',
   'patch_frontmatter',
   'outline_note',
+  'patch_note',
 ] as const;
 
 // Metadata-safe keys: logged at info. Note content (`content`, `frontmatter`,
@@ -152,6 +154,11 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
     case 'outline_note': {
       const input = OutlineNoteInput.parse(args);
       const result = await outlineNote(ctx, input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+    case 'patch_note': {
+      const input = PatchNoteInput.parse(args);
+      const result = await patchNote(ctx, input);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     }
     default:

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -232,6 +232,35 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['path'],
       },
     },
+    {
+      name: 'patch_note',
+      description:
+        'Surgically edit a section of a note — targeted by heading or block reference — without rewriting the whole file. Operations: append (add after section), prepend (add after heading line), replace (swap section content). Frontmatter is never touched.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Vault-relative path to the note.' },
+          target: {
+            type: 'object',
+            description:
+              'Exactly one of: { heading: "Section Title" } or { block: "block-id" } (without the ^ prefix).',
+          },
+          operation: {
+            type: 'string',
+            enum: ['append', 'prepend', 'replace'],
+            description:
+              'append: insert after section content. prepend: insert after heading line. replace: swap section content.',
+          },
+          content: { type: 'string', description: 'Content to insert or replace with.' },
+          createIfMissing: {
+            type: 'boolean',
+            description:
+              'If the heading target is not found, append a new heading (level 2) + content. Only valid for heading targets. Default false.',
+          },
+        },
+        required: ['path', 'target', 'operation', 'content'],
+      },
+    },
   ],
 }));
 
@@ -242,7 +271,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req): Promise<CallToolRes
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
-log.info('ready', { tools: 10, transport: 'stdio' });
+log.info('ready', { tools: 11, transport: 'stdio' });
 
 process.stderr.write(
   `seekstone: add to Claude Desktop:\n${JSON.stringify(

--- a/packages/server/src/tools/patch_note.test.ts
+++ b/packages/server/src/tools/patch_note.test.ts
@@ -1,0 +1,345 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import MiniSearch from 'minisearch';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ServerContext } from '../context.js';
+import type { IndexedNote } from '../index/types.js';
+import { patchNote } from './patch_note.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const NOTE = `---
+title: Test
+tags: [a]
+---
+# Top
+
+Top intro.
+
+## Log
+
+Log entry one.
+Log entry two. ^log-ref
+
+## Config
+
+Config content.
+
+### Sub
+
+Sub content.
+`;
+
+const NOTE_NO_FM = `# First
+
+First content.
+
+## Second
+
+Second content.
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildCtx(vaultRoot: string): ServerContext {
+  const index = new MiniSearch<IndexedNote>({
+    idField: 'id',
+    fields: ['title', 'body', 'tags', 'fmKeys'],
+    storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
+    searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
+  });
+  return { vaultRoot, index, notes: new Map() };
+}
+
+let vaultRoot: string;
+
+beforeEach(async () => {
+  vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-patch-note-'));
+  await writeFile(join(vaultRoot, 'note.md'), NOTE, 'utf8');
+  await writeFile(join(vaultRoot, 'no-fm.md'), NOTE_NO_FM, 'utf8');
+});
+
+afterEach(async () => {
+  await rm(vaultRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance criteria
+// ---------------------------------------------------------------------------
+
+describe('patchNote — heading target', () => {
+  it('append inserts content at end of section, before next heading', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await patchNote(ctx, {
+      path: 'note.md',
+      target: { heading: 'Log' },
+      operation: 'append',
+      content: 'Log entry three.',
+      createIfMissing: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    // New content appears before ## Config
+    const configIdx = written.indexOf('## Config');
+    const newIdx = written.indexOf('Log entry three.');
+    expect(newIdx).toBeGreaterThan(0);
+    expect(newIdx).toBeLessThan(configIdx);
+    // Original entries still present
+    expect(written).toContain('Log entry one.');
+    expect(written).toContain('Log entry two. ^log-ref');
+  });
+
+  it('prepend inserts content immediately after the heading line', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await patchNote(ctx, {
+      path: 'note.md',
+      target: { heading: 'Log' },
+      operation: 'prepend',
+      content: 'Prepended entry.',
+      createIfMissing: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    const headingIdx = written.indexOf('## Log\n');
+    const prependIdx = written.indexOf('Prepended entry.');
+    expect(prependIdx).toBeGreaterThan(headingIdx);
+    // Original content still follows
+    expect(written).toContain('Log entry one.');
+    const prependEnd = prependIdx + 'Prepended entry.'.length;
+    const logOneIdx = written.indexOf('Log entry one.');
+    expect(logOneIdx).toBeGreaterThan(prependEnd);
+  });
+
+  it('replace swaps only the targeted section body', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await patchNote(ctx, {
+      path: 'note.md',
+      target: { heading: 'Log' },
+      operation: 'replace',
+      content: 'Replaced content.',
+      createIfMissing: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(written).toContain('Replaced content.');
+    expect(written).not.toContain('Log entry one.');
+    expect(written).not.toContain('Log entry two.');
+  });
+
+  it('sibling section is byte-identical after patch', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const before = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    const configStart = before.indexOf('## Config');
+    const configSection = before.slice(configStart);
+
+    await patchNote(ctx, {
+      path: 'note.md',
+      target: { heading: 'Log' },
+      operation: 'append',
+      content: 'New log.',
+      createIfMissing: false,
+    });
+
+    const after = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    const configStartAfter = after.indexOf('## Config');
+    expect(after.slice(configStartAfter)).toBe(configSection);
+  });
+
+  it('frontmatter bytes are identical pre/post for every body patch', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const fmEnd = NOTE.indexOf('---\n', 4) + 4;
+    const originalFm = NOTE.slice(0, fmEnd);
+
+    for (const operation of ['append', 'prepend', 'replace'] as const) {
+      await writeFile(join(vaultRoot, 'note.md'), NOTE, 'utf8');
+      await patchNote(ctx, {
+        path: 'note.md',
+        target: { heading: 'Log' },
+        operation,
+        content: 'Test content.',
+        createIfMissing: false,
+      });
+      const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+      expect(written.slice(0, fmEnd)).toBe(originalFm);
+    }
+  });
+
+  it('heading match is case-insensitive', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await expect(
+      patchNote(ctx, {
+        path: 'note.md',
+        target: { heading: 'log' },
+        operation: 'append',
+        content: 'Case insensitive.',
+        createIfMissing: false,
+      }),
+    ).resolves.toMatchObject({ frontmatterUnchanged: true });
+  });
+
+  it('missing heading without createIfMissing throws with available list', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const err = await patchNote(ctx, {
+      path: 'note.md',
+      target: { heading: 'Nonexistent' },
+      operation: 'append',
+      content: 'x',
+      createIfMissing: false,
+    }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const payload = JSON.parse((err as Error).message);
+    expect(payload.error).toBe('heading_not_found');
+    expect(payload.available).toContain('Log');
+    // No write occurred
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(written).toBe(NOTE);
+  });
+
+  it('createIfMissing appends a new heading and content', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await patchNote(ctx, {
+      path: 'note.md',
+      target: { heading: 'New Section' },
+      operation: 'append',
+      content: 'Brand new content.',
+      createIfMissing: true,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(written).toContain('## New Section');
+    expect(written).toContain('Brand new content.');
+    // Original content preserved
+    expect(written).toContain('## Log');
+    expect(written).toContain('## Config');
+  });
+
+  it('works on notes without frontmatter', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await patchNote(ctx, {
+      path: 'no-fm.md',
+      target: { heading: 'Second' },
+      operation: 'append',
+      content: 'Appended to second.',
+      createIfMissing: false,
+    });
+    const written = await readFile(join(vaultRoot, 'no-fm.md'), 'utf8');
+    expect(written).toContain('Appended to second.');
+    expect(written).toContain('Second content.');
+  });
+
+  it('returns bytesWritten matching file size', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await patchNote(ctx, {
+      path: 'note.md',
+      target: { heading: 'Log' },
+      operation: 'append',
+      content: 'Size check.',
+      createIfMissing: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(result.bytesWritten).toBe(Buffer.byteLength(written, 'utf8'));
+    expect(result.frontmatterUnchanged).toBe(true);
+  });
+});
+
+describe('patchNote — block target', () => {
+  it('append inserts content after the block line', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await patchNote(ctx, {
+      path: 'note.md',
+      target: { block: 'log-ref' },
+      operation: 'append',
+      content: 'After the block.',
+      createIfMissing: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    const blockIdx = written.indexOf('Log entry two. ^log-ref');
+    const afterIdx = written.indexOf('After the block.');
+    expect(afterIdx).toBeGreaterThan(blockIdx);
+  });
+
+  it('replace swaps the block line', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await patchNote(ctx, {
+      path: 'note.md',
+      target: { block: 'log-ref' },
+      operation: 'replace',
+      content: 'Replaced block content.',
+      createIfMissing: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(written).toContain('Replaced block content.');
+    expect(written).not.toContain('Log entry two. ^log-ref');
+  });
+
+  it('frontmatter bytes unchanged for block patch', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const fmEnd = NOTE.indexOf('---\n', 4) + 4;
+    const originalFm = NOTE.slice(0, fmEnd);
+    await patchNote(ctx, {
+      path: 'note.md',
+      target: { block: 'log-ref' },
+      operation: 'append',
+      content: 'FM safety check.',
+      createIfMissing: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(written.slice(0, fmEnd)).toBe(originalFm);
+  });
+
+  it('missing block throws with available list', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const err = await patchNote(ctx, {
+      path: 'note.md',
+      target: { block: 'nonexistent' },
+      operation: 'append',
+      content: 'x',
+      createIfMissing: false,
+    }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const payload = JSON.parse((err as Error).message);
+    expect(payload.error).toBe('block_not_found');
+    expect(payload.available).toContain('log-ref');
+  });
+});
+
+describe('patchNote — cache + safety', () => {
+  it('updates the in-memory cache after patch', async () => {
+    const ctx = buildCtx(vaultRoot);
+    // Seed the cache entry
+    ctx.notes.set('note.md', {
+      id: 'note.md',
+      title: 'Test',
+      body: '',
+      tags: '',
+      fmKeys: 'title tags',
+      raw: NOTE,
+      sizeBytes: Buffer.byteLength(NOTE, 'utf8'),
+      mtimeMs: Date.now(),
+    });
+    await patchNote(ctx, {
+      path: 'note.md',
+      target: { heading: 'Log' },
+      operation: 'append',
+      content: 'Cache check.',
+      createIfMissing: false,
+    });
+    const cached = ctx.notes.get('note.md');
+    expect(cached?.raw).toContain('Cache check.');
+    expect(cached?.body).toContain('Cache check.');
+  });
+
+  it('throws "Path outside vault" for traversal attempts', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await expect(
+      patchNote(ctx, {
+        path: '../outside.md',
+        target: { heading: 'x' },
+        operation: 'append',
+        content: 'x',
+        createIfMissing: false,
+      }),
+    ).rejects.toThrow('Path outside vault');
+  });
+});

--- a/packages/server/src/tools/patch_note.ts
+++ b/packages/server/src/tools/patch_note.ts
@@ -1,0 +1,188 @@
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parseFrontmatter } from '@seekstone/core/frontmatter';
+import { buildOutline } from '@seekstone/core/outline';
+import { z } from 'zod';
+import type { ServerContext } from '../context.js';
+
+export const PatchNoteInput = z.object({
+  path: z.string().describe('Vault-relative path to the note.'),
+  target: z
+    .union([
+      z.object({ heading: z.string().describe('Heading text (without # markers).') }),
+      z.object({ block: z.string().describe('Block reference ID (without the ^ prefix).') }),
+    ])
+    .describe('Target section. Provide exactly one of heading or block.'),
+  operation: z
+    .enum(['append', 'prepend', 'replace'])
+    .describe(
+      'append: insert after section content. prepend: insert after heading line. replace: swap section content.',
+    ),
+  content: z.string().min(1).describe('Content to insert or replace with.'),
+  createIfMissing: z
+    .boolean()
+    .default(false)
+    .describe(
+      'If the heading target is not found, append a new heading (level 2) + content. Only valid for heading targets.',
+    ),
+});
+export type PatchNoteInput = z.infer<typeof PatchNoteInput>;
+
+export interface PatchNoteResult {
+  path: string;
+  bytesWritten: number;
+  targetResolvedAt: { line: number; byteOffset: number };
+  frontmatterUnchanged: true;
+}
+
+/** Character offset of the start of the next line after `offset`. */
+function lineEnd(raw: string, offset: number): number {
+  const nl = raw.indexOf('\n', offset);
+  return nl === -1 ? raw.length : nl + 1;
+}
+
+/** Character offset of the start of the line that contains `offset`. */
+function lineStart(raw: string, offset: number): number {
+  if (offset === 0) return 0;
+  const prev = raw.lastIndexOf('\n', offset - 1);
+  return prev === -1 ? 0 : prev + 1;
+}
+
+async function atomicWrite(absPath: string, content: string): Promise<void> {
+  const tmpPath = `${absPath}.seekstone-patch-tmp`;
+  await writeFile(tmpPath, content, 'utf8');
+  await rename(tmpPath, absPath);
+}
+
+export async function patchNote(
+  ctx: ServerContext,
+  input: PatchNoteInput,
+): Promise<PatchNoteResult> {
+  const absPath = join(ctx.vaultRoot, input.path);
+  if (!absPath.startsWith(ctx.vaultRoot)) {
+    throw new Error(`Path outside vault: ${input.path}`);
+  }
+
+  const raw = await readFile(absPath, 'utf8');
+  const fm = parseFrontmatter(raw);
+  const originalFmRegion = raw.slice(0, fm.bodyStart);
+  const outline = buildOutline(raw, { includeBlocks: true });
+
+  let contentStart: number;
+  let contentEnd: number;
+  let resolvedAt: { line: number; byteOffset: number };
+
+  if ('heading' in input.target) {
+    const targetText = input.target.heading;
+    const heading = outline.headings.find((h) => h.text.toLowerCase() === targetText.toLowerCase());
+
+    if (!heading) {
+      if (input.createIfMissing) {
+        const sep = raw.endsWith('\n\n') ? '' : raw.endsWith('\n') ? '\n' : '\n\n';
+        const contentNl = input.content.endsWith('\n') ? '' : '\n';
+        const newContent = `${raw}${sep}## ${targetText}\n\n${input.content}${contentNl}`;
+        await atomicWrite(absPath, newContent);
+        await verifyFrontmatter(absPath, originalFmRegion);
+        updateCache(ctx, input.path, newContent, fm.bodyStart);
+        const headingOffset = raw.length + sep.length;
+        return {
+          path: input.path,
+          bytesWritten: Buffer.byteLength(newContent, 'utf8'),
+          targetResolvedAt: {
+            line: newContent.slice(0, headingOffset).split('\n').length,
+            byteOffset: headingOffset,
+          },
+          frontmatterUnchanged: true,
+        };
+      }
+      throw new Error(
+        JSON.stringify({
+          error: 'heading_not_found',
+          target: targetText,
+          available: outline.headings.map((h) => h.text),
+        }),
+      );
+    }
+
+    const headingLineEnd = lineEnd(raw, heading.byteOffset);
+    const nextSibling = outline.headings.find(
+      (h) => h.byteOffset > heading.byteOffset && h.level <= heading.level,
+    );
+    contentStart = headingLineEnd;
+    contentEnd = nextSibling?.byteOffset ?? raw.length;
+    resolvedAt = { line: heading.line, byteOffset: heading.byteOffset };
+  } else {
+    const targetId = input.target.block;
+    const block = outline.blocks.find((b) => b.id === targetId);
+    if (!block) {
+      throw new Error(
+        JSON.stringify({
+          error: 'block_not_found',
+          target: targetId,
+          available: outline.blocks.map((b) => b.id),
+        }),
+      );
+    }
+    contentStart = lineStart(raw, block.byteOffset);
+    contentEnd = lineEnd(raw, block.byteOffset);
+    resolvedAt = { line: block.line, byteOffset: block.byteOffset };
+  }
+
+  const before = raw.slice(0, contentStart);
+  const section = raw.slice(contentStart, contentEnd);
+  const after = raw.slice(contentEnd);
+
+  let newContent: string;
+  switch (input.operation) {
+    case 'prepend': {
+      const sep = input.content.endsWith('\n') ? '' : '\n';
+      newContent = `${before}${input.content}${sep}${section}${after}`;
+      break;
+    }
+    case 'append': {
+      const sectionNl = section.endsWith('\n') ? '' : '\n';
+      const contentNl = input.content.endsWith('\n') ? '' : '\n';
+      newContent = `${before}${section}${sectionNl}${input.content}${contentNl}${after}`;
+      break;
+    }
+    case 'replace': {
+      const contentNl = input.content.endsWith('\n') ? '' : '\n';
+      newContent = `${before}${input.content}${contentNl}${after}`;
+      break;
+    }
+    default:
+      throw new Error(`Unknown operation: ${String(input.operation)}`);
+  }
+
+  await atomicWrite(absPath, newContent);
+  await verifyFrontmatter(absPath, originalFmRegion);
+  updateCache(ctx, input.path, newContent, fm.bodyStart);
+
+  return {
+    path: input.path,
+    bytesWritten: Buffer.byteLength(newContent, 'utf8'),
+    targetResolvedAt: resolvedAt,
+    frontmatterUnchanged: true,
+  };
+}
+
+async function verifyFrontmatter(absPath: string, originalFmRegion: string): Promise<void> {
+  const written = await readFile(absPath, 'utf8');
+  if (written.slice(0, originalFmRegion.length) !== originalFmRegion) {
+    throw new Error('Write-safety violation: frontmatter region changed unexpectedly');
+  }
+}
+
+function updateCache(
+  ctx: ServerContext,
+  path: string,
+  newContent: string,
+  bodyStart: number,
+): void {
+  const cached = ctx.notes.get(path);
+  if (cached) {
+    cached.body = newContent.slice(bodyStart);
+    cached.raw = newContent;
+    cached.sizeBytes = Buffer.byteLength(newContent, 'utf8');
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `patch_note` — surgical section editing without rewriting the whole note
- Targets a section by **heading text** or **block reference** (`^id`), with three operations: `append`, `prepend`, `replace`
- Builds on `buildOutline()` from `@seekstone/core/outline` (SHA-10) for section bounds
- Atomic write (temp file + rename) + post-write frontmatter verification

## How it works

**Section bounds:** heading content spans from the end of the heading line to the start of the next heading at equal or lesser depth (sibling/parent), or end of file.

**Block bounds:** the entire line containing `^id`.

**`createIfMissing`:** when the heading target doesn't exist, appends a new level-2 heading + content to end of file.

**Not-found errors** are structured JSON listing available headings/blocks so the caller can recover.

## Changes

- `packages/server/src/tools/patch_note.ts` — tool implementation
- `packages/server/src/dispatch.ts` + `index.ts` — registration (10 → 11 tools)
- 16 new tests covering all 6 acceptance criteria + cache, traversal, no-FM notes

## Test plan

- [ ] `npm test` — 353/353 passing
- [ ] `npx tsc -p packages/server/tsconfig.json --noEmit` clean
- [ ] `npm run lint` clean
- [ ] `append` inserts before next heading, sibling section byte-identical
- [ ] `prepend` inserts immediately after heading line
- [ ] `replace` swaps section content
- [ ] FM bytes identical for all three operations
- [ ] Block target `append` / `replace`
- [ ] Missing target returns structured error with available list
- [ ] `createIfMissing` creates heading at end of file
- [ ] Path traversal throws

Closes SHA-11.