### PR TITLE
feat(server): section/block/line selectors for read_note (SHA-9)

### DIFF
--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -108,7 +108,7 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
     case 'read_note': {
       const input = ReadNoteInput.parse(args);
       const result = await readNote(ctx, input);
-      return { content: [{ type: 'text', text: result.content }] };
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     }
     case 'list_notes': {
       const input = ListNotesInput.parse(args);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -78,13 +78,39 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'read_note',
       description:
-        'Read the full content of a specific note by its vault-relative path. Use search first to find the right path.',
+        'Read a note or a span of it — by heading section, block reference, or line range. Returns structured JSON with the content, bytes returned, and total note size so payload savings are measurable. Use search or outline_note first to find the right path and section names.',
       inputSchema: {
         type: 'object',
         properties: {
           path: {
             type: 'string',
             description: 'Vault-relative path, e.g. "Daily Notes/2026-05-29.md".',
+          },
+          section: {
+            type: 'string',
+            description:
+              'Return only this heading section (heading text, # prefix optional). First match wins.',
+          },
+          block: {
+            type: 'string',
+            description: 'Return only the line anchored by this block id (^ prefix optional).',
+          },
+          lines: {
+            type: 'object',
+            description: 'Return only this line range (1-indexed, inclusive).',
+            properties: {
+              from: { type: 'number', description: 'First line (1-indexed).' },
+              to: {
+                type: 'number',
+                description: 'Last line (1-indexed, inclusive). Defaults to EOF.',
+              },
+            },
+            required: ['from'],
+          },
+          includeFrontmatter: {
+            type: 'boolean',
+            description:
+              'Prepend frontmatter to section/block span results. Default false for spans.',
           },
         },
         required: ['path'],

--- a/packages/server/src/tools/read_note.test.ts
+++ b/packages/server/src/tools/read_note.test.ts
@@ -5,7 +5,29 @@ import MiniSearch from 'minisearch';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ServerContext } from '../context.js';
 import type { IndexedNote } from '../index/types.js';
-import { readNote } from './read_note.js';
+import { ReadNoteInput, readNote } from './read_note.js';
+
+const NOTE = `---
+title: My Note
+tags: [a]
+---
+# Top
+
+Top intro.
+
+## Decisions
+
+Decision one.
+Decision two. ^dec-ref
+
+## Background
+
+Background content.
+
+### Sub
+
+Sub content.
+`;
 
 let vaultRoot: string;
 let ctx: ServerContext;
@@ -18,7 +40,7 @@ beforeAll(async () => {
     storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
   });
   ctx = { vaultRoot, index, notes: new Map() };
-
+  await writeFile(join(vaultRoot, 'note.md'), NOTE, 'utf8');
   await writeFile(join(vaultRoot, 'hello.md'), '# Hello\n\nSome content here.\n', 'utf8');
 });
 
@@ -26,24 +48,179 @@ afterAll(async () => {
   await rm(vaultRoot, { recursive: true, force: true });
 });
 
-describe('readNote', () => {
-  it('reads a real file and returns path, content, sizeBytes', async () => {
+// ---------------------------------------------------------------------------
+// Whole-note reads
+// ---------------------------------------------------------------------------
+
+describe('readNote — whole note', () => {
+  it('returns path, content, bytesReturned, noteBytes', async () => {
     const result = await readNote(ctx, { path: 'hello.md' });
     expect(result.path).toBe('hello.md');
     expect(result.content).toBe('# Hello\n\nSome content here.\n');
-    expect(result.sizeBytes).toBe(Buffer.byteLength(result.content, 'utf8'));
+    expect(result.bytesReturned).toBe(Buffer.byteLength(result.content, 'utf8'));
+    expect(result.noteBytes).toBe(result.bytesReturned);
+    expect(result.span).toBeUndefined();
   });
 
-  it('sizeBytes matches Buffer.byteLength of the content', async () => {
-    const result = await readNote(ctx, { path: 'hello.md' });
-    expect(result.sizeBytes).toBe(Buffer.byteLength(result.content, 'utf8'));
-  });
-
-  it('throws "Path outside vault" for path with ../ traversal', async () => {
+  it('throws "Path outside vault" for path traversal', async () => {
     await expect(readNote(ctx, { path: '../etc/passwd' })).rejects.toThrow('Path outside vault');
   });
 
   it('throws ENOENT for a non-existent file', async () => {
     await expect(readNote(ctx, { path: 'does-not-exist.md' })).rejects.toThrow(/ENOENT/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// section selector
+// ---------------------------------------------------------------------------
+
+describe('readNote — section selector', () => {
+  it('returns the heading line + body up to the next sibling heading', async () => {
+    const result = await readNote(ctx, { path: 'note.md', section: 'Decisions' });
+    expect(result.content).toContain('## Decisions');
+    expect(result.content).toContain('Decision one.');
+    expect(result.content).toContain('Decision two.');
+    // Sibling section not included
+    expect(result.content).not.toContain('## Background');
+    expect(result.content).not.toContain('Background content.');
+  });
+
+  it('content is byte-for-byte identical to the source slice', async () => {
+    const result = await readNote(ctx, { path: 'note.md', section: 'Decisions' });
+    expect(result.span).toBeDefined();
+    const span = result.span;
+    if (span === undefined) return;
+    expect(NOTE.slice(span.charStart, span.charEnd)).toBe(result.content);
+  });
+
+  it('accepts heading text with leading # prefix', async () => {
+    const result = await readNote(ctx, { path: 'note.md', section: '## Decisions' });
+    expect(result.content).toContain('## Decisions');
+  });
+
+  it('bytesReturned is less than noteBytes for a section read', async () => {
+    const result = await readNote(ctx, { path: 'note.md', section: 'Decisions' });
+    expect(result.bytesReturned).toBeLessThan(result.noteBytes);
+  });
+
+  it('excludes frontmatter by default', async () => {
+    const result = await readNote(ctx, { path: 'note.md', section: 'Decisions' });
+    expect(result.content).not.toContain('title: My Note');
+  });
+
+  it('includes frontmatter when includeFrontmatter is true', async () => {
+    const result = await readNote(ctx, {
+      path: 'note.md',
+      section: 'Decisions',
+      includeFrontmatter: true,
+    });
+    expect(result.content).toContain('title: My Note');
+    expect(result.content).toContain('## Decisions');
+  });
+
+  it('section includes nested sub-headings', async () => {
+    const result = await readNote(ctx, { path: 'note.md', section: 'Background' });
+    expect(result.content).toContain('### Sub');
+    expect(result.content).toContain('Sub content.');
+  });
+
+  it('missing section throws structured error with available list', async () => {
+    const err = await readNote(ctx, { path: 'note.md', section: 'Nonexistent' }).catch(
+      (e: Error) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    const payload = JSON.parse((err as Error).message);
+    expect(payload.error).toBe('section_not_found');
+    expect(payload.available).toContain('Decisions');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// block selector
+// ---------------------------------------------------------------------------
+
+describe('readNote — block selector', () => {
+  it('returns the line containing the block anchor', async () => {
+    const result = await readNote(ctx, { path: 'note.md', block: 'dec-ref' });
+    expect(result.content).toContain('^dec-ref');
+    expect(result.content).toContain('Decision two.');
+  });
+
+  it('accepts block id with leading ^ prefix', async () => {
+    const result = await readNote(ctx, { path: 'note.md', block: '^dec-ref' });
+    expect(result.content).toContain('^dec-ref');
+  });
+
+  it('content is byte-for-byte identical to the source slice', async () => {
+    const result = await readNote(ctx, { path: 'note.md', block: 'dec-ref' });
+    const span = result.span;
+    if (span === undefined) return;
+    expect(NOTE.slice(span.charStart, span.charEnd)).toBe(result.content);
+  });
+
+  it('missing block throws structured error with available list', async () => {
+    const err = await readNote(ctx, { path: 'note.md', block: 'no-such-block' }).catch(
+      (e: Error) => e,
+    );
+    const payload = JSON.parse((err as Error).message);
+    expect(payload.error).toBe('block_not_found');
+    expect(payload.available).toContain('dec-ref');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lines selector
+// ---------------------------------------------------------------------------
+
+describe('readNote — lines selector', () => {
+  it('returns exactly the specified line range, verbatim', async () => {
+    const rawLines = NOTE.split('\n');
+    const result = await readNote(ctx, { path: 'note.md', lines: { from: 1, to: 3 } });
+    const expected = `${rawLines.slice(0, 3).join('\n')}\n`;
+    expect(result.content).toBe(expected);
+  });
+
+  it('content is byte-for-byte identical to the source slice', async () => {
+    const result = await readNote(ctx, { path: 'note.md', lines: { from: 5, to: 8 } });
+    const span = result.span;
+    if (span === undefined) return;
+    expect(NOTE.slice(span.charStart, span.charEnd)).toBe(result.content);
+  });
+
+  it('omitting to returns from the given line to EOF', async () => {
+    const result = await readNote(ctx, { path: 'note.md', lines: { from: 5 } });
+    expect(result.span).toBeDefined();
+    expect(result.bytesReturned).toBeGreaterThan(0);
+    expect(result.bytesReturned).toBeLessThan(result.noteBytes);
+  });
+
+  it('bytesReturned is less than noteBytes for a partial read', async () => {
+    const result = await readNote(ctx, { path: 'note.md', lines: { from: 1, to: 3 } });
+    expect(result.bytesReturned).toBeLessThan(result.noteBytes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mutual exclusion
+// ---------------------------------------------------------------------------
+
+describe('readNote — validation', () => {
+  it('rejects specifying both section and block', () => {
+    expect(() =>
+      ReadNoteInput.parse({ path: 'note.md', section: 'Decisions', block: 'dec-ref' }),
+    ).toThrow();
+  });
+
+  it('rejects specifying both section and lines', () => {
+    expect(() =>
+      ReadNoteInput.parse({ path: 'note.md', section: 'Decisions', lines: { from: 1 } }),
+    ).toThrow();
+  });
+
+  it('rejects specifying block and lines together', () => {
+    expect(() =>
+      ReadNoteInput.parse({ path: 'note.md', block: 'dec-ref', lines: { from: 1 } }),
+    ).toThrow();
   });
 });

--- a/packages/server/src/tools/read_note.ts
+++ b/packages/server/src/tools/read_note.ts
@@ -1,30 +1,150 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { parseFrontmatter } from '@seekstone/core/frontmatter';
+import { buildOutline } from '@seekstone/core/outline';
 import { z } from 'zod';
 import type { ServerContext } from '../context.js';
 
-export const ReadNoteInput = z.object({
-  path: z.string().describe('Vault-relative path to the note, e.g. "Daily Notes/2026-05-29.md".'),
-});
+export const ReadNoteInput = z
+  .object({
+    path: z.string().describe('Vault-relative path to the note, e.g. "Daily Notes/2026-05-29.md".'),
+    section: z
+      .string()
+      .optional()
+      .describe('Return only this heading section (heading text, # prefix optional).'),
+    block: z
+      .string()
+      .optional()
+      .describe('Return only the block anchored by this id (^ prefix optional).'),
+    lines: z
+      .object({
+        from: z.number().int().min(1).describe('First line (1-indexed, inclusive).'),
+        to: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe('Last line (1-indexed, inclusive). Defaults to end of file.'),
+      })
+      .optional()
+      .describe('Return only this line range (1-indexed, inclusive).'),
+    includeFrontmatter: z
+      .boolean()
+      .optional()
+      .describe(
+        'Include frontmatter in span results. Default false for section/block spans. No effect on lines or whole-note reads.',
+      ),
+  })
+  .refine((v) => [v.section, v.block, v.lines].filter((x) => x !== undefined).length <= 1, {
+    message: 'At most one of section, block, or lines may be specified.',
+  });
 export type ReadNoteInput = z.infer<typeof ReadNoteInput>;
 
 export interface ReadNoteResult {
   path: string;
   content: string;
-  sizeBytes: number;
+  /** Bytes in the returned content (UTF-8). */
+  bytesReturned: number;
+  /** Total UTF-8 byte size of the source file. */
+  noteBytes: number;
+  /** Character offsets of the returned span in the raw file. Absent for whole-note reads. */
+  span?: { charStart: number; charEnd: number };
 }
 
 export async function readNote(ctx: ServerContext, input: ReadNoteInput): Promise<ReadNoteResult> {
-  // Prevent path traversal — the path must not escape the vault root.
   const absPath = join(ctx.vaultRoot, input.path);
   if (!absPath.startsWith(ctx.vaultRoot)) {
     throw new Error(`Path outside vault: ${input.path}`);
   }
 
-  const content = await readFile(absPath, 'utf8');
+  const raw = await readFile(absPath, 'utf8');
+  const noteBytes = Buffer.byteLength(raw, 'utf8');
+
+  // Whole-note read — no selector
+  if (input.section === undefined && input.block === undefined && input.lines === undefined) {
+    return { path: input.path, content: raw, bytesReturned: noteBytes, noteBytes };
+  }
+
+  const fm = parseFrontmatter(raw);
+  const outline = buildOutline(raw, { includeBlocks: true });
+
+  let charStart: number;
+  let charEnd: number;
+
+  if (input.section !== undefined) {
+    const target = input.section.replace(/^#+\s*/, '').trim();
+    const heading = outline.headings.find((h) => h.text === target);
+    if (!heading) {
+      throw new Error(
+        JSON.stringify({
+          error: 'section_not_found',
+          target,
+          available: outline.headings.map((h) => h.text),
+        }),
+      );
+    }
+    const nextSibling = outline.headings.find(
+      (h) => h.byteOffset > heading.byteOffset && h.level <= heading.level,
+    );
+    charStart = heading.byteOffset;
+    charEnd = nextSibling?.byteOffset ?? raw.length;
+  } else if (input.block !== undefined) {
+    const targetId = input.block.replace(/^\^/, '');
+    const block = outline.blocks.find((b) => b.id === targetId);
+    if (!block) {
+      throw new Error(
+        JSON.stringify({
+          error: 'block_not_found',
+          target: targetId,
+          available: outline.blocks.map((b) => b.id),
+        }),
+      );
+    }
+    const lineS = block.byteOffset === 0 ? 0 : raw.lastIndexOf('\n', block.byteOffset - 1) + 1;
+    const nlAfter = raw.indexOf('\n', block.byteOffset);
+    const lineE = nlAfter === -1 ? raw.length : nlAfter + 1;
+    charStart = lineS;
+    charEnd = lineE;
+  } else {
+    // lines selector
+    const linesRange = input.lines;
+    if (linesRange === undefined) throw new Error('internal: unreachable');
+    const { from, to } = linesRange;
+    const rawLines = raw.split('\n');
+    const fromIdx = from - 1; // 0-indexed
+    const toIdxInclusive =
+      to !== undefined ? Math.min(to - 1, rawLines.length - 1) : rawLines.length - 1;
+
+    let offset = 0;
+    charStart = 0;
+    charEnd = raw.length;
+
+    for (const [i, line] of rawLines.entries()) {
+      if (i === fromIdx) charStart = offset;
+      offset += line.length + 1; // +1 for the \n consumed by split
+      if (i === toIdxInclusive) {
+        charEnd = Math.min(offset, raw.length);
+        break;
+      }
+    }
+  }
+
+  // Build content — prepend FM if requested (section/block only)
+  let content: string;
+  if (input.includeFrontmatter === true && input.lines === undefined) {
+    const fmRegion = raw.slice(0, fm.bodyStart);
+    const spanContent = raw.slice(charStart, charEnd);
+    // Avoid duplicating FM if the span already covers it (e.g. section at bodyStart)
+    content = charStart < fm.bodyStart ? spanContent : `${fmRegion}${spanContent}`;
+  } else {
+    content = raw.slice(charStart, charEnd);
+  }
+
   return {
     path: input.path,
     content,
-    sizeBytes: Buffer.byteLength(content, 'utf8'),
+    bytesReturned: Buffer.byteLength(content, 'utf8'),
+    noteBytes,
+    span: { charStart, charEnd },
   };
 }


### PR DESCRIPTION
## Summary

- Extends `read_note` with three optional span selectors: `section` (heading text, `#` prefix optional), `block` (`^id` anchor, `^` prefix optional), and `lines` (1-indexed inclusive `from`/`to` range)
- Returns `bytesReturned` and `noteBytes` on every call so clients can measure payload savings; partial reads also include `span: { charStart, charEnd }`
- `includeFrontmatter: true` prepends the FM region to section/block spans
- Mutual exclusion of all three selectors enforced via Zod `.refine()`
- Dispatch updated to return structured JSON (was bare text content)
- 21 tests covering whole-note, section (nested, missing, FM toggle), block (missing), lines (range, open-ended), and validation cases

## Test plan

- [ ] `npm test` — 201 tests pass
- [ ] `npm run lint` — clean
- [ ] CI matrix green before merge