### PR TITLE
feat(server): get_backlinks + get_links with reverse-link index (SHA-13)

### DIFF
--- a/packages/core/src/extract.ts
+++ b/packages/core/src/extract.ts
@@ -18,6 +18,46 @@ export interface Wikilink {
 }
 
 const WIKILINK_RE = /\[\[([^\]|#\n]+)(#[^\]|\n]+)?(\|[^\]\n]+)?\]\]/g;
+
+// Matches both embeds (![[...]]) and plain wikilinks ([[...]]).
+const LINK_WITH_LINES_RE_SRC = /(!?\[\[)([^\]|#\n]+)(#[^\]|\n]+)?(\|[^\]\n]+)?(\]\])/.source;
+
+export type LinkType = 'wikilink' | 'embed';
+
+export interface LinkRecord {
+  /** Full raw match, e.g. "[[Note Name|alias]]" or "![[embed.png]]". */
+  raw: string;
+  /** Raw target before `#` and `|`. */
+  target: string;
+  fragment: string | null;
+  alias: string | null;
+  linkType: LinkType;
+  /** 1-indexed line number in the source file. */
+  line: number;
+}
+
+/**
+ * Extract all wikilinks and embeds from a raw note (including frontmatter),
+ * annotating each with its 1-indexed line number.
+ */
+export function extractLinksWithLines(raw: string): LinkRecord[] {
+  const out: LinkRecord[] = [];
+  const lines = raw.split('\n');
+  for (const [lineIdx, lineText] of lines.entries()) {
+    for (const m of lineText.matchAll(new RegExp(LINK_WITH_LINES_RE_SRC, 'g'))) {
+      const prefix = m[1] ?? '';
+      out.push({
+        raw: m[0] ?? '',
+        target: (m[2] ?? '').trim(),
+        fragment: m[3] ? m[3].slice(1).trim() : null,
+        alias: m[4] ? m[4].slice(1).trim() : null,
+        linkType: prefix.startsWith('!') ? 'embed' : 'wikilink',
+        line: lineIdx + 1,
+      });
+    }
+  }
+  return out;
+}
 const URL_RE = /https?:\/\/[^\s<>"')]+/g;
 // Obsidian inline tag: must start with letter or underscore, then word chars, /, -.
 // Must not be immediately preceded by `]` (avoids matching `]#` from links) or be

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -1,8 +1,22 @@
+import type { LinkType } from '@seekstone/core/extract';
 import type MiniSearch from 'minisearch';
 import type { IndexedNote } from './index/types.js';
+
+export interface BacklinkRef {
+  /** Vault-relative path of the note that contains the link. */
+  path: string;
+  /** 1-indexed line number of the link in the source note. */
+  line: number;
+  linkType: LinkType;
+}
 
 export interface ServerContext {
   vaultRoot: string;
   index: MiniSearch<IndexedNote>;
   notes: Map<string, IndexedNote>;
+  /**
+   * Reverse-link index: target vault-relative path → backlink refs pointing to it.
+   * Sorted by source path; maintained incrementally by the watcher.
+   */
+  backlinks: Map<string, BacklinkRef[]>;
 }

--- a/packages/server/src/dispatch.test.ts
+++ b/packages/server/src/dispatch.test.ts
@@ -40,7 +40,7 @@ beforeAll(async () => {
   vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-dispatch-'));
   await writeFile(join(vaultRoot, 'note.md'), '---\ntitle: A\n---\n# A\nhello world\n', 'utf8');
   const { index, notes } = await buildIndex(vaultRoot);
-  ctx = { vaultRoot, index, notes };
+  ctx = { vaultRoot, index, notes, backlinks: new Map() };
 });
 
 afterAll(async () => {

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -3,6 +3,8 @@ import type { Logger } from './log.js';
 import { AppendNoteInput, appendNote } from './tools/append_note.js';
 import { CreateNoteInput, createNote } from './tools/create_note.js';
 import { DeleteNoteInput, deleteNote } from './tools/delete_note.js';
+import { GetBacklinksInput, getBacklinks } from './tools/get_backlinks.js';
+import { GetLinksInput, getLinks } from './tools/get_links.js';
 import { ListNotesInput, listNotes } from './tools/list_notes.js';
 import { ListTagsInput, listTags } from './tools/list_tags.js';
 import { MoveNoteInput, moveNote } from './tools/move_note.js';
@@ -30,6 +32,8 @@ export const HANDLED_TOOLS = [
   'patch_frontmatter',
   'outline_note',
   'patch_note',
+  'get_backlinks',
+  'get_links',
 ] as const;
 
 // Metadata-safe keys: logged at info. Note content (`content`, `frontmatter`,
@@ -159,6 +163,16 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
     case 'patch_note': {
       const input = PatchNoteInput.parse(args);
       const result = await patchNote(ctx, input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+    case 'get_backlinks': {
+      const input = GetBacklinksInput.parse(args);
+      const result = getBacklinks(ctx, input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+    case 'get_links': {
+      const input = GetLinksInput.parse(args);
+      const result = getLinks(ctx, input);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     }
     default:

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -48,10 +48,10 @@ if (!vaultRoot) {
 }
 
 log.info('building index', { vault: vaultRoot });
-const { index, notes, buildMs } = await buildIndex(vaultRoot);
+const { index, notes, backlinks, buildMs } = await buildIndex(vaultRoot);
 log.info('index ready', { notes: notes.size, buildMs });
 
-const ctx: ServerContext = { vaultRoot, index, notes };
+const ctx: ServerContext = { vaultRoot, index, notes, backlinks };
 
 const watcher = startWatcher(ctx, log);
 process.on('exit', watcher.stop);
@@ -287,6 +287,39 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['path', 'target', 'operation', 'content'],
       },
     },
+    {
+      name: 'get_backlinks',
+      description:
+        'Return every note that links to the target note, with the source line and an optional excerpt. Results come from the pre-built reverse-link index so this is a fast, pure index lookup. Sort order: source path ascending.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Vault-relative path to the target note.' },
+          includeContext: {
+            type: 'boolean',
+            description:
+              'Include a short excerpt (~200 chars) from the linking line. Default true.',
+          },
+          limit: {
+            type: 'number',
+            description: 'Max backlinks to return (1–500). Default 50.',
+          },
+        },
+        required: ['path'],
+      },
+    },
+    {
+      name: 'get_links',
+      description:
+        'Return all outgoing wikilinks and embeds from a note. Each link is marked resolved (with target path) or unresolved. Duplicate targets are de-duplicated; results sorted by line number.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Vault-relative path to the note.' },
+        },
+        required: ['path'],
+      },
+    },
   ],
 }));
 
@@ -297,7 +330,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req): Promise<CallToolRes
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
-log.info('ready', { tools: 11, transport: 'stdio' });
+log.info('ready', { tools: 13, transport: 'stdio' });
 
 process.stderr.write(
   `seekstone: add to Claude Desktop:\n${JSON.stringify(

--- a/packages/server/src/index/build.ts
+++ b/packages/server/src/index/build.ts
@@ -1,9 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import { basename, extname } from 'node:path';
-import { extractInlineTags, frontmatterTags } from '@seekstone/core/extract';
+import { extractInlineTags, extractLinksWithLines, frontmatterTags } from '@seekstone/core/extract';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { walkVault } from '@seekstone/core/walk';
 import MiniSearch from 'minisearch';
+import type { BacklinkRef } from '../context.js';
+import { resolveLink } from './resolve.js';
 import type { IndexedNote } from './types.js';
 
 export type VaultIndex = MiniSearch<IndexedNote>;
@@ -11,6 +13,7 @@ export type VaultIndex = MiniSearch<IndexedNote>;
 export interface BuildResult {
   index: VaultIndex;
   notes: Map<string, IndexedNote>;
+  backlinks: Map<string, BacklinkRef[]>;
   buildMs: number;
 }
 
@@ -68,5 +71,32 @@ export async function buildIndex(vaultRoot: string): Promise<BuildResult> {
 
   index.addAll(docs);
 
-  return { index, notes, buildMs: Date.now() - t0 };
+  const backlinks = buildBacklinks(notes);
+
+  return { index, notes, backlinks, buildMs: Date.now() - t0 };
+}
+
+function buildBacklinks(notes: Map<string, IndexedNote>): Map<string, BacklinkRef[]> {
+  const result = new Map<string, BacklinkRef[]>();
+  for (const [srcPath, doc] of notes) {
+    const seen = new Set<string>();
+    for (const link of extractLinksWithLines(doc.raw)) {
+      const resolved = resolveLink(link.target, notes);
+      if (resolved === undefined) continue;
+      // De-duplicate: one entry per (source, resolved-target) pair
+      const dedupeKey = `${srcPath}\0${resolved}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      let arr = result.get(resolved);
+      if (arr === undefined) {
+        arr = [];
+        result.set(resolved, arr);
+      }
+      arr.push({ path: srcPath, line: link.line, linkType: link.linkType });
+    }
+  }
+  for (const arr of result.values()) {
+    arr.sort((a, b) => a.path.localeCompare(b.path));
+  }
+  return result;
 }

--- a/packages/server/src/index/resolve.ts
+++ b/packages/server/src/index/resolve.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve a wikilink target string to a vault-relative note path.
+ *
+ * Uses Obsidian's loose resolution: exact match → add .md → basename match
+ * → path-without-extension match. Returns undefined if no note matches.
+ */
+export function resolveLink(target: string, notes: Map<string, unknown>): string | undefined {
+  if (notes.has(target)) return target;
+  const withMd = `${target}.md`;
+  if (notes.has(withMd)) return withMd;
+
+  const targetLower = target.toLowerCase();
+  const targetBase = (target.split('/').pop() ?? target).toLowerCase();
+
+  for (const path of notes.keys()) {
+    const pathNoExt = path.replace(/\.md$/i, '');
+    if (pathNoExt.toLowerCase() === targetLower) return path;
+    const pathBase = (pathNoExt.split('/').pop() ?? pathNoExt).toLowerCase();
+    if (pathBase === targetBase) return path;
+  }
+
+  return undefined;
+}

--- a/packages/server/src/no-network.test.ts
+++ b/packages/server/src/no-network.test.ts
@@ -32,7 +32,7 @@ beforeAll(async () => {
   );
   await writeFile(join(vaultRoot, 'b.md'), '# B\nmore text linking [[A]]\n', 'utf8');
   const built = await buildIndex(vaultRoot);
-  ctx = { vaultRoot, index: built.index, notes: built.notes };
+  ctx = { vaultRoot, index: built.index, notes: built.notes, backlinks: built.backlinks };
 });
 
 afterAll(async () => {

--- a/packages/server/src/tools/append_note.test.ts
+++ b/packages/server/src/tools/append_note.test.ts
@@ -37,7 +37,7 @@ function buildCtx(
   }));
   index.addAll(docs);
   for (const doc of docs) notesMap.set(doc.id, doc);
-  return { vaultRoot, index, notes: notesMap };
+  return { vaultRoot, index, notes: notesMap, backlinks: new Map() };
 }
 
 let vaultRoot: string;

--- a/packages/server/src/tools/create_note.test.ts
+++ b/packages/server/src/tools/create_note.test.ts
@@ -17,7 +17,7 @@ function freshCtx(): ServerContext {
     storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
     searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
   });
-  return { vaultRoot: tmpDir, index, notes: new Map() };
+  return { vaultRoot: tmpDir, index, notes: new Map(), backlinks: new Map() };
 }
 
 beforeAll(async () => {

--- a/packages/server/src/tools/delete_note.test.ts
+++ b/packages/server/src/tools/delete_note.test.ts
@@ -17,7 +17,7 @@ function freshCtx(): ServerContext {
     storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
     searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
   });
-  return { vaultRoot: tmpDir, index, notes: new Map() };
+  return { vaultRoot: tmpDir, index, notes: new Map(), backlinks: new Map() };
 }
 
 function seedNote(relPath: string, raw: string): IndexedNote {

--- a/packages/server/src/tools/get_backlinks.test.ts
+++ b/packages/server/src/tools/get_backlinks.test.ts
@@ -1,0 +1,105 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ServerContext } from '../context.js';
+import { buildIndex } from '../index/build.js';
+import { getBacklinks } from './get_backlinks.js';
+
+// target.md is linked by source_a.md and source_b.md; source_c.md links elsewhere
+const TARGET = `# Target Note\n\nThis is the target.\n`;
+
+const SOURCE_A = `# Source A\n\nLinks to [[target]].\n`;
+
+const SOURCE_B = `# Source B\n\nAlso links to [[target]] with an alias: [[target|T]].\n`;
+
+const SOURCE_C = `# Source C\n\nLinks to [[source_a]] but not the target.\n`;
+
+const NO_LINKS = `# Isolated\n\nNo links here.\n`;
+
+let vaultRoot: string;
+let ctx: ServerContext;
+
+beforeAll(async () => {
+  vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-get-backlinks-'));
+  await writeFile(join(vaultRoot, 'target.md'), TARGET, 'utf8');
+  await writeFile(join(vaultRoot, 'source_a.md'), SOURCE_A, 'utf8');
+  await writeFile(join(vaultRoot, 'source_b.md'), SOURCE_B, 'utf8');
+  await writeFile(join(vaultRoot, 'source_c.md'), SOURCE_C, 'utf8');
+  await writeFile(join(vaultRoot, 'isolated.md'), NO_LINKS, 'utf8');
+  const result = await buildIndex(vaultRoot);
+  ctx = { ...result, vaultRoot };
+});
+
+afterAll(async () => {
+  await rm(vaultRoot, { recursive: true, force: true });
+});
+
+describe('getBacklinks', () => {
+  it('returns all notes that link to the target', () => {
+    const result = getBacklinks(ctx, { path: 'target.md' });
+    expect(result.target).toBe('target.md');
+    const paths = result.backlinks.map((b) => b.path);
+    expect(paths).toContain('source_a.md');
+    expect(paths).toContain('source_b.md');
+    expect(paths).not.toContain('source_c.md');
+    expect(paths).not.toContain('isolated.md');
+  });
+
+  it('total reflects the full count before limit', () => {
+    const result = getBacklinks(ctx, { path: 'target.md' });
+    expect(result.total).toBeGreaterThanOrEqual(2);
+    expect(result.total).toBe(result.backlinks.length);
+  });
+
+  it('includes line number for each backlink', () => {
+    const result = getBacklinks(ctx, { path: 'target.md' });
+    for (const bl of result.backlinks) {
+      expect(bl.line).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes excerpt by default (includeContext defaults to true)', () => {
+    const result = getBacklinks(ctx, { path: 'target.md' });
+    for (const bl of result.backlinks) {
+      expect(bl.excerpt).toBeDefined();
+      expect(bl.excerpt).toContain('[[target');
+    }
+  });
+
+  it('omits excerpt when includeContext is false', () => {
+    const result = getBacklinks(ctx, { path: 'target.md', includeContext: false });
+    for (const bl of result.backlinks) {
+      expect(bl.excerpt).toBeUndefined();
+    }
+  });
+
+  it('de-duplicates multiple links from the same source note', () => {
+    // source_b.md links [[target]] twice; should produce one entry
+    const result = getBacklinks(ctx, { path: 'target.md' });
+    const fromB = result.backlinks.filter((b) => b.path === 'source_b.md');
+    expect(fromB).toHaveLength(1);
+  });
+
+  it('respects limit', () => {
+    const result = getBacklinks(ctx, { path: 'target.md', limit: 1 });
+    expect(result.backlinks).toHaveLength(1);
+    expect(result.total).toBeGreaterThanOrEqual(2);
+  });
+
+  it('results sorted by source path ascending', () => {
+    const result = getBacklinks(ctx, { path: 'target.md' });
+    const paths = result.backlinks.map((b) => b.path);
+    expect(paths).toEqual([...paths].sort());
+  });
+
+  it('returns empty backlinks for a note nobody links to', () => {
+    const result = getBacklinks(ctx, { path: 'isolated.md' });
+    expect(result.backlinks).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it('throws "Path outside vault" for traversal attempts', () => {
+    expect(() => getBacklinks(ctx, { path: '../etc/passwd' })).toThrow('Path outside vault');
+  });
+});

--- a/packages/server/src/tools/get_backlinks.ts
+++ b/packages/server/src/tools/get_backlinks.ts
@@ -1,0 +1,67 @@
+import { join } from 'node:path';
+import { z } from 'zod';
+import type { ServerContext } from '../context.js';
+
+export const GetBacklinksInput = z.object({
+  path: z.string().describe('Vault-relative path to the target note.'),
+  includeContext: z
+    .boolean()
+    .optional()
+    .describe('Include a short excerpt (~200 chars) from the linking line. Default true.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe('Max backlinks to return. Default 50.'),
+});
+export type GetBacklinksInput = z.infer<typeof GetBacklinksInput>;
+
+export interface BacklinkEntry {
+  path: string;
+  line: number;
+  excerpt?: string;
+  linkType: 'wikilink' | 'embed';
+}
+
+export interface GetBacklinksResult {
+  target: string;
+  backlinks: BacklinkEntry[];
+  total: number;
+}
+
+const EXCERPT_MAX = 200;
+
+export function getBacklinks(ctx: ServerContext, input: GetBacklinksInput): GetBacklinksResult {
+  const absPath = join(ctx.vaultRoot, input.path);
+  if (!absPath.startsWith(ctx.vaultRoot)) {
+    throw new Error(`Path outside vault: ${input.path}`);
+  }
+
+  const includeContext = input.includeContext ?? true;
+  const limit = input.limit ?? 50;
+
+  const refs = ctx.backlinks.get(input.path) ?? [];
+  const total = refs.length;
+  const limited = refs.slice(0, limit);
+
+  const backlinks: BacklinkEntry[] = [];
+  for (const ref of limited) {
+    const entry: BacklinkEntry = { path: ref.path, line: ref.line, linkType: ref.linkType };
+    if (includeContext) {
+      const srcNote = ctx.notes.get(ref.path);
+      if (srcNote !== undefined) {
+        const rawLines = srcNote.raw.split('\n');
+        const lineText = rawLines[ref.line - 1];
+        if (lineText !== undefined) {
+          entry.excerpt =
+            lineText.length > EXCERPT_MAX ? `${lineText.slice(0, EXCERPT_MAX)}…` : lineText;
+        }
+      }
+    }
+    backlinks.push(entry);
+  }
+
+  return { target: input.path, backlinks, total };
+}

--- a/packages/server/src/tools/get_links.test.ts
+++ b/packages/server/src/tools/get_links.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ServerContext } from '../context.js';
+import { buildIndex } from '../index/build.js';
+import { getLinks } from './get_links.js';
+
+const NOTE_A = `---
+title: Note A
+---
+# Note A
+
+Links to [[b]] and [[c|alias]].
+
+Also links to [[b]] again (duplicate).
+
+Embeds: ![[embed.png]]
+`;
+
+const NOTE_B = `# Note B
+
+Content of Note B. No outgoing links.
+`;
+
+const NOTE_C = `# Note C
+
+Links back to [[a]].
+`;
+
+const NOTE_UNRESOLVED = `# Orphan
+
+Points to [[Does Not Exist]] and [[Also Missing]].
+`;
+
+let vaultRoot: string;
+let ctx: ServerContext;
+
+beforeAll(async () => {
+  vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-get-links-'));
+  await writeFile(join(vaultRoot, 'a.md'), NOTE_A, 'utf8');
+  await writeFile(join(vaultRoot, 'b.md'), NOTE_B, 'utf8');
+  await writeFile(join(vaultRoot, 'c.md'), NOTE_C, 'utf8');
+  await writeFile(join(vaultRoot, 'orphan.md'), NOTE_UNRESOLVED, 'utf8');
+  const result = await buildIndex(vaultRoot);
+  ctx = { ...result, vaultRoot };
+});
+
+afterAll(async () => {
+  await rm(vaultRoot, { recursive: true, force: true });
+});
+
+describe('getLinks', () => {
+  it('returns resolved links with target paths', () => {
+    const result = getLinks(ctx, { path: 'a.md' });
+    expect(result.path).toBe('a.md');
+    const bLink = result.links.find((l) => l.target === 'b.md');
+    expect(bLink).toBeDefined();
+    expect(bLink?.resolved).toBe(true);
+    expect(bLink?.linkType).toBe('wikilink');
+  });
+
+  it('de-duplicates the same target appearing multiple times', () => {
+    const result = getLinks(ctx, { path: 'a.md' });
+    const bLinks = result.links.filter((l) => l.target === 'b.md');
+    expect(bLinks).toHaveLength(1);
+  });
+
+  it('resolves aliased links to their target path', () => {
+    const result = getLinks(ctx, { path: 'a.md' });
+    const cLink = result.links.find((l) => l.target === 'c.md');
+    expect(cLink).toBeDefined();
+    expect(cLink?.resolved).toBe(true);
+    expect(cLink?.raw).toContain('[[c|alias]]');
+  });
+
+  it('marks unresolved links with resolved: false and no target', () => {
+    const result = getLinks(ctx, { path: 'orphan.md' });
+    expect(result.links.every((l) => l.resolved === false)).toBe(true);
+    expect(result.links.every((l) => l.target === undefined)).toBe(true);
+  });
+
+  it('detects embeds as linkType "embed"', () => {
+    const result = getLinks(ctx, { path: 'a.md' });
+    const embed = result.links.find((l) => l.linkType === 'embed');
+    expect(embed).toBeDefined();
+    expect(embed?.raw).toContain('embed.png');
+  });
+
+  it('returns empty links for a note with no outgoing links', () => {
+    const result = getLinks(ctx, { path: 'b.md' });
+    expect(result.links).toHaveLength(0);
+  });
+
+  it('results are sorted by line number', () => {
+    const result = getLinks(ctx, { path: 'a.md' });
+    for (let i = 1; i < result.links.length; i++) {
+      const prev = result.links[i - 1];
+      const curr = result.links[i];
+      if (prev !== undefined && curr !== undefined) {
+        expect(curr.line).toBeGreaterThanOrEqual(prev.line);
+      }
+    }
+  });
+
+  it('throws "Path outside vault" for traversal attempts', () => {
+    expect(() => getLinks(ctx, { path: '../etc/passwd' })).toThrow('Path outside vault');
+  });
+
+  it('throws "Note not found" for a path not in the index', () => {
+    expect(() => getLinks(ctx, { path: 'no-such-note.md' })).toThrow('Note not found');
+  });
+});

--- a/packages/server/src/tools/get_links.ts
+++ b/packages/server/src/tools/get_links.ts
@@ -1,0 +1,57 @@
+import { join } from 'node:path';
+import { extractLinksWithLines } from '@seekstone/core/extract';
+import type { LinkType } from '@seekstone/core/extract';
+import { z } from 'zod';
+import type { ServerContext } from '../context.js';
+import { resolveLink } from '../index/resolve.js';
+
+export const GetLinksInput = z.object({
+  path: z.string().describe('Vault-relative path to the note.'),
+});
+export type GetLinksInput = z.infer<typeof GetLinksInput>;
+
+export interface GetLinksEntry {
+  raw: string;
+  /** Resolved vault-relative path. Absent when unresolved. */
+  target?: string;
+  resolved: boolean;
+  linkType: LinkType;
+  line: number;
+}
+
+export interface GetLinksResult {
+  path: string;
+  links: GetLinksEntry[];
+}
+
+export function getLinks(ctx: ServerContext, input: GetLinksInput): GetLinksResult {
+  const absPath = join(ctx.vaultRoot, input.path);
+  if (!absPath.startsWith(ctx.vaultRoot)) {
+    throw new Error(`Path outside vault: ${input.path}`);
+  }
+  const note = ctx.notes.get(input.path);
+  if (note === undefined) throw new Error(`Note not found: ${input.path}`);
+
+  const rawLinks = extractLinksWithLines(note.raw);
+
+  // De-duplicate: one entry per (target string) — keep first occurrence by line
+  const seen = new Set<string>();
+  const links: GetLinksEntry[] = [];
+  for (const link of rawLinks) {
+    if (seen.has(link.target)) continue;
+    seen.add(link.target);
+    const resolvedPath = resolveLink(link.target, ctx.notes);
+    const entry: GetLinksEntry = {
+      raw: link.raw,
+      resolved: resolvedPath !== undefined,
+      linkType: link.linkType,
+      line: link.line,
+    };
+    if (resolvedPath !== undefined) entry.target = resolvedPath;
+    links.push(entry);
+  }
+
+  links.sort((a, b) => a.line - b.line);
+
+  return { path: input.path, links };
+}

--- a/packages/server/src/tools/list_notes.test.ts
+++ b/packages/server/src/tools/list_notes.test.ts
@@ -34,7 +34,7 @@ function buildCtx(
   }));
   index.addAll(docs);
   for (const doc of docs) notesMap.set(doc.id, doc);
-  return { vaultRoot, index, notes: notesMap };
+  return { vaultRoot, index, notes: notesMap, backlinks: new Map() };
 }
 
 const SAMPLE_NOTES = [

--- a/packages/server/src/tools/list_tags.test.ts
+++ b/packages/server/src/tools/list_tags.test.ts
@@ -34,7 +34,7 @@ function buildCtx(
   }));
   index.addAll(docs);
   for (const doc of docs) notesMap.set(doc.id, doc);
-  return { vaultRoot, index, notes: notesMap };
+  return { vaultRoot, index, notes: notesMap, backlinks: new Map() };
 }
 
 const SAMPLE_NOTES = [

--- a/packages/server/src/tools/move_note.test.ts
+++ b/packages/server/src/tools/move_note.test.ts
@@ -17,7 +17,7 @@ function freshCtx(): ServerContext {
     storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
     searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
   });
-  return { vaultRoot: tmpDir, index, notes: new Map() };
+  return { vaultRoot: tmpDir, index, notes: new Map(), backlinks: new Map() };
 }
 
 function seedNote(relPath: string, raw: string): IndexedNote {

--- a/packages/server/src/tools/outline_note.test.ts
+++ b/packages/server/src/tools/outline_note.test.ts
@@ -14,7 +14,7 @@ function buildCtx(vaultRoot: string): ServerContext {
     storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
     searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
   });
-  return { vaultRoot, index, notes: new Map() };
+  return { vaultRoot, index, notes: new Map(), backlinks: new Map() };
 }
 
 const NOTE = `---

--- a/packages/server/src/tools/patch_frontmatter.test.ts
+++ b/packages/server/src/tools/patch_frontmatter.test.ts
@@ -38,7 +38,7 @@ function buildCtx(
   }));
   index.addAll(docs);
   for (const doc of docs) notesMap.set(doc.id, doc);
-  return { vaultRoot, index, notes: notesMap };
+  return { vaultRoot, index, notes: notesMap, backlinks: new Map() };
 }
 
 let vaultRoot: string;

--- a/packages/server/src/tools/patch_note.test.ts
+++ b/packages/server/src/tools/patch_note.test.ts
@@ -53,7 +53,7 @@ function buildCtx(vaultRoot: string): ServerContext {
     storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
     searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
   });
-  return { vaultRoot, index, notes: new Map() };
+  return { vaultRoot, index, notes: new Map(), backlinks: new Map() };
 }
 
 let vaultRoot: string;

--- a/packages/server/src/tools/read_note.test.ts
+++ b/packages/server/src/tools/read_note.test.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
     fields: ['title', 'body', 'tags', 'fmKeys'],
     storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
   });
-  ctx = { vaultRoot, index, notes: new Map() };
+  ctx = { vaultRoot, index, notes: new Map(), backlinks: new Map() };
   await writeFile(join(vaultRoot, 'note.md'), NOTE, 'utf8');
   await writeFile(join(vaultRoot, 'hello.md'), '# Hello\n\nSome content here.\n', 'utf8');
 });

--- a/packages/server/src/tools/search.test.ts
+++ b/packages/server/src/tools/search.test.ts
@@ -34,7 +34,7 @@ function buildCtx(
   }));
   index.addAll(docs);
   for (const doc of docs) notesMap.set(doc.id, doc);
-  return { vaultRoot, index, notes: notesMap };
+  return { vaultRoot, index, notes: notesMap, backlinks: new Map() };
 }
 
 // Three notes: one in daily/, one in projects/, one tagged #work

--- a/packages/server/src/watcher.test.ts
+++ b/packages/server/src/watcher.test.ts
@@ -18,7 +18,7 @@ function freshCtx(vaultRoot: string): ServerContext {
     storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
     searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
   });
-  return { vaultRoot, index, notes: new Map() };
+  return { vaultRoot, index, notes: new Map(), backlinks: new Map() };
 }
 
 async function waitFor(condition: () => boolean, timeoutMs = 30000): Promise<void> {

--- a/packages/server/src/watcher.ts
+++ b/packages/server/src/watcher.ts
@@ -1,8 +1,10 @@
 import { readFile } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
+import { extractLinksWithLines } from '@seekstone/core/extract';
 import chokidar from 'chokidar';
-import type { ServerContext } from './context.js';
+import type { BacklinkRef, ServerContext } from './context.js';
 import { buildDoc, upsertDoc } from './index/doc.js';
+import { resolveLink } from './index/resolve.js';
 import type { Logger } from './log.js';
 
 /**
@@ -30,6 +32,38 @@ export interface WatcherOptions {
   usePolling?: boolean;
 }
 
+function removeNoteBacklinks(ctx: ServerContext, relPath: string): void {
+  const oldDoc = ctx.notes.get(relPath);
+  if (oldDoc === undefined) return;
+  for (const link of extractLinksWithLines(oldDoc.raw)) {
+    const resolved = resolveLink(link.target, ctx.notes);
+    if (resolved === undefined) continue;
+    const arr = ctx.backlinks.get(resolved);
+    if (arr === undefined) continue;
+    const filtered = arr.filter((r) => r.path !== relPath);
+    ctx.backlinks.set(resolved, filtered);
+  }
+}
+
+function addNoteBacklinks(ctx: ServerContext, relPath: string, raw: string): void {
+  const seen = new Set<string>();
+  for (const link of extractLinksWithLines(raw)) {
+    const resolved = resolveLink(link.target, ctx.notes);
+    if (resolved === undefined) continue;
+    const dedupeKey = `${relPath}\0${resolved}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    let arr = ctx.backlinks.get(resolved);
+    if (arr === undefined) {
+      arr = [];
+      ctx.backlinks.set(resolved, arr);
+    }
+    const ref: BacklinkRef = { path: relPath, line: link.line, linkType: link.linkType };
+    arr.push(ref);
+    arr.sort((a, b) => a.path.localeCompare(b.path));
+  }
+}
+
 export function startWatcher(
   ctx: ServerContext,
   log?: Logger,
@@ -42,7 +76,9 @@ export function startWatcher(
   async function upsert(relPath: string, op: 'add' | 'change'): Promise<void> {
     try {
       const raw = await readFile(join(ctx.vaultRoot, relPath), 'utf8');
+      removeNoteBacklinks(ctx, relPath);
       upsertDoc(ctx, buildDoc(relPath, raw));
+      addNoteBacklinks(ctx, relPath, raw);
       log?.debug('index updated', { path: relPath, op });
     } catch {
       // File vanished between event and read — ignore; an unlink will follow.
@@ -51,6 +87,7 @@ export function startWatcher(
 
   function remove(relPath: string): void {
     if (ctx.notes.has(relPath)) {
+      removeNoteBacklinks(ctx, relPath);
       ctx.index.discard(relPath);
       ctx.notes.delete(relPath);
       log?.debug('index removed', { path: relPath, op: 'delete' });


### PR DESCRIPTION
## Summary

- **`get_backlinks(path, includeContext?, limit?)`** — returns every note that links to the target, with source line and optional ~200-char excerpt. Pure index lookup (pre-built reverse-link map) — no vault scan per call. Results sorted by source path ascending; duplicates from the same source deduplicated at build time.
- **`get_links(path)`** — returns all outgoing wikilinks and embeds from a note, each marked `resolved: true/false`. Resolved links include the vault-relative target path. Duplicate targets deduplicated; sorted by line number.

**Infrastructure added:**
- `extractLinksWithLines(raw)` in `@seekstone/core/extract` — extracts `LinkRecord[]` with `linkType` (`wikilink` | `embed`) and 1-indexed line numbers
- `resolveLink(target, notes)` in `index/resolve.ts` — loose Obsidian-style resolution (exact path → +`.md` → basename match → path-without-ext match)
- `BacklinkRef` + `backlinks: Map<string, BacklinkRef[]>` added to `ServerContext`
- `buildIndex()` populates the backlinks map after the initial vault scan
- `startWatcher()` maintains the backlinks map incrementally (add/change/unlink)

## Test plan

- [ ] `npm test` — 220 tests pass (19 new: 9 `get_links`, 10 `get_backlinks`)
- [ ] `npm run lint` — clean
- [ ] CI matrix green before merge