### PR TITLE
docs(release): add RELEASING.md + Glama manual step note (SHA-85)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,3 +92,8 @@ jobs:
           gh release upload "obsidian-mcp-seekstone@${OMCP_VERSION}" seekstone.mcpb --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # NOTE: a manual Glama release step is still required after every publish.
+      # Glama has no public API for programmatic release creation (investigated SHA-85).
+      # See RELEASING.md for the manual steps and the placeholder curl command to
+      # drop in here once Glama exposes an API or webhook.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,29 @@
+# Releasing
+
+Releases are driven by [Changesets](https://github.com/changesets/changesets). The normal flow is:
+
+1. Add a changeset for each PR: `npx changeset`
+2. CI opens a "Version Packages" PR automatically on the next push to `main`.
+3. Merging that PR publishes to npm (OIDC provenance), creates GitHub Releases, and attaches the `.mcpb` bundle — all without manual steps.
+
+## Post-publish: Glama
+
+After every npm publish you need to create a new release on the Glama listing manually:
+
+1. Open <https://glama.ai/mcp/servers/shaqmughal/seekstone/admin/dockerfile>
+2. Click **"Create Release"** (or the equivalent button in the admin UI).
+3. Verify the new version appears on <https://glama.ai/mcp/servers/shaqmughal/seekstone>.
+
+**Why this isn't automated yet:** Glama has no public REST API or documented webhook for programmatic release creation (investigated in SHA-85, June 2026). The build spec uses `"pinnedCommit": null`, so the build itself always pulls the latest commit — only the release creation step is missing. If Glama adds an API or webhook in the future, the step would slot into `release.yml` after the MCPB upload:
+
+```yaml
+- name: Trigger Glama release
+  if: steps.changesets.outputs.published == 'true'
+  run: |
+    VERSION=$(node -p "require('./packages/server/package.json').version")
+    curl -fsSL -X POST "https://glama.ai/api/..." \
+      -H "Authorization: Bearer ${{ secrets.GLAMA_API_TOKEN }}" \
+      -d "{\"version\": \"${VERSION}\"}"
+```
+
+Until then, the manual step above is required to keep the Glama listing current.


### PR DESCRIPTION
## Summary

Investigation result: **Glama has no public REST API or documented webhook for programmatic release creation** as of June 2026.

What was checked:
- `glama.ai/docs` and `glama.ai/mcp/reference` — only a read-only MCP query API (`GET /servers/{owner}/{repo}`), no write/trigger endpoints
- `glama.ai/mcp/hosting` — documents the GitHub App integration; auto-redeploys on push but the release record itself still requires a manual click in the admin UI
- GitHub Actions marketplace — no Glama release action exists
- Web search for "glama.ai API release webhook" — no community solutions found

The `pinnedCommit: null` build spec means the Docker build already pulls latest on rebuild — the gap is solely the "Create Release" button click in the admin UI.

## Changes

- **`RELEASING.md`** — documents the Changesets release flow end-to-end, the required manual Glama step, and includes a placeholder `curl` stub for when Glama adds an API
- **`release.yml`** — adds a comment after the MCPB upload step pointing to `RELEASING.md` and showing where the automated step would slot in

## Test plan

- [ ] Read RELEASING.md and verify the manual Glama step is accurate
- [ ] CI passes (docs-only change, no code touched)