### PR TITLE
chore: changesets for 0.4.0 release

### DIFF
--- a/.changeset/bug-fixes.md
+++ b/.changeset/bug-fixes.md
@@ -1,0 +1,9 @@
+---
+"seekstone": patch
+"obsidian-mcp-seekstone": patch
+---
+
+Fix watcher ignored-path guard and MCPB bundle crash
+
+- **Watcher**: guard against empty relative paths in the `ignored` callback. Paths that resolved to an empty string (e.g. the vault root itself during chokidar's initial scan) could be evaluated incorrectly, risking file events being missed on some configurations.
+- **MCPB**: fully bundle all dependencies to fix an `Error: require('process') is not supported` crash on ESM environments. Also improves the vault picker description and bumps the bundle to manifest v0.4.

--- a/.changeset/new-tools-and-features.md
+++ b/.changeset/new-tools-and-features.md
@@ -1,0 +1,22 @@
+---
+"seekstone": minor
+"obsidian-mcp-seekstone": minor
+---
+
+Add five new tools, read_note range selectors, and Claude Code init support
+
+**New tools:**
+
+- `list_tags` — lists every tag across the vault with per-tag note counts
+- `outline_note` — returns the heading structure of a note as a nested tree
+- `patch_note` — replaces a specific section of a note's body without rewriting the whole file
+- `get_links` — returns all wikilinks and embeds in a note with resolved vault-relative paths and line numbers
+- `get_backlinks` — returns all notes that link to a given note, with line numbers and optional excerpts; backed by a reverse-link index built at startup and maintained incrementally by the file watcher
+
+**`read_note` range selectors:**
+
+Three new optional selectors narrow the response to a sub-region of the note: `section` (by heading name), `block` (by block reference `^id`), and `lines` (`{ from, to }`). Only one selector may be used per call. The response includes a `span: { charStart, charEnd }` field for the selected range.
+
+**`seekstone init` — Claude Code support:**
+
+`seekstone init --client code --write` now auto-writes the MCP config directly into Claude Code's settings file, with the same timestamped-backup safety as the Desktop variant.


### PR DESCRIPTION
## Summary

Adds the two changeset files that were missing from the PRs merged since `seekstone@0.3.0`.

Merging this PR triggers CI to open the **"Version Packages"** PR, which bumps `package.json` versions and writes `CHANGELOG.md`. Merging *that* PR publishes to npm and creates the GitHub Release.

## Unreleased changes captured

**Minor (→ 0.4.0)** — `new-tools-and-features.md`
- `list_tags`, `outline_note`, `patch_note`, `get_links`, `get_backlinks` tools (SHA-17, SHA-10, SHA-11, SHA-13)
- `read_note` section/block/lines range selectors (SHA-9)
- `seekstone init --client code --write` Claude Code support (SHA-77)

**Patch** — `bug-fixes.md`
- Watcher: guard empty relative path in `ignored` callback (SHA-87)
- MCPB: fix ESM `require('process')` crash + manifest v0.4 (SHA-79, SHA-81)

## Excluded (no package change)
- Docs, README, badge, harness, and CI-only changes