### PR TITLE
ci: add changeset check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,43 @@ jobs:
         env:
           SEEKSTONE_COVERAGE: '1'
         run: npx vitest run --coverage --root packages/server
+
+  changeset:
+    name: changeset check
+    runs-on: ubuntu-latest
+    # Only meaningful on PRs; skip the automated "Version Packages" branch.
+    if: |
+      github.event_name == 'pull_request' &&
+      github.head_ref != 'changeset-release/main'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Require changeset for publishable package changes
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          # Which publishable packages did this PR touch?
+          PACKAGES_CHANGED=$(git diff --name-only "origin/${BASE}...HEAD" \
+            | grep -E '^packages/(server|obsidian-mcp-seekstone)/' \
+            | wc -l | tr -d ' ')
+
+          if [ "$PACKAGES_CHANGED" -eq 0 ]; then
+            echo "No publishable package files changed — no changeset required."
+            exit 0
+          fi
+
+          # Did this PR add a changeset file?
+          CHANGESET_ADDED=$(git diff --name-only --diff-filter=A "origin/${BASE}...HEAD" \
+            | grep -E '^\.changeset/.+\.md$' \
+            | grep -v 'README' \
+            | wc -l | tr -d ' ')
+
+          if [ "$CHANGESET_ADDED" -eq 0 ]; then
+            echo "❌ This PR modifies a publishable package but contains no changeset."
+            echo "   Run 'npx changeset' and commit the generated file."
+            exit 1
+          fi
+
+          echo "✅ Changeset found."


### PR DESCRIPTION
## Summary

Adds a `changeset check` CI job that fails if a PR touches `packages/server` or `packages/obsidian-mcp-seekstone` without including a changeset file.

## Behaviour

- **Passes silently** if the PR only touches docs, harness, CI, or other non-publishable paths
- **Passes** if a `.changeset/*.md` file was added in the PR diff
- **Fails** with a clear message if publishable packages changed but no changeset was added
- **Skips entirely** on the automated `changeset-release/main` branch (the "Version Packages" PR that Changesets opens itself)

## Why not the Changesets bot?

The official `changesets-bot` GitHub App is private/unavailable for install. This job replicates the enforcement layer directly in CI without any external App dependency.

## After merging

Optionally make `changeset check` a required status check in branch protection (Settings → Branches → main → Require status checks → `changeset check`) for hard enforcement.