### PR TITLE
fix(release): use GH_PAT so Version Packages PR triggers CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,11 +72,12 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
-          # No NODE_AUTH_TOKEN: npm authenticates via OIDC trusted publishing.
-          # Requires a Trusted Publisher configured for BOTH packages on npmjs.com:
-          #   - seekstone (GitHub Actions, repo shaqmughal/seekstone, workflow release.yml)
-          #   - obsidian-mcp-seekstone (same settings)
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (fine-grained PAT, Contents+PRs read/write) is required here
+          # instead of GITHUB_TOKEN. PRs opened with GITHUB_TOKEN are created by
+          # github-actions[bot] and GitHub intentionally blocks pull_request CI
+          # events on them to prevent recursive workflow loops. A PAT makes the PR
+          # look like it came from a real user, so CI fires normally.
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Build MCP Bundle


### PR DESCRIPTION
## Problem

PR #48 ("chore: version packages") has no CI checks running — it shows as stuck with no status reported. Root cause: GitHub blocks `pull_request` CI events on PRs opened by `github-actions[bot]` using `GITHUB_TOKEN`, to prevent recursive workflow loops. The Changesets action opens the version PR with `GITHUB_TOKEN`, so CI never fires.

## Fix

Switch the Changesets action to use `GH_PAT` (a fine-grained PAT) instead of `GITHUB_TOKEN`. A PAT makes the PR look like it came from a real user, so CI runs normally.

## Setup required before merging

1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens**
2. Generate a token scoped to `shaqmughal/seekstone` with **Contents** (read/write) and **Pull requests** (read/write) permissions
3. Add it as a repo secret named `GH_PAT` under **repo Settings → Secrets and variables → Actions**

Once the secret exists, the next time the Changesets action runs (after merging a changeset PR), the version PR it opens will trigger CI automatically.

## Effect on PR #48

PR #48 was opened with the old `GITHUB_TOKEN` so it won't retroactively get CI. Once this fix is merged, close and re-trigger PR #48 by pushing a trivial commit to `main` — the Changesets action will re-open/update the version PR using the PAT.