### PR TITLE
ci: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 # Never run two releases at once.
 concurrency: release-${{ github.ref }}


### PR DESCRIPTION
Allows manually triggering the release workflow so the Changesets version PR can be re-created cleanly using GH_PAT after fixing the GITHUB_TOKEN race condition.