### PR TITLE
ci(registry): bump server.json to v0.4.0 + automate MCP registry publish on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install mcp-publisher
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Sync server.json version
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          VERSION=$(node -p "require('./packages/server/package.json').version")
+          OMCP_VERSION=$(node -p "require('./packages/obsidian-mcp-seekstone/package.json').version")
+          jq --arg v "$VERSION" --arg ov "$OMCP_VERSION" \
+            '.version = $v | .packages[] |= if .identifier == "seekstone" then .version = $v elif .identifier == "obsidian-mcp-seekstone" then .version = $ov else . end' \
+            server.json > server.tmp && mv server.tmp server.json
+
+      - name: Publish to MCP Registry
+        if: steps.changesets.outputs.published == 'true'
+        run: ./mcp-publisher publish
+
       # NOTE: a manual Glama release step is still required after every publish.
       # Glama has no public API for programmatic release creation (investigated SHA-85).
       # See RELEASING.md for the manual steps and the placeholder curl command to

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shaqmughal/seekstone",
   "description": "Filesystem-direct Obsidian MCP server — search and edit your vault with low context-tax.",
-  "version": "0.2.2",
+  "version": "0.4.0",
   "repository": {
     "url": "https://github.com/shaqmughal/seekstone",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "obsidian-mcp-seekstone",
-      "version": "0.2.2",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "seekstone",
-      "version": "0.2.1",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What

- Bumps `server.json` from v0.2.2/0.2.1 → v0.4.0 (both packages)
- Adds three steps to `release.yml` that run after every npm publish:
  1. **Install mcp-publisher** — downloads the binary from the official registry releases
  2. **Sync server.json version** — dynamically sets both package versions from `package.json` so `server.json` never drifts again
  3. **Publish to MCP Registry** — uses the existing `id-token: write` OIDC permission (no new secrets needed)

## Why

The Official MCP Registry is the canonical upstream — PulseMCP and other directories auto-ingest from it. The registry entry was stuck at v0.2.2 while npm is at v0.4.0.

## After merge

Manually run `mcp-publisher publish` once from the repo root to sync the registry to v0.4.0. All future releases will be automated via CI.

```bash
brew install mcp-publisher  # or download binary from GitHub releases
mcp-publisher login github   # authenticate as shaqmughal
mcp-publisher publish
```

Closes SHA-89