### PR TITLE
fix(server): use build-time VERSION in MCP serverInfo handshake

### DIFF
--- a/.changeset/fix-server-version-in-mcp-handshake.md
+++ b/.changeset/fix-server-version-in-mcp-handshake.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Fix serverInfo.version in MCP handshake — was hardcoded to "0.1.0" instead of using the build-time version constant. MCP clients that surface server metadata now see the correct version.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -56,7 +56,7 @@ const ctx: ServerContext = { vaultRoot, index, notes, backlinks };
 const watcher = startWatcher(ctx, log);
 process.on('exit', watcher.stop);
 
-const server = new Server({ name: 'seekstone', version: '0.1.0' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'seekstone', version: VERSION }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [


### PR DESCRIPTION
## Summary

- The `Server` constructor in `src/index.ts` was hardcoded to `version: '0.1.0'` since the server was first scaffolded — it was never updated to use the `VERSION` constant already derived from `__SEEKSTONE_VERSION__` at build time via tsup
- Every MCP client handshake has been reporting `serverInfo.version: "0.1.0"` regardless of the published npm version
- Discovered via Glama instance logs showing `"serverInfo":{"name":"seekstone","version":"0.1.0"}`

## Test plan

- [x] All 220 existing tests pass
- [x] Lint clean
- [ ] After merge, verify `npx seekstone --version` matches the released version in the MCP handshake