### PR TITLE
feat(server): add replace_in_note tool (SHA-12)

### DIFF
--- a/.changeset/fix-server-version-in-mcp-handshake.md
+++ b/.changeset/fix-server-version-in-mcp-handshake.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Fix serverInfo.version in MCP handshake — was hardcoded to "0.1.0" instead of using the build-time version constant. MCP clients that surface server metadata now see the correct version.

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -12,6 +12,7 @@ import { OutlineNoteInput, outlineNote } from './tools/outline_note.js';
 import { PatchFrontmatterInput, patchFrontmatter } from './tools/patch_frontmatter.js';
 import { PatchNoteInput, patchNote } from './tools/patch_note.js';
 import { ReadNoteInput, readNote } from './tools/read_note.js';
+import { ReplaceInNoteInput, replaceInNote } from './tools/replace_in_note.js';
 import { SearchInput, search } from './tools/search.js';
 
 export type ToolResult = {
@@ -34,6 +35,7 @@ export const HANDLED_TOOLS = [
   'patch_note',
   'get_backlinks',
   'get_links',
+  'replace_in_note',
 ] as const;
 
 // Metadata-safe keys: logged at info. Note content (`content`, `frontmatter`,
@@ -173,6 +175,11 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
     case 'get_links': {
       const input = GetLinksInput.parse(args);
       const result = getLinks(ctx, input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+    case 'replace_in_note': {
+      const input = ReplaceInNoteInput.parse(args);
+      const result = await replaceInNote(ctx, input);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     }
     default:

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -56,7 +56,7 @@ const ctx: ServerContext = { vaultRoot, index, notes, backlinks };
 const watcher = startWatcher(ctx, log);
 process.on('exit', watcher.stop);
 
-const server = new Server({ name: 'seekstone', version: '0.1.0' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'seekstone', version: VERSION }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -320,6 +320,43 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['path'],
       },
     },
+    {
+      name: 'replace_in_note',
+      description:
+        'Find and replace text within a note body. Supports literal and regex search, case sensitivity, whole-word matching, and a replacement limit. Frontmatter is never touched. Use dryRun to preview matches before writing.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Vault-relative path to the note.' },
+          find: { type: 'string', description: 'Text or pattern to find.' },
+          replace: {
+            type: 'string',
+            description: 'Replacement text. Supports $1, $2, … backreferences in regex mode.',
+          },
+          regex: {
+            type: 'boolean',
+            description: 'Treat find as a regular expression. Default false.',
+          },
+          caseSensitive: {
+            type: 'boolean',
+            description: 'Case-sensitive matching. Default false.',
+          },
+          wholeWord: {
+            type: 'boolean',
+            description: 'Match whole words only (\\b boundary). Default false.',
+          },
+          limit: {
+            type: 'number',
+            description: 'Maximum number of replacements. Omit to replace all.',
+          },
+          dryRun: {
+            type: 'boolean',
+            description: 'If true, report matches without writing. Default false.',
+          },
+        },
+        required: ['path', 'find', 'replace'],
+      },
+    },
   ],
 }));
 
@@ -330,7 +367,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req): Promise<CallToolRes
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
-log.info('ready', { tools: 13, transport: 'stdio' });
+log.info('ready', { tools: 14, transport: 'stdio' });
 
 process.stderr.write(
   `seekstone: add to Claude Desktop:\n${JSON.stringify(

--- a/packages/server/src/tools/replace_in_note.test.ts
+++ b/packages/server/src/tools/replace_in_note.test.ts
@@ -275,9 +275,8 @@ describe('replaceInNote — dryRun', () => {
       dryRun: true,
     });
     expect(result.matches).toHaveLength(1);
-    const first = result.matches[0]!;
-    expect(first.line).toBeGreaterThan(0);
-    expect(first.byteOffset).toBeGreaterThan(0);
+    expect(result.matches.at(0)?.line).toBeGreaterThan(0);
+    expect(result.matches.at(0)?.byteOffset).toBeGreaterThan(0);
   });
 });
 

--- a/packages/server/src/tools/replace_in_note.test.ts
+++ b/packages/server/src/tools/replace_in_note.test.ts
@@ -1,0 +1,325 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import MiniSearch from 'minisearch';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ServerContext } from '../context.js';
+import type { IndexedNote } from '../index/types.js';
+import { replaceInNote } from './replace_in_note.js';
+
+const NOTE = `---
+title: Test Note
+tags: [alpha, beta]
+---
+# Heading
+
+Hello world. Hello again.
+
+## Sub
+
+World is wonderful. hello lowercase.
+`;
+
+const NOTE_NO_FM = `# Plain
+
+Hello world. Hello again.
+`;
+
+function buildCtx(vaultRoot: string): ServerContext {
+  const index = new MiniSearch<IndexedNote>({
+    idField: 'id',
+    fields: ['title', 'body', 'tags', 'fmKeys'],
+    storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
+    searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
+  });
+  return { vaultRoot, index, notes: new Map(), backlinks: new Map() };
+}
+
+let vaultRoot: string;
+
+beforeEach(async () => {
+  vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-replace-in-note-'));
+  await writeFile(join(vaultRoot, 'note.md'), NOTE, 'utf8');
+  await writeFile(join(vaultRoot, 'no-fm.md'), NOTE_NO_FM, 'utf8');
+});
+
+afterEach(async () => {
+  await rm(vaultRoot, { recursive: true, force: true });
+});
+
+describe('replaceInNote — literal mode', () => {
+  it('replaces all occurrences by default', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'Hello',
+      replace: 'Hi',
+      regex: false,
+      caseSensitive: false,
+      wholeWord: false,
+      dryRun: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(result.replacements).toBe(3); // Hello world, Hello again, hello lowercase
+    expect(written).not.toContain('Hello');
+    expect(written).not.toContain('hello');
+    expect(written.match(/Hi /g)?.length).toBe(3);
+  });
+
+  it('caseSensitive: true only matches exact case', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'Hello',
+      replace: 'Hi',
+      regex: false,
+      caseSensitive: true,
+      wholeWord: false,
+      dryRun: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(result.replacements).toBe(2); // Hello world + Hello again (not hello lowercase)
+    expect(written).toContain('hello lowercase');
+  });
+
+  it('limit caps the number of replacements', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'Hello',
+      replace: 'Hi',
+      regex: false,
+      caseSensitive: false,
+      wholeWord: false,
+      limit: 1,
+      dryRun: false,
+    });
+    expect(result.replacements).toBe(1);
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    // At least two Hello/hello occurrences still remain
+    const remaining = (written.match(/hello/gi) ?? []).length;
+    expect(remaining).toBe(2);
+  });
+
+  it('wholeWord: true does not match substrings', async () => {
+    const content = `---\ntitle: t\n---\nHelloWorld hello\n`;
+    await writeFile(join(vaultRoot, 'word.md'), content, 'utf8');
+    const ctx = buildCtx(vaultRoot);
+    const result = await replaceInNote(ctx, {
+      path: 'word.md',
+      find: 'hello',
+      replace: 'hi',
+      regex: false,
+      caseSensitive: false,
+      wholeWord: true,
+      dryRun: false,
+    });
+    const written = await readFile(join(vaultRoot, 'word.md'), 'utf8');
+    expect(result.replacements).toBe(1); // only standalone "hello", not "HelloWorld"
+    expect(written).toContain('HelloWorld');
+    expect(written).toContain('hi');
+  });
+
+  it('zero matches → no write, replacements: 0, success', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const before = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    const result = await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'xyznotpresent',
+      replace: 'anything',
+      regex: false,
+      caseSensitive: false,
+      wholeWord: false,
+      dryRun: false,
+    });
+    expect(result.replacements).toBe(0);
+    expect(result.matches).toHaveLength(0);
+    expect(result.bytesWritten).toBeUndefined();
+    const after = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(after).toBe(before);
+  });
+
+  it('frontmatter bytes are identical pre/post', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const fmEnd = NOTE.indexOf('---\n', 4) + 4;
+    const originalFm = NOTE.slice(0, fmEnd);
+    await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'Hello',
+      replace: 'Hi',
+      regex: false,
+      caseSensitive: false,
+      wholeWord: false,
+      dryRun: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(written.slice(0, fmEnd)).toBe(originalFm);
+  });
+
+  it('works on notes without frontmatter', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await replaceInNote(ctx, {
+      path: 'no-fm.md',
+      find: 'Hello',
+      replace: 'Greetings',
+      regex: false,
+      caseSensitive: false,
+      wholeWord: false,
+      dryRun: false,
+    });
+    expect(result.replacements).toBe(2);
+    const written = await readFile(join(vaultRoot, 'no-fm.md'), 'utf8');
+    expect(written).not.toContain('Hello');
+    expect(written).toContain('Greetings');
+    expect(result.frontmatterUnchanged).toBe(true);
+  });
+
+  it('returns bytesWritten matching file size', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'Hello',
+      replace: 'Hi',
+      regex: false,
+      caseSensitive: false,
+      wholeWord: false,
+      dryRun: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(result.bytesWritten).toBe(Buffer.byteLength(written, 'utf8'));
+  });
+});
+
+describe('replaceInNote — regex mode', () => {
+  it('regex mode replaces pattern matches', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'hel+o',
+      replace: 'Hi',
+      regex: true,
+      caseSensitive: false,
+      wholeWord: false,
+      dryRun: false,
+    });
+    expect(result.replacements).toBe(3);
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(written).not.toContain('Hello');
+    expect(written).not.toContain('hello');
+  });
+
+  it('regex mode expands capture-group backreferences', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await replaceInNote(ctx, {
+      path: 'note.md',
+      find: '(Hello|hello)',
+      replace: '[$1]',
+      regex: true,
+      caseSensitive: true,
+      wholeWord: false,
+      dryRun: false,
+    });
+    const written = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(written).toContain('[Hello]');
+    expect(written).toContain('[hello]');
+  });
+
+  it('invalid regex throws before any IO', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const before = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    await expect(
+      replaceInNote(ctx, {
+        path: 'note.md',
+        find: '[invalid',
+        replace: 'x',
+        regex: true,
+        caseSensitive: false,
+        wholeWord: false,
+        dryRun: false,
+      }),
+    ).rejects.toThrow('Invalid regex');
+    const after = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(after).toBe(before);
+  });
+});
+
+describe('replaceInNote — dryRun', () => {
+  it('dryRun: true reports matches without writing', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const before = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    const result = await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'Hello',
+      replace: 'Hi',
+      regex: false,
+      caseSensitive: false,
+      wholeWord: false,
+      dryRun: true,
+    });
+    expect(result.replacements).toBe(3);
+    expect(result.matches).toHaveLength(3);
+    expect(result.bytesWritten).toBeUndefined();
+    const after = await readFile(join(vaultRoot, 'note.md'), 'utf8');
+    expect(after).toBe(before);
+  });
+
+  it('dryRun matches report correct line numbers (1-based)', async () => {
+    const ctx = buildCtx(vaultRoot);
+    const result = await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'Hello world',
+      replace: '',
+      regex: false,
+      caseSensitive: true,
+      wholeWord: false,
+      dryRun: true,
+    });
+    expect(result.matches).toHaveLength(1);
+    const first = result.matches[0]!;
+    expect(first.line).toBeGreaterThan(0);
+    expect(first.byteOffset).toBeGreaterThan(0);
+  });
+});
+
+describe('replaceInNote — cache + safety', () => {
+  it('updates the in-memory cache after a write', async () => {
+    const ctx = buildCtx(vaultRoot);
+    ctx.notes.set('note.md', {
+      id: 'note.md',
+      title: 'Test Note',
+      body: '',
+      tags: '',
+      fmKeys: 'title tags',
+      raw: NOTE,
+      sizeBytes: Buffer.byteLength(NOTE, 'utf8'),
+      mtimeMs: Date.now(),
+    });
+    await replaceInNote(ctx, {
+      path: 'note.md',
+      find: 'Hello',
+      replace: 'Hi',
+      regex: false,
+      caseSensitive: false,
+      wholeWord: false,
+      dryRun: false,
+    });
+    const cached = ctx.notes.get('note.md');
+    expect(cached?.raw).toContain('Hi');
+    expect(cached?.raw).not.toContain('Hello');
+  });
+
+  it('throws "Path outside vault" for path traversal', async () => {
+    const ctx = buildCtx(vaultRoot);
+    await expect(
+      replaceInNote(ctx, {
+        path: '../outside.md',
+        find: 'x',
+        replace: 'y',
+        regex: false,
+        caseSensitive: false,
+        wholeWord: false,
+        dryRun: false,
+      }),
+    ).rejects.toThrow('Path outside vault');
+  });
+});

--- a/packages/server/src/tools/replace_in_note.ts
+++ b/packages/server/src/tools/replace_in_note.ts
@@ -12,20 +12,14 @@ export const ReplaceInNoteInput = z.object({
     .describe('Replacement text. Supports $1, $2, … backreferences in regex mode.'),
   regex: z.boolean().default(false).describe('Treat find as a regular expression.'),
   caseSensitive: z.boolean().default(false).describe('Case-sensitive matching.'),
-  wholeWord: z
-    .boolean()
-    .default(false)
-    .describe('Match whole words only (\\b word-boundary).'),
+  wholeWord: z.boolean().default(false).describe('Match whole words only (\\b word-boundary).'),
   limit: z
     .number()
     .int()
     .min(1)
     .optional()
     .describe('Maximum number of replacements. Omit to replace all.'),
-  dryRun: z
-    .boolean()
-    .default(false)
-    .describe('If true, report matches without writing anything.'),
+  dryRun: z.boolean().default(false).describe('If true, report matches without writing anything.'),
 });
 export type ReplaceInNoteInput = z.infer<typeof ReplaceInNoteInput>;
 
@@ -98,7 +92,12 @@ export async function replaceInNote(
   });
 
   if (input.dryRun || toReplace.length === 0) {
-    return { path: input.path, replacements: toReplace.length, matches, frontmatterUnchanged: true };
+    return {
+      path: input.path,
+      replacements: toReplace.length,
+      matches,
+      frontmatterUnchanged: true,
+    };
   }
 
   // Apply replacements left-to-right, resolving backreferences per match.
@@ -106,11 +105,10 @@ export async function replaceInNote(
   let newBody = '';
   let lastIndex = 0;
   for (const m of toReplace) {
-    newBody += body.slice(lastIndex, m.index!);
-    newBody += input.regex
-      ? m[0].replace(singleRe, input.replace)
-      : input.replace;
-    lastIndex = m.index! + m[0].length;
+    const matchIndex = m.index ?? 0;
+    newBody += body.slice(lastIndex, matchIndex);
+    newBody += input.regex ? m[0].replace(singleRe, input.replace) : input.replace;
+    lastIndex = matchIndex + m[0].length;
   }
   newBody += body.slice(lastIndex);
 

--- a/packages/server/src/tools/replace_in_note.ts
+++ b/packages/server/src/tools/replace_in_note.ts
@@ -1,0 +1,139 @@
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parseFrontmatter } from '@seekstone/core/frontmatter';
+import { z } from 'zod';
+import type { ServerContext } from '../context.js';
+
+export const ReplaceInNoteInput = z.object({
+  path: z.string().describe('Vault-relative path to the note.'),
+  find: z.string().min(1).describe('Text or pattern to find.'),
+  replace: z
+    .string()
+    .describe('Replacement text. Supports $1, $2, … backreferences in regex mode.'),
+  regex: z.boolean().default(false).describe('Treat find as a regular expression.'),
+  caseSensitive: z.boolean().default(false).describe('Case-sensitive matching.'),
+  wholeWord: z
+    .boolean()
+    .default(false)
+    .describe('Match whole words only (\\b word-boundary).'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('Maximum number of replacements. Omit to replace all.'),
+  dryRun: z
+    .boolean()
+    .default(false)
+    .describe('If true, report matches without writing anything.'),
+});
+export type ReplaceInNoteInput = z.infer<typeof ReplaceInNoteInput>;
+
+export interface MatchPosition {
+  line: number;
+  byteOffset: number;
+}
+
+export interface ReplaceInNoteResult {
+  path: string;
+  replacements: number;
+  matches: MatchPosition[];
+  bytesWritten?: number;
+  frontmatterUnchanged: true;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildRegex(
+  find: string,
+  opts: { regex: boolean; caseSensitive: boolean; wholeWord: boolean },
+): RegExp {
+  let pattern = opts.regex ? find : escapeRegex(find);
+  if (opts.wholeWord) pattern = `\\b(?:${pattern})\\b`;
+  const flags = `g${opts.caseSensitive ? '' : 'i'}`;
+  return new RegExp(pattern, flags);
+}
+
+async function atomicWrite(absPath: string, content: string): Promise<void> {
+  const tmpPath = `${absPath}.seekstone-replace-tmp`;
+  await writeFile(tmpPath, content, 'utf8');
+  await rename(tmpPath, absPath);
+}
+
+export async function replaceInNote(
+  ctx: ServerContext,
+  input: ReplaceInNoteInput,
+): Promise<ReplaceInNoteResult> {
+  const absPath = join(ctx.vaultRoot, input.path);
+  if (!absPath.startsWith(ctx.vaultRoot)) {
+    throw new Error(`Path outside vault: ${input.path}`);
+  }
+
+  // Validate regex before any IO.
+  let re: RegExp;
+  try {
+    re = buildRegex(input.find, {
+      regex: input.regex,
+      caseSensitive: input.caseSensitive,
+      wholeWord: input.wholeWord,
+    });
+  } catch (err) {
+    throw new Error(`Invalid regex: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const raw = await readFile(absPath, 'utf8');
+  const fm = parseFrontmatter(raw);
+  const originalFmRegion = raw.slice(0, fm.bodyStart);
+  const body = raw.slice(fm.bodyStart);
+
+  const allMatches = [...body.matchAll(re)];
+  const toReplace = input.limit !== undefined ? allMatches.slice(0, input.limit) : allMatches;
+
+  const matches: MatchPosition[] = toReplace.map((m) => {
+    const fileOffset = fm.bodyStart + (m.index ?? 0);
+    const line = raw.slice(0, fileOffset).split('\n').length;
+    return { line, byteOffset: fileOffset };
+  });
+
+  if (input.dryRun || toReplace.length === 0) {
+    return { path: input.path, replacements: toReplace.length, matches, frontmatterUnchanged: true };
+  }
+
+  // Apply replacements left-to-right, resolving backreferences per match.
+  const singleRe = new RegExp(re.source, re.flags.replace('g', ''));
+  let newBody = '';
+  let lastIndex = 0;
+  for (const m of toReplace) {
+    newBody += body.slice(lastIndex, m.index!);
+    newBody += input.regex
+      ? m[0].replace(singleRe, input.replace)
+      : input.replace;
+    lastIndex = m.index! + m[0].length;
+  }
+  newBody += body.slice(lastIndex);
+
+  const newContent = `${originalFmRegion}${newBody}`;
+  await atomicWrite(absPath, newContent);
+
+  const written = await readFile(absPath, 'utf8');
+  if (written.slice(0, originalFmRegion.length) !== originalFmRegion) {
+    throw new Error('Write-safety violation: frontmatter region changed unexpectedly');
+  }
+
+  const cached = ctx.notes.get(input.path);
+  if (cached) {
+    cached.body = newBody;
+    cached.raw = newContent;
+    cached.sizeBytes = Buffer.byteLength(newContent, 'utf8');
+  }
+
+  return {
+    path: input.path,
+    replacements: toReplace.length,
+    matches,
+    bytesWritten: Buffer.byteLength(newContent, 'utf8'),
+    frontmatterUnchanged: true,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `replace_in_note` — literal and regex find/replace within a single note's body
- Supports `caseSensitive`, `wholeWord`, `limit` (max replacements), and `dryRun` (preview without writing)
- Regex mode expands capture-group backreferences (`$1`, `$2`, etc.) in the replacement string
- Frontmatter is never touched; writes are atomic (temp+rename) with post-write FM verification
- Cache updated on write; invalid regex throws before any IO
- 15 tests covering all acceptance criteria from the PRD

Closes SHA-12.

## Test plan

- [ ] `npm test` passes (15 new tests + full suite green)
- [ ] `npx tsc -p packages/server/tsconfig.json --noEmit` clean
- [ ] Literal replace, regex replace, dryRun, limit, caseSensitive, wholeWord all exercised in tests
- [ ] Frontmatter byte-identity verified pre/post write