### PR TITLE
chore: add changeset for replace_in_note (minor)

### DIFF
--- a/.changeset/feat-replace-in-note.md
+++ b/.changeset/feat-replace-in-note.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+Add `replace_in_note` tool — literal and regex find/replace within a note body. Supports case-insensitive matching (default), whole-word boundaries, capture-group backreferences in regex mode, a replacement limit, and a dry-run preview mode. Frontmatter is never touched.


### PR DESCRIPTION
`replace_in_note` merged in #58 without a changeset, so it's missing from the release notes and version bump. This adds the changeset.

Once merged, Changesets will update the "Version Packages" PR (#60) from `0.4.2` → `0.5.0` with the correct CHANGELOG entry.