### PR TITLE
fix(release): revert to seekstone@VERSION tag format for MCPB upload

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
-  "tagFormat": "v${version}"
+  "ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           VERSION=$(node -p "require('./packages/server/package.json').version")
-          gh release upload "v${VERSION}" seekstone.mcpb --clobber
+          gh release upload "seekstone@${VERSION}" seekstone.mcpb --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,12 +94,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install mcp-publisher
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Sync server.json version
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           VERSION=$(node -p "require('./packages/server/package.json').version")
           OMCP_VERSION=$(node -p "require('./packages/obsidian-mcp-seekstone/package.json').version")
@@ -108,7 +108,7 @@ jobs:
             server.json > server.tmp && mv server.tmp server.json
 
       - name: Publish to MCP Registry
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: ./mcp-publisher publish
 
       # NOTE: a manual Glama release step is still required after every publish.

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shaqmughal/seekstone",
   "description": "Filesystem-direct Obsidian MCP server — search and edit your vault with low context-tax.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "url": "https://github.com/shaqmughal/seekstone",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "obsidian-mcp-seekstone",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "seekstone",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- Reverts `gh release upload` target from `v${VERSION}` back to `seekstone@${VERSION}` to match the tag Changesets actually creates for monorepos
- Removes the non-functional `tagFormat: "v${version}"` from `.changeset/config.json` — this option is only respected for single-package repos; monorepos always emit `packageName@version` tags regardless

## Context

PR #59 changed the workflow to `v${VERSION}` and added `tagFormat` to the config, aiming for `v0.x.y` convention. However, the Changesets action for monorepos ignores `tagFormat` and always creates `seekstone@0.5.0` / `obsidian-mcp-seekstone@0.5.0` release tags. The mismatch caused the 0.5.0 release run to fail at "Attach MCPB to GitHub Release" with "release not found". The mcpb was manually attached to `seekstone@0.5.0` and the fix is captured here.

## Test plan

- [ ] CI green on this PR
- [ ] Next release cycle: MCPB attachment step succeeds with `seekstone@{version}` tag