### PR TITLE
fix(release): authenticate mcp-publisher with github-oidc before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,9 @@ jobs:
 
       - name: Publish to MCP Registry
         if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
-        run: ./mcp-publisher publish
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
 
       # NOTE: a manual Glama release step is still required after every publish.
       # Glama has no public API for programmatic release creation (investigated SHA-85).


### PR DESCRIPTION
## Summary

Adds `mcp-publisher login github-oidc` before `mcp-publisher publish` in the release workflow. The publish step was failing with:

> Error: not authenticated, run 'mcp-publisher login <method>' first

The `id-token: write` permission is already set on the job, so the OIDC exchange will work automatically in CI.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, trigger `workflow_dispatch` on release.yml to verify MCP registry publish succeeds for 0.5.0