### PR TITLE
fix(release): authenticate mcp-publisher with github-oidc + sync manifest version

### DIFF
--- a/.changeset/fix-manifest-version-sync.md
+++ b/.changeset/fix-manifest-version-sync.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Sync manifest.json version to 0.5.0 (was left at 0.3.0 after changeset release) and ignore the mcp-publisher binary from git.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,9 @@ jobs:
 
       - name: Publish to MCP Registry
         if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
-        run: ./mcp-publisher publish
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
 
       # NOTE: a manual Glama release step is still required after every publish.
       # Glama has no public API for programmatic release creation (investigated SHA-85).

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ safety-scratch/
 # claude code local task state
 .claude/scheduled_tasks.lock
 seekstone.mcpb
+
+# mcp-publisher binary downloaded by CI release workflow
+mcp-publisher

--- a/packages/server/manifest.json
+++ b/packages/server/manifest.json
@@ -12,21 +12,13 @@
     "url": "https://github.com/shaqmughal/seekstone"
   },
   "license": "MIT",
-  "keywords": [
-    "obsidian",
-    "mcp",
-    "notes",
-    "vault",
-    "knowledge-base"
-  ],
+  "keywords": ["obsidian", "mcp", "notes", "vault", "knowledge-base"],
   "server": {
     "type": "node",
     "entry_point": "dist/index.js",
     "mcp_config": {
       "command": "node",
-      "args": [
-        "${__dirname}/dist/index.js"
-      ],
+      "args": ["${__dirname}/dist/index.js"],
       "env": {
         "SEEKSTONE_VAULT": "${user_config.vault}"
       }

--- a/packages/server/manifest.json
+++ b/packages/server/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.4",
   "name": "seekstone",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "description": "Obsidian MCP server — filesystem-direct vault access, low context-tax.",
   "author": {
     "name": "Shaq Mughal",
@@ -12,13 +12,21 @@
     "url": "https://github.com/shaqmughal/seekstone"
   },
   "license": "MIT",
-  "keywords": ["obsidian", "mcp", "notes", "vault", "knowledge-base"],
+  "keywords": [
+    "obsidian",
+    "mcp",
+    "notes",
+    "vault",
+    "knowledge-base"
+  ],
   "server": {
     "type": "node",
     "entry_point": "dist/index.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/dist/index.js"],
+      "args": [
+        "${__dirname}/dist/index.js"
+      ],
       "env": {
         "SEEKSTONE_VAULT": "${user_config.vault}"
       }


### PR DESCRIPTION
## Summary

- Adds `./mcp-publisher login github-oidc` before `./mcp-publisher publish` in the release workflow — the registry step was failing with "not authenticated" because no login preceded the publish
- Syncs `manifest.json` version from `0.3.0` to `0.5.0` to match `package.json` (missed when changesets bumped the version)
- Ignores the `mcp-publisher` binary in `.gitignore` — CI downloads it fresh each run, it shouldn't live in the working tree

## Test plan

- [ ] Trigger a release and confirm the MCP registry publish step succeeds without an auth error
- [ ] Verify `manifest.json` version matches `package.json` after merge