### PR TITLE
feat(coverage): add HTML reporter to server vitest config (SHA-124)

### DIFF
--- a/.changeset/feat-html-coverage-reporter.md
+++ b/.changeset/feat-html-coverage-reporter.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Add HTML reporter to server vitest coverage config so `--coverage` runs generate an interactive report at `coverage/index.html`.

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     testTimeout: 35000,
     coverage: {
       provider: 'v8',
-      reporter: ['text'],
+      reporter: ['text', 'html'],
       include: ['src/**/*.ts'],
       // Excluded from the gate: the thin bootstrap entry (side-effecting, only
       // exercised by the smoke test), type-only modules, the fs-integration


### PR DESCRIPTION
## Summary

- Adds `'html'` to `coverage.reporter` in `packages/server/vitest.config.ts` alongside the existing `'text'` reporter
- Every `--coverage` run now generates an interactive HTML report at `coverage/index.html` (directory is already gitignored)

## Usage

```bash
npm run test --workspace=packages/server -- --coverage
open packages/server/coverage/index.html
```

## Test plan

- [x] HTML report generated at `coverage/index.html` locally
- [x] All 235 tests passing, thresholds met (98.4% stmts, 86.9% branches, 100% functions)

Closes SHA-124