### PR TITLE
fix(ci): scope changeset gate to src/ and package.json only (SHA-125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,11 @@ jobs:
           BASE: ${{ github.base_ref }}
         run: |
           # Which publishable packages did this PR touch?
+          # Only src/ and package.json count — config, test, and manifest files
+          # don't affect what's published to npm and don't need a changeset.
           PACKAGES_CHANGED=$(git diff --name-only "origin/${BASE}...HEAD" \
-            | grep -E '^packages/(server|obsidian-mcp-seekstone)/' \
+            | grep -E '^packages/(server|obsidian-mcp-seekstone)/(src/|package\.json$)' \
+            | grep -v '\.test\.ts$' \
             | wc -l | tr -d ' ')
 
           if [ "$PACKAGES_CHANGED" -eq 0 ]; then


### PR DESCRIPTION
## Summary

The changeset check was firing on any file under `packages/(server|obsidian-mcp-seekstone)/`, including `vitest.config.ts`, `tsconfig.json`, `manifest.json`, and test files — none of which affect what's published to npm.

This tightens the gate to only count files that actually matter for publishing:
- `src/**` (excluding `*.test.ts`)
- `package.json`

Config files, test files, and `manifest.json` no longer require a changeset.

## Test plan

- [ ] A PR touching only `vitest.config.ts` passes the changeset check without a changeset
- [ ] A PR touching `src/` still requires a changeset
- [ ] A PR touching `package.json` still requires a changeset

Closes SHA-125