### PR TITLE
fix(deps): force tmp>=0.2.6 via npm overrides (SHA-126)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4437,16 +4437,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/outdent": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
@@ -5457,16 +5447,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "version-packages": "changeset version && biome format --write .",
     "release": "changeset publish"
   },
+  "overrides": {
+    "tmp": ">=0.2.6"
+  },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^2.1.2",
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
## Summary

Patches two open Dependabot security alerts against `tmp`, a transitive dependency 3 levels deep via `@anthropic-ai/mcpb` → `@inquirer/editor` → `external-editor` → `tmp@0.0.33`:

- **High** (GHSA): Path traversal via unsanitized prefix/postfix — patched in tmp 0.2.6+
- **Low** (GHSA): Arbitrary temp file/dir write via symlink `dir` parameter — patched in tmp 0.2.4+

Dependabot cannot auto-fix transitive deps at this depth. Adds an `npm overrides` entry to force `tmp` to `>=0.2.6`. Resolved version is `0.2.7`.

## Test plan

- [x] `npm install` reports `found 0 vulnerabilities`
- [x] `tmp` resolves to `0.2.7` in lockfile
- [x] All 404 tests passing

Closes SHA-126