### PR TITLE
feat(server): add get_periodic_note and append_periodic_note tools

### DIFF
--- a/.changeset/feat-periodic-notes.md
+++ b/.changeset/feat-periodic-notes.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+Add `get_periodic_note` and `append_periodic_note` tools for filesystem-direct access to daily, weekly, monthly, quarterly, and yearly periodic notes. Reads folder/format/template config from `.obsidian/daily-notes.json` and the periodic-notes plugin data.json with moment.js-compatible date tokens. No running Obsidian required.

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -11,6 +11,12 @@ import { MoveNoteInput, moveNote } from './tools/move_note.js';
 import { OutlineNoteInput, outlineNote } from './tools/outline_note.js';
 import { PatchFrontmatterInput, patchFrontmatter } from './tools/patch_frontmatter.js';
 import { PatchNoteInput, patchNote } from './tools/patch_note.js';
+import {
+  AppendPeriodicNoteInput,
+  GetPeriodicNoteInput,
+  appendPeriodicNote,
+  getPeriodicNote,
+} from './tools/periodic_note.js';
 import { ReadNoteInput, readNote } from './tools/read_note.js';
 import { ReplaceInNoteInput, replaceInNote } from './tools/replace_in_note.js';
 import { SearchInput, search } from './tools/search.js';
@@ -36,6 +42,8 @@ export const HANDLED_TOOLS = [
   'get_backlinks',
   'get_links',
   'replace_in_note',
+  'get_periodic_note',
+  'append_periodic_note',
 ] as const;
 
 // Metadata-safe keys: logged at info. Note content (`content`, `frontmatter`,
@@ -52,6 +60,8 @@ const META_KEYS = [
   'pattern',
   'minCount',
   'sort',
+  'period',
+  'date',
 ] as const;
 
 function safeMeta(args: unknown): Record<string, unknown> {
@@ -181,6 +191,23 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
       const input = ReplaceInNoteInput.parse(args);
       const result = await replaceInNote(ctx, input);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+    case 'get_periodic_note': {
+      const input = GetPeriodicNoteInput.parse(args);
+      const result = await getPeriodicNote(ctx, input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+    case 'append_periodic_note': {
+      const input = AppendPeriodicNoteInput.parse(args);
+      const result = await appendPeriodicNote(ctx, input);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Appended ${result.bytesWritten} bytes to ${result.path}.`,
+          },
+        ],
+      };
     }
     default:
       throw new Error(`Unknown tool: ${name}`);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -357,6 +357,59 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['path', 'find', 'replace'],
       },
     },
+    {
+      name: 'get_periodic_note',
+      description:
+        'Get the path and existence status of a periodic note (daily, weekly, monthly, quarterly, or yearly) for a given date. Reads folder/format config from .obsidian/daily-notes.json (daily) or the periodic-notes plugin data.json. Optionally creates the note from the configured template if it is missing.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          period: {
+            type: 'string',
+            enum: ['daily', 'weekly', 'monthly', 'quarterly', 'yearly'],
+            description: 'Period type. Default: daily.',
+          },
+          date: {
+            type: 'string',
+            description: 'ISO date string (YYYY-MM-DD). Defaults to today when omitted.',
+          },
+          createIfMissing: {
+            type: 'boolean',
+            description:
+              'Create the note from the configured template if it does not exist. Default false.',
+          },
+        },
+        required: [],
+      },
+    },
+    {
+      name: 'append_periodic_note',
+      description:
+        'Append text to a periodic note (daily, weekly, monthly, quarterly, or yearly). Preserves existing frontmatter exactly. Creates the note first (from template if configured) when createIfMissing is true (default).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          period: {
+            type: 'string',
+            enum: ['daily', 'weekly', 'monthly', 'quarterly', 'yearly'],
+            description: 'Period type. Default: daily.',
+          },
+          date: {
+            type: 'string',
+            description: 'ISO date string (YYYY-MM-DD). Defaults to today when omitted.',
+          },
+          content: {
+            type: 'string',
+            description: 'Text to append to the note body.',
+          },
+          createIfMissing: {
+            type: 'boolean',
+            description: 'Create the note if it does not exist before appending. Default true.',
+          },
+        },
+        required: ['content'],
+      },
+    },
   ],
 }));
 
@@ -367,7 +420,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req): Promise<CallToolRes
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
-log.info('ready', { tools: 14, transport: 'stdio' });
+log.info('ready', { tools: 16, transport: 'stdio' });
 
 process.stderr.write(
   `seekstone: add to Claude Desktop:\n${JSON.stringify(

--- a/packages/server/src/tools/periodic_note.test.ts
+++ b/packages/server/src/tools/periodic_note.test.ts
@@ -1,0 +1,292 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import MiniSearch from 'minisearch';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ServerContext } from '../context.js';
+import type { IndexedNote } from '../index/types.js';
+import {
+  appendPeriodicNote,
+  formatMomentDate,
+  getPeriodicNote,
+  resolveNotePath,
+} from './periodic_note.js';
+
+let tmpDir: string;
+
+function freshCtx(): ServerContext {
+  const index = new MiniSearch<IndexedNote>({
+    idField: 'id',
+    fields: ['title', 'body', 'tags', 'fmKeys'],
+    storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
+    searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
+  });
+  return { vaultRoot: tmpDir, index, notes: new Map(), backlinks: new Map() };
+}
+
+beforeAll(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'seekstone-periodic-note-test-'));
+});
+
+afterAll(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// ── formatMomentDate ──────────────────────────────────────────────────────────
+
+describe('formatMomentDate', () => {
+  const d = new Date('2026-06-09'); // Tuesday, ISO week 24
+
+  it('formats YYYY-MM-DD', () => {
+    expect(formatMomentDate(d, 'YYYY-MM-DD')).toBe('2026-06-09');
+  });
+
+  it('formats YY-MM-DD', () => {
+    expect(formatMomentDate(d, 'YY-MM-DD')).toBe('26-06-09');
+  });
+
+  it('formats YYYY/MM/DD', () => {
+    expect(formatMomentDate(d, 'YYYY/MM/DD')).toBe('2026/06/09');
+  });
+
+  it('formats D MMMM — single-digit day, literal month name preserved via []', () => {
+    expect(formatMomentDate(d, 'D [June] YYYY')).toBe('9 June 2026');
+  });
+
+  it('formats monthly YYYY-MM', () => {
+    expect(formatMomentDate(d, 'YYYY-MM')).toBe('2026-06');
+  });
+
+  it('formats quarterly YYYY-[Q]Q', () => {
+    expect(formatMomentDate(d, 'YYYY-[Q]Q')).toBe('2026-Q2');
+  });
+
+  it('formats yearly YYYY', () => {
+    expect(formatMomentDate(d, 'YYYY')).toBe('2026');
+  });
+
+  it('formats weekly gggg-[W]ww', () => {
+    expect(formatMomentDate(d, 'gggg-[W]ww')).toBe('2026-W24');
+  });
+
+  it('handles ISO week year boundary — 2019-12-30 is week 01 of 2020', () => {
+    const boundary = new Date('2019-12-30');
+    expect(formatMomentDate(boundary, 'gggg-[W]ww')).toBe('2020-W01');
+  });
+
+  it('preserves multiple literals', () => {
+    expect(formatMomentDate(d, '[Week] ww [of] YYYY')).toBe('Week 24 of 2026');
+  });
+});
+
+// ── resolveNotePath ───────────────────────────────────────────────────────────
+
+describe('resolveNotePath', () => {
+  it('places note in configured folder', () => {
+    const cfg = { folder: 'Journal', format: 'YYYY-MM-DD', template: '' };
+    expect(resolveNotePath(cfg, new Date('2026-06-09'))).toBe('Journal/2026-06-09.md');
+  });
+
+  it('places note at vault root when folder is empty', () => {
+    const cfg = { folder: '', format: 'YYYY-MM-DD', template: '' };
+    expect(resolveNotePath(cfg, new Date('2026-06-09'))).toBe('2026-06-09.md');
+  });
+
+  it('handles nested folder', () => {
+    const cfg = { folder: 'Notes/Daily', format: 'YYYY-MM-DD', template: '' };
+    expect(resolveNotePath(cfg, new Date('2026-01-01'))).toBe('Notes/Daily/2026-01-01.md');
+  });
+});
+
+// ── getPeriodicNote ───────────────────────────────────────────────────────────
+
+describe('getPeriodicNote', () => {
+  it('reports note as missing without creating when createIfMissing is false', async () => {
+    const ctx = freshCtx();
+    const result = await getPeriodicNote(ctx, {
+      period: 'daily',
+      date: '2026-01-01',
+      createIfMissing: false,
+    });
+    expect(result.existed).toBe(false);
+    expect(result.created).toBe(false);
+    expect(result.path).toBe('2026-01-01.md'); // default folder + format
+  });
+
+  it('creates the note when createIfMissing is true', async () => {
+    const ctx = freshCtx();
+    const result = await getPeriodicNote(ctx, {
+      period: 'daily',
+      date: '2026-01-02',
+      createIfMissing: true,
+    });
+    expect(result.created).toBe(true);
+    expect(result.existed).toBe(false);
+    const disk = await readFile(join(tmpDir, result.path), 'utf8');
+    expect(disk).toBe('');
+  });
+
+  it('reports note as existed when it already exists', async () => {
+    const ctx = freshCtx();
+    await writeFile(join(tmpDir, '2026-01-03.md'), '# Existing note', 'utf8');
+    const result = await getPeriodicNote(ctx, { period: 'daily', date: '2026-01-03' });
+    expect(result.existed).toBe(true);
+    expect(result.created).toBe(false);
+  });
+
+  it('reads config from .obsidian/daily-notes.json', async () => {
+    const vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-cfg-daily-'));
+    const ctx2 = { vaultRoot, index: freshCtx().index, notes: new Map(), backlinks: new Map() };
+    try {
+      await mkdir(join(vaultRoot, '.obsidian'), { recursive: true });
+      await writeFile(
+        join(vaultRoot, '.obsidian', 'daily-notes.json'),
+        JSON.stringify({ folder: 'Journal', format: 'YYYY-MM-DD' }),
+        'utf8',
+      );
+      const result = await getPeriodicNote(ctx2, {
+        period: 'daily',
+        date: '2026-05-29',
+        createIfMissing: false,
+      });
+      expect(result.path).toBe('Journal/2026-05-29.md');
+    } finally {
+      await rm(vaultRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('creates from template when template is configured', async () => {
+    const vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-cfg-template-'));
+    const ctx2 = { vaultRoot, index: freshCtx().index, notes: new Map(), backlinks: new Map() };
+    try {
+      await mkdir(join(vaultRoot, '.obsidian'), { recursive: true });
+      await mkdir(join(vaultRoot, 'Templates'), { recursive: true });
+      await writeFile(join(vaultRoot, 'Templates', 'daily.md'), '# Daily Note\n', 'utf8');
+      await writeFile(
+        join(vaultRoot, '.obsidian', 'daily-notes.json'),
+        JSON.stringify({ folder: '', format: 'YYYY-MM-DD', template: 'Templates/daily' }),
+        'utf8',
+      );
+      const result = await getPeriodicNote(ctx2, {
+        period: 'daily',
+        date: '2026-01-10',
+        createIfMissing: true,
+      });
+      expect(result.created).toBe(true);
+      const disk = await readFile(join(vaultRoot, result.path), 'utf8');
+      expect(disk).toBe('# Daily Note\n');
+    } finally {
+      await rm(vaultRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves weekly path from periodic-notes plugin config', async () => {
+    const vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-cfg-weekly-'));
+    const ctx2 = { vaultRoot, index: freshCtx().index, notes: new Map(), backlinks: new Map() };
+    try {
+      await mkdir(join(vaultRoot, '.obsidian', 'plugins', 'periodic-notes'), { recursive: true });
+      await writeFile(
+        join(vaultRoot, '.obsidian', 'plugins', 'periodic-notes', 'data.json'),
+        JSON.stringify({ weekly: { folder: 'Weekly', format: 'gggg-[W]ww' } }),
+        'utf8',
+      );
+      const result = await getPeriodicNote(ctx2, {
+        period: 'weekly',
+        date: '2026-06-09',
+        createIfMissing: false,
+      });
+      expect(result.path).toBe('Weekly/2026-W24.md');
+    } finally {
+      await rm(vaultRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('uses default format when no config file exists', async () => {
+    const vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-no-config-'));
+    const ctx2 = { vaultRoot, index: freshCtx().index, notes: new Map(), backlinks: new Map() };
+    try {
+      const result = await getPeriodicNote(ctx2, {
+        period: 'monthly',
+        date: '2026-06-09',
+        createIfMissing: false,
+      });
+      expect(result.path).toBe('2026-06.md');
+    } finally {
+      await rm(vaultRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a path outside the vault (folder config with ..)', async () => {
+    const vaultRoot = await mkdtemp(join(tmpdir(), 'seekstone-traversal-'));
+    const ctx2 = { vaultRoot, index: freshCtx().index, notes: new Map(), backlinks: new Map() };
+    try {
+      await mkdir(join(vaultRoot, '.obsidian'), { recursive: true });
+      await writeFile(
+        join(vaultRoot, '.obsidian', 'daily-notes.json'),
+        JSON.stringify({ folder: '../../etc', format: 'YYYY-MM-DD' }),
+        'utf8',
+      );
+      await expect(
+        getPeriodicNote(ctx2, { period: 'daily', date: '2026-01-01', createIfMissing: false }),
+      ).rejects.toThrow('Path outside vault');
+    } finally {
+      await rm(vaultRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── appendPeriodicNote ────────────────────────────────────────────────────────
+
+describe('appendPeriodicNote', () => {
+  it('creates and appends to a missing note when createIfMissing is true', async () => {
+    const ctx = freshCtx();
+    const result = await appendPeriodicNote(ctx, {
+      period: 'daily',
+      date: '2026-02-01',
+      content: 'First entry.',
+      createIfMissing: true,
+    });
+    expect(result.path).toBe('2026-02-01.md');
+    const disk = await readFile(join(tmpDir, result.path), 'utf8');
+    expect(disk).toBe('First entry.');
+  });
+
+  it('appends to an existing note preserving frontmatter', async () => {
+    const ctx = freshCtx();
+    const initial = '---\ntags: [daily]\n---\n\nMorning notes.';
+    await writeFile(join(tmpDir, '2026-02-02.md'), initial, 'utf8');
+    const result = await appendPeriodicNote(ctx, {
+      period: 'daily',
+      date: '2026-02-02',
+      content: 'Evening entry.',
+    });
+    const disk = await readFile(join(tmpDir, result.path), 'utf8');
+    expect(disk).toContain('---\ntags: [daily]\n---');
+    expect(disk).toContain('Morning notes.');
+    expect(disk).toContain('Evening entry.');
+  });
+
+  it('throws when note is missing and createIfMissing is false', async () => {
+    const ctx = freshCtx();
+    await expect(
+      appendPeriodicNote(ctx, {
+        period: 'daily',
+        date: '2026-03-01',
+        content: 'x',
+        createIfMissing: false,
+      }),
+    ).rejects.toThrow('not found');
+  });
+
+  it('returns bytesWritten matching actual file size', async () => {
+    const ctx = freshCtx();
+    await writeFile(join(tmpDir, '2026-02-03.md'), 'Existing content.', 'utf8');
+    const result = await appendPeriodicNote(ctx, {
+      period: 'daily',
+      date: '2026-02-03',
+      content: 'New line.',
+    });
+    const disk = await readFile(join(tmpDir, result.path));
+    expect(result.bytesWritten).toBe(disk.byteLength);
+  });
+});

--- a/packages/server/src/tools/periodic_note.ts
+++ b/packages/server/src/tools/periodic_note.ts
@@ -1,0 +1,256 @@
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { parseFrontmatter } from '@seekstone/core/frontmatter';
+import { z } from 'zod';
+import type { ServerContext } from '../context.js';
+import { buildDoc, upsertDoc } from '../index/doc.js';
+
+// ── Period type ───────────────────────────────────────────────────────────────
+
+const PERIOD = z.enum(['daily', 'weekly', 'monthly', 'quarterly', 'yearly']);
+type Period = z.infer<typeof PERIOD>;
+
+// ── Config shapes (read from .obsidian on disk) ───────────────────────────────
+
+interface PeriodicEntry {
+  folder?: string;
+  format?: string;
+  template?: string;
+}
+
+interface DailyNotesJson extends PeriodicEntry {}
+
+interface PeriodicNotesJson {
+  daily?: PeriodicEntry;
+  weekly?: PeriodicEntry;
+  monthly?: PeriodicEntry;
+  quarterly?: PeriodicEntry;
+  yearly?: PeriodicEntry;
+}
+
+const DEFAULTS: Record<Period, Required<PeriodicEntry>> = {
+  daily: { folder: '', format: 'YYYY-MM-DD', template: '' },
+  weekly: { folder: '', format: 'gggg-[W]ww', template: '' },
+  monthly: { folder: '', format: 'YYYY-MM', template: '' },
+  quarterly: { folder: '', format: 'YYYY-[Q]Q', template: '' },
+  yearly: { folder: '', format: 'YYYY', template: '' },
+};
+
+async function readJson<T>(absPath: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(absPath, 'utf8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveConfig(vaultRoot: string, period: Period): Promise<Required<PeriodicEntry>> {
+  const defaults = DEFAULTS[period];
+
+  if (period === 'daily') {
+    const cfg = await readJson<DailyNotesJson>(join(vaultRoot, '.obsidian', 'daily-notes.json'));
+    return {
+      folder: cfg?.folder ?? defaults.folder,
+      format: cfg?.format ?? defaults.format,
+      template: cfg?.template ?? defaults.template,
+    };
+  }
+
+  const cfg = await readJson<PeriodicNotesJson>(
+    join(vaultRoot, '.obsidian', 'plugins', 'periodic-notes', 'data.json'),
+  );
+  const entry = cfg?.[period];
+  return {
+    folder: entry?.folder ?? defaults.folder,
+    format: entry?.format ?? defaults.format,
+    template: entry?.template ?? defaults.template,
+  };
+}
+
+// ── Moment-style date formatting (no external dep) ───────────────────────────
+
+function isoWeekAndYear(date: Date): { week: number; year: number } {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = d.getUTCDay() || 7; // Mon=1 … Sun=7
+  d.setUTCDate(d.getUTCDate() + 4 - day); // nearest Thursday
+  const jan1 = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - jan1.getTime()) / 86_400_000 + 1) / 7);
+  return { week, year: d.getUTCFullYear() };
+}
+
+export function formatMomentDate(date: Date, format: string): string {
+  // Use UTC accessors: ISO date strings (YYYY-MM-DD) parse as UTC midnight,
+  // so local-time accessors would return the previous day in negative-offset
+  // timezones (EST, PST, etc.).
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth() + 1;
+  const day = date.getUTCDate();
+  const quarter = Math.ceil(month / 3);
+  const { week: isoWeek, year: isoYear } = isoWeekAndYear(date);
+
+  // Protect literal text in square brackets from token substitution.
+  const PLACEHOLDER = '\x00';
+  const literals: string[] = [];
+  let s = format.replace(/\[([^\]]*)\]/g, (_, lit) => {
+    literals.push(lit);
+    return `${PLACEHOLDER}${literals.length - 1}${PLACEHOLDER}`;
+  });
+
+  // Substitute longest tokens first to avoid partial matches (e.g. YYYY before YY).
+  s = s
+    .replace(/gggg/g, String(isoYear).padStart(4, '0'))
+    .replace(/YYYY/g, String(year).padStart(4, '0'))
+    .replace(/YY/g, String(year).slice(-2))
+    .replace(/MM/g, String(month).padStart(2, '0'))
+    .replace(/M/g, String(month))
+    .replace(/DD/g, String(day).padStart(2, '0'))
+    .replace(/D/g, String(day))
+    .replace(/ww/g, String(isoWeek).padStart(2, '0'))
+    .replace(/W/g, String(isoWeek))
+    .replace(/Q/g, String(quarter));
+
+  // Restore literals.
+  return s.replace(
+    new RegExp(`${PLACEHOLDER}(\\d+)${PLACEHOLDER}`, 'g'),
+    (_, i) => literals[+i] ?? '',
+  );
+}
+
+// ── Resolve a note path from config + date ────────────────────────────────────
+
+export function resolveNotePath(cfg: Required<PeriodicEntry>, date: Date): string {
+  const filename = `${formatMomentDate(date, cfg.format)}.md`;
+  return cfg.folder ? `${cfg.folder}/${filename}` : filename;
+}
+
+// ── Tool: get_periodic_note ───────────────────────────────────────────────────
+
+export const GetPeriodicNoteInput = z.object({
+  period: PERIOD.default('daily').describe(
+    'Period type: daily (default), weekly, monthly, quarterly, or yearly.',
+  ),
+  date: z
+    .string()
+    .optional()
+    .describe('ISO date string (YYYY-MM-DD). Defaults to today when omitted.'),
+  createIfMissing: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Create the note from the configured template if it does not exist. Default false — reports missing without creating.',
+    ),
+});
+export type GetPeriodicNoteInput = z.input<typeof GetPeriodicNoteInput>;
+
+export interface GetPeriodicNoteResult {
+  path: string;
+  existed: boolean;
+  created: boolean;
+}
+
+export async function getPeriodicNote(
+  ctx: ServerContext,
+  rawInput: GetPeriodicNoteInput,
+): Promise<GetPeriodicNoteResult> {
+  const input = GetPeriodicNoteInput.parse(rawInput);
+  const date = input.date ? new Date(input.date) : new Date();
+  const cfg = await resolveConfig(ctx.vaultRoot, input.period);
+  const path = resolveNotePath(cfg, date);
+  const abs = join(ctx.vaultRoot, path);
+
+  if (!abs.startsWith(ctx.vaultRoot)) throw new Error(`Path outside vault: ${path}`);
+
+  let existed = false;
+  try {
+    await access(abs);
+    existed = true;
+  } catch {}
+
+  if (existed) return { path, existed: true, created: false };
+
+  if (!input.createIfMissing) return { path, existed: false, created: false };
+
+  // Read template if configured.
+  let body = '';
+  if (cfg.template) {
+    const templateAbs = join(
+      ctx.vaultRoot,
+      cfg.template.endsWith('.md') ? cfg.template : `${cfg.template}.md`,
+    );
+    if (templateAbs.startsWith(ctx.vaultRoot)) {
+      try {
+        body = await readFile(templateAbs, 'utf8');
+      } catch {}
+    }
+  }
+
+  await mkdir(dirname(abs), { recursive: true });
+  await writeFile(abs, body, 'utf8');
+  upsertDoc(ctx, buildDoc(path, body));
+
+  return { path, existed: false, created: true };
+}
+
+// ── Tool: append_periodic_note ────────────────────────────────────────────────
+
+export const AppendPeriodicNoteInput = z.object({
+  period: PERIOD.default('daily').describe('Period type. Default: daily.'),
+  date: z.string().optional().describe('ISO date string (YYYY-MM-DD). Defaults to today.'),
+  content: z
+    .string()
+    .min(1)
+    .describe('Text to append to the note body. Separated from existing content by a blank line.'),
+  createIfMissing: z
+    .boolean()
+    .default(true)
+    .describe('Create the note if it does not exist before appending. Default true.'),
+});
+export type AppendPeriodicNoteInput = z.input<typeof AppendPeriodicNoteInput>;
+
+export interface AppendPeriodicNoteResult {
+  path: string;
+  bytesWritten: number;
+}
+
+export async function appendPeriodicNote(
+  ctx: ServerContext,
+  rawInput: AppendPeriodicNoteInput,
+): Promise<AppendPeriodicNoteResult> {
+  const input = AppendPeriodicNoteInput.parse(rawInput);
+  const date = input.date ? new Date(input.date) : new Date();
+  const cfg = await resolveConfig(ctx.vaultRoot, input.period);
+  const path = resolveNotePath(cfg, date);
+  const abs = join(ctx.vaultRoot, path);
+
+  if (!abs.startsWith(ctx.vaultRoot)) throw new Error(`Path outside vault: ${path}`);
+
+  let original = '';
+  try {
+    original = await readFile(abs, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    if (!input.createIfMissing) throw new Error(`Periodic note not found: ${path}`);
+    await mkdir(dirname(abs), { recursive: true });
+    await writeFile(abs, input.content, 'utf8');
+    upsertDoc(ctx, buildDoc(path, input.content));
+    return { path, bytesWritten: Buffer.byteLength(input.content, 'utf8') };
+  }
+
+  // Preserve frontmatter, append to body.
+  const fm = parseFrontmatter(original);
+  const body = fm.body.endsWith('\n') ? fm.body : `${fm.body}\n`;
+  const separator = body.endsWith('\n\n') ? '' : '\n';
+  const newBody = `${body}${separator}${input.content}`;
+  const header = original.slice(0, fm.bodyStart);
+  const newRaw = `${header}${newBody}`;
+
+  await writeFile(abs, newRaw, 'utf8');
+
+  const cached = ctx.notes.get(path);
+  if (cached) {
+    cached.body = newBody;
+    cached.raw = newRaw;
+  }
+
+  return { path, bytesWritten: Buffer.byteLength(newRaw, 'utf8') };
+}


### PR DESCRIPTION
## Summary

- Adds `get_periodic_note` — resolves and optionally creates a periodic note (daily/weekly/monthly/quarterly/yearly) for a given date, reading folder/format/template config from `.obsidian/daily-notes.json` and the periodic-notes plugin `data.json`
- Adds `append_periodic_note` — appends text to a periodic note, preserving frontmatter byte-for-byte, creating from template if missing
- Moment-style date token formatter (`YYYY`, `MM`, `DD`, `gggg`, `ww`, `Q`, etc.) with ISO 8601 week year boundary handling and UTC accessors so ISO date strings are correct in every timezone

## Test plan

- [x] 25 unit tests covering `formatMomentDate`, `resolveNotePath`, `getPeriodicNote`, `appendPeriodicNote`
- [x] ISO week year boundary test (`2019-12-30` → week 01 of 2020)
- [x] UTC timezone correctness (no off-by-one day in EST/PST)
- [x] Config reading from both daily-notes.json and periodic-notes plugin
- [x] Template instantiation, createIfMissing, frontmatter preservation
- [x] Path traversal rejection
- [x] `npm test` → 260/260 passing
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] Changeset added (minor bump)

Closes SHA-24