### PR TITLE
feat(harness): expand benchmark harness with SeekstoneAdapter and extended tool coverage (SHA-127)

### DIFF
--- a/packages/harness/queries/default.json
+++ b/packages/harness/queries/default.json
@@ -28,8 +28,8 @@
     }
   ],
   "reads": {
-    "small": null,
-    "large": null,
+    "small": "Daily Notes/2026-05-17.md",
+    "large": "2 Personal/1.2 Projects/Market Problem Discovery/01-inventory.md",
     "_hint": "After running `harness profile`, paste a small (~2 KB) and large (>50 KB) note path from vault-stats.json here. Leave null to auto-pick from the stats file."
   },
   "runs": 20,

--- a/packages/harness/src/bench/adapters/mcp-obsidian.ts
+++ b/packages/harness/src/bench/adapters/mcp-obsidian.ts
@@ -1,0 +1,107 @@
+import type { Backend, BackendResponse, ListEntry, SearchHit } from '../backend.js';
+import { McpSubprocess } from './mcp-subprocess.js';
+
+/**
+ * Adapter for mcp-obsidian by MarkusPfundstein.
+ * https://github.com/MarkusPfundstein/mcp-obsidian
+ *
+ * Python-based, REST API architecture — requires Obsidian running with the
+ * Local REST API plugin. Spawned via `uvx mcp-obsidian`.
+ *
+ * Tool mapping:
+ *   obsidian_simple_search      → search(query)
+ *   obsidian_get_file_contents  → read(path)
+ *   obsidian_put_content        → write(path, content)
+ *   obsidian_list_files_in_vault / obsidian_list_files_in_dir → list(path?)
+ */
+
+export interface McpObsidianAdapterOptions {
+  /** Bearer token from Obsidian Local REST API plugin settings. */
+  apiKey: string;
+  /** Obsidian REST API host. Defaults to 127.0.0.1. */
+  host?: string;
+  /** Obsidian REST API port. Defaults to 27124. */
+  port?: number;
+  /** Protocol, 'https' or 'http'. Defaults to 'https'. */
+  protocol?: string;
+  /** Override the spawn command. Defaults to ['uvx', 'mcp-obsidian']. */
+  cmd?: string[];
+}
+
+export class McpObsidianAdapter implements Backend {
+  readonly name = 'mcp-obsidian';
+  readonly description = 'mcp-obsidian (MarkusPfundstein, REST API, requires Obsidian running)';
+
+  private constructor(private readonly mcp: McpSubprocess) {}
+
+  static async build(opts: McpObsidianAdapterOptions): Promise<McpObsidianAdapter> {
+    const cmd = opts.cmd ??
+      process.env.SEEKSTONE_MCP_OBSIDIAN_CMD?.split(' ') ?? ['uvx', 'mcp-obsidian'];
+    const env: Record<string, string> = {
+      OBSIDIAN_API_KEY: opts.apiKey,
+      OBSIDIAN_HOST: opts.host ?? '127.0.0.1',
+      OBSIDIAN_PORT: String(opts.port ?? 27124),
+      OBSIDIAN_PROTOCOL: opts.protocol ?? 'https',
+    };
+    const mcp = await McpSubprocess.connect('mcp-obsidian', cmd, { env, initTimeout: 60_000 });
+    return new McpObsidianAdapter(mcp);
+  }
+
+  async close(): Promise<void> {
+    return this.mcp.close();
+  }
+
+  async search(query: string): Promise<BackendResponse<SearchHit[]>> {
+    const text = await this.mcp.callTool('obsidian_simple_search', {
+      query,
+      context_length: 200,
+    });
+    let hits: SearchHit[] = [];
+    try {
+      // Obsidian REST /search/simple/ → [{ filename, result: { score, matches: [{ context }] } }]
+      const raw = JSON.parse(text) as Array<{
+        filename?: string;
+        result?: { score?: number; matches?: Array<{ context?: string }> };
+      }>;
+      if (Array.isArray(raw)) {
+        hits = raw.map((r) => ({
+          path: r.filename ?? '',
+          score: r.result?.score,
+          snippet: r.result?.matches?.[0]?.context,
+        }));
+      }
+    } catch {
+      /* non-JSON or empty string */
+    }
+    return { result: hits, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async read(path: string): Promise<BackendResponse<string>> {
+    const text = await this.mcp.callTool('obsidian_get_file_contents', { filepath: path });
+    return { result: text, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async write(path: string, content: string): Promise<BackendResponse<void>> {
+    await this.mcp.callTool('obsidian_put_content', { filepath: path, content });
+    return { result: undefined, payloadBytes: Buffer.byteLength(content, 'utf8') };
+  }
+
+  async list(path?: string): Promise<BackendResponse<ListEntry[]>> {
+    const text = path
+      ? await this.mcp.callTool('obsidian_list_files_in_dir', { dirpath: path })
+      : await this.mcp.callTool('obsidian_list_files_in_vault', {});
+    let entries: ListEntry[] = [];
+    try {
+      // Obsidian REST /vault/ → { files: ["dir/", "note.md", ...] }
+      const raw = JSON.parse(text) as { files?: string[] } | string[];
+      const files = Array.isArray(raw) ? raw : (raw.files ?? []);
+      entries = (files as string[]).map((f) => ({
+        path: f.endsWith('/') ? f.slice(0, -1) : f,
+        isDirectory: f.endsWith('/'),
+      }));
+    } catch {
+      /* ignore */
+    }
+    return { result: entries, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+}

--- a/packages/harness/src/bench/adapters/mcp-subprocess.ts
+++ b/packages/harness/src/bench/adapters/mcp-subprocess.ts
@@ -1,0 +1,130 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { type Interface, createInterface } from 'node:readline';
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: number;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id?: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export interface McpToolResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}
+
+/**
+ * Shared MCP JSON-RPC stdio subprocess handler.
+ * Spawns a process, performs the initialize handshake, and provides
+ * callTool() for all three competitor adapters to share.
+ */
+export class McpSubprocess {
+  private nextId = 1;
+  private readonly pending = new Map<
+    number,
+    {
+      resolve: (v: JsonRpcResponse) => void;
+      reject: (e: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  private constructor(
+    private readonly proc: ChildProcess,
+    private readonly rl: Interface,
+    private readonly stdin_: NodeJS.WritableStream,
+    private readonly serverName: string,
+  ) {}
+
+  static async connect(
+    serverName: string,
+    cmd: string[],
+    opts: { env?: Record<string, string>; initTimeout?: number } = {},
+  ): Promise<McpSubprocess> {
+    const [bin, ...args] = cmd;
+    const proc = spawn(bin ?? '', args, {
+      stdio: ['pipe', 'pipe', 'ignore'],
+      env: { ...process.env, ...opts.env },
+    });
+
+    const rl = createInterface({ input: proc.stdout as NodeJS.ReadableStream });
+    const sub = new McpSubprocess(proc, rl, proc.stdin as NodeJS.WritableStream, serverName);
+
+    rl.on('line', (line) => {
+      if (!line.trim()) return;
+      let msg: JsonRpcResponse;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (msg.id == null) return;
+      const waiter = sub.pending.get(msg.id as number);
+      if (!waiter) return;
+      sub.pending.delete(msg.id as number);
+      clearTimeout(waiter.timer);
+      if (msg.error) {
+        waiter.reject(new Error(`${serverName} ${msg.error.code}: ${msg.error.message}`));
+      } else {
+        waiter.resolve(msg);
+      }
+    });
+
+    await sub.rpc(
+      'initialize',
+      {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'seekstone-harness', version: '1.0' },
+      },
+      opts.initTimeout ?? 30_000,
+    );
+    sub.notify('notifications/initialized', {});
+    return sub;
+  }
+
+  async callTool(name: string, args: Record<string, unknown>, timeout = 60_000): Promise<string> {
+    const resp = await this.rpc('tools/call', { name, arguments: args }, timeout);
+    const tool = resp.result as McpToolResult;
+    if (tool?.isError) {
+      throw new Error(`${this.serverName} ${name}: ${tool.content?.[0]?.text ?? 'error'}`);
+    }
+    return tool?.content?.[0]?.text ?? '';
+  }
+
+  async close(): Promise<void> {
+    for (const [, w] of this.pending) {
+      clearTimeout(w.timer);
+      w.reject(new Error('closed'));
+    }
+    this.pending.clear();
+    this.rl.close();
+    this.proc.kill();
+    await new Promise<void>((res) => this.proc.once('exit', res));
+  }
+
+  private rpc(method: string, params: unknown, timeout = 60_000): Promise<JsonRpcResponse> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${this.serverName} timeout: ${method}`));
+      }, timeout);
+      this.pending.set(id, { resolve, reject, timer });
+      this.stdin_.write(
+        `${JSON.stringify({ jsonrpc: '2.0', id, method, params } as JsonRpcRequest)}\n`,
+      );
+    });
+  }
+
+  private notify(method: string, params: unknown): void {
+    this.stdin_.write(`${JSON.stringify({ jsonrpc: '2.0', method, params } as JsonRpcRequest)}\n`);
+  }
+}

--- a/packages/harness/src/bench/adapters/obsidian-mcp-pro.ts
+++ b/packages/harness/src/bench/adapters/obsidian-mcp-pro.ts
@@ -1,0 +1,112 @@
+import type { Backend, BackendResponse, ListEntry, SearchHit } from '../backend.js';
+import { McpSubprocess } from './mcp-subprocess.js';
+
+/**
+ * Adapter for obsidian-mcp-pro by rps321321.
+ * https://github.com/rps321321/obsidian-mcp-pro
+ *
+ * TypeScript, filesystem-direct — does NOT require Obsidian running.
+ * Vault path passed via OBSIDIAN_VAULT_PATH env var.
+ *
+ * Tool mapping:
+ *   search_notes → search(query)
+ *   get_note     → read(path)
+ *   create_note  → write(path, content)
+ *   list_notes   → list(path?)
+ */
+
+export interface ObsidianMcpProAdapterOptions {
+  /** Absolute path to the vault root. */
+  vaultRoot: string;
+  /** Override the spawn command. Defaults to ['npx', '-y', 'obsidian-mcp-pro']. */
+  cmd?: string[];
+}
+
+export class ObsidianMcpProAdapter implements Backend {
+  readonly name = 'obsidian-mcp-pro';
+  readonly description = 'obsidian-mcp-pro (rps321321, filesystem-direct, no Obsidian required)';
+
+  private constructor(private readonly mcp: McpSubprocess) {}
+
+  static async build(opts: ObsidianMcpProAdapterOptions): Promise<ObsidianMcpProAdapter> {
+    const cmd = opts.cmd ??
+      process.env.SEEKSTONE_OBSIDIAN_MCP_PRO_CMD?.split(' ') ?? ['npx', '-y', 'obsidian-mcp-pro'];
+    const env: Record<string, string> = {
+      OBSIDIAN_VAULT_PATH: opts.vaultRoot,
+    };
+    const mcp = await McpSubprocess.connect('obsidian-mcp-pro', cmd, {
+      env,
+      initTimeout: 60_000,
+    });
+    return new ObsidianMcpProAdapter(mcp);
+  }
+
+  async close(): Promise<void> {
+    return this.mcp.close();
+  }
+
+  async search(query: string): Promise<BackendResponse<SearchHit[]>> {
+    const text = await this.mcp.callTool('search_notes', {
+      query,
+      maxResults: 10,
+    });
+    let hits: SearchHit[] = [];
+    try {
+      const parsed = JSON.parse(text) as
+        | Array<{
+            path?: string;
+            score?: number;
+            excerpt?: string;
+            snippet?: string;
+            matches?: Array<{ context?: string }>;
+          }>
+        | { results?: Array<{ path?: string; score?: number; excerpt?: string }> };
+      const raw = Array.isArray(parsed) ? parsed : (parsed.results ?? []);
+      hits = raw.map((h) => ({
+        path: h.path ?? '',
+        score: h.score,
+        snippet: h.excerpt ?? h.snippet ?? h.matches?.[0]?.context,
+      }));
+    } catch {
+      /* plain-text response */
+    }
+    return { result: hits, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async read(path: string): Promise<BackendResponse<string>> {
+    const text = await this.mcp.callTool('get_note', { path });
+    return { result: text, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async write(path: string, content: string): Promise<BackendResponse<void>> {
+    await this.mcp.callTool('create_note', { path, content });
+    return { result: undefined, payloadBytes: Buffer.byteLength(content, 'utf8') };
+  }
+
+  async list(path?: string): Promise<BackendResponse<ListEntry[]>> {
+    const args: Record<string, unknown> = { limit: 500 };
+    if (path) args.folder = path;
+    const text = await this.mcp.callTool('list_notes', args);
+    let entries: ListEntry[] = [];
+    try {
+      const parsed = JSON.parse(text) as
+        | Array<{ path?: string; isDirectory?: boolean }>
+        | { notes?: Array<{ path?: string }>; paths?: string[] };
+      if (Array.isArray(parsed)) {
+        entries = parsed.map((n) => ({ path: n.path ?? '', isDirectory: n.isDirectory ?? false }));
+      } else if (parsed.notes) {
+        entries = parsed.notes.map((n) => ({ path: n.path ?? '', isDirectory: false }));
+      } else if (parsed.paths) {
+        entries = parsed.paths.map((p) => ({ path: p, isDirectory: false }));
+      }
+    } catch {
+      /* plain-text path listing */
+      entries = text
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .map((p) => ({ path: p, isDirectory: false }));
+    }
+    return { result: entries, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+}

--- a/packages/harness/src/bench/adapters/obsidian-mcp-pro.ts
+++ b/packages/harness/src/bench/adapters/obsidian-mcp-pro.ts
@@ -52,15 +52,14 @@ export class ObsidianMcpProAdapter implements Backend {
     });
     let hits: SearchHit[] = [];
     try {
-      const parsed = JSON.parse(text) as
-        | Array<{
-            path?: string;
-            score?: number;
-            excerpt?: string;
-            snippet?: string;
-            matches?: Array<{ context?: string }>;
-          }>
-        | { results?: Array<{ path?: string; score?: number; excerpt?: string }> };
+      type RawHit = {
+        path?: string;
+        score?: number;
+        excerpt?: string;
+        snippet?: string;
+        matches?: Array<{ context?: string }>;
+      };
+      const parsed = JSON.parse(text) as Array<RawHit> | { results?: Array<RawHit> };
       const raw = Array.isArray(parsed) ? parsed : (parsed.results ?? []);
       hits = raw.map((h) => ({
         path: h.path ?? '',

--- a/packages/harness/src/bench/adapters/obsidian-mcp-server.ts
+++ b/packages/harness/src/bench/adapters/obsidian-mcp-server.ts
@@ -1,0 +1,129 @@
+import type { Backend, BackendResponse, ListEntry, SearchHit } from '../backend.js';
+import { McpSubprocess } from './mcp-subprocess.js';
+
+/**
+ * Adapter for obsidian-mcp-server by cyanheads.
+ * https://github.com/cyanheads/obsidian-mcp-server
+ *
+ * TypeScript, REST API architecture — requires Obsidian running with the
+ * Local REST API plugin. Spawned via `npx obsidian-mcp-server` with
+ * OBSIDIAN_API_KEY and OBSIDIAN_BASE_URL env vars.
+ *
+ * Tool mapping:
+ *   obsidian_search_notes → search(query)
+ *   obsidian_get_note     → read(path)
+ *   obsidian_write_note   → write(path, content)
+ *   obsidian_list_notes   → list(path?)
+ */
+
+export interface ObsidianMcpServerAdapterOptions {
+  /** Bearer token from Obsidian Local REST API plugin settings. */
+  apiKey: string;
+  /**
+   * Obsidian REST API base URL.
+   * Defaults to https://127.0.0.1:27124 (the Local REST API plugin default).
+   */
+  baseUrl?: string;
+  /** Override the spawn command. Defaults to ['npx', '--yes', 'obsidian-mcp-server']. */
+  cmd?: string[];
+}
+
+export class ObsidianMcpServerAdapter implements Backend {
+  readonly name = 'obsidian-mcp-server';
+  readonly description = 'obsidian-mcp-server (cyanheads, REST API, requires Obsidian running)';
+
+  private constructor(private readonly mcp: McpSubprocess) {}
+
+  static async build(opts: ObsidianMcpServerAdapterOptions): Promise<ObsidianMcpServerAdapter> {
+    const cmd = opts.cmd ??
+      process.env.SEEKSTONE_OBSIDIAN_MCP_SERVER_CMD?.split(' ') ?? [
+        'npx',
+        '--yes',
+        'obsidian-mcp-server',
+      ];
+    const env: Record<string, string> = {
+      OBSIDIAN_API_KEY: opts.apiKey,
+      OBSIDIAN_BASE_URL: opts.baseUrl ?? 'https://127.0.0.1:27124',
+      OBSIDIAN_VERIFY_SSL: 'false',
+      MCP_TRANSPORT_TYPE: 'stdio',
+    };
+    const mcp = await McpSubprocess.connect('obsidian-mcp-server', cmd, {
+      env,
+      initTimeout: 60_000,
+    });
+    return new ObsidianMcpServerAdapter(mcp);
+  }
+
+  async close(): Promise<void> {
+    return this.mcp.close();
+  }
+
+  async search(query: string): Promise<BackendResponse<SearchHit[]>> {
+    const text = await this.mcp.callTool('obsidian_search_notes', {
+      mode: 'text',
+      query,
+      contextLength: 200,
+    });
+    let hits: SearchHit[] = [];
+    try {
+      // Response: { result: { mode, hits: [{ path, score, matches: [{ context }] }], totalCount } }
+      const parsed = JSON.parse(text) as {
+        result?: {
+          hits?: Array<{
+            path?: string;
+            score?: number;
+            matches?: Array<{ context?: string }>;
+          }>;
+        };
+      };
+      const rawHits = parsed.result?.hits ?? [];
+      hits = rawHits.map((h) => ({
+        path: h.path ?? '',
+        score: h.score,
+        snippet: h.matches?.[0]?.context,
+      }));
+    } catch {
+      /* non-JSON response */
+    }
+    return { result: hits, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async read(path: string): Promise<BackendResponse<string>> {
+    const text = await this.mcp.callTool('obsidian_get_note', {
+      format: 'content',
+      target: { type: 'path', path },
+    });
+    return { result: text, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async write(path: string, content: string): Promise<BackendResponse<void>> {
+    await this.mcp.callTool('obsidian_write_note', {
+      target: { type: 'path', path },
+      content,
+      overwrite: true,
+    });
+    return { result: undefined, payloadBytes: Buffer.byteLength(content, 'utf8') };
+  }
+
+  async list(path?: string): Promise<BackendResponse<ListEntry[]>> {
+    const text = await this.mcp.callTool('obsidian_list_notes', {
+      ...(path ? { path } : {}),
+      depth: 1,
+    });
+    let entries: ListEntry[] = [];
+    try {
+      // Response: { result: { notes: [{ path, ... }] } } or flat array
+      const parsed = JSON.parse(text) as
+        | { result?: { notes?: Array<{ path?: string; isDirectory?: boolean }> } }
+        | Array<{ path?: string; isDirectory?: boolean }>;
+      const notes = Array.isArray(parsed) ? parsed : (parsed.result?.notes ?? []);
+      entries = (notes as Array<{ path?: string; isDirectory?: boolean }>).map((n) => ({
+        path: n.path ?? '',
+        isDirectory: n.isDirectory ?? false,
+      }));
+    } catch {
+      /* ignore */
+    }
+    return { result: entries, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+}

--- a/packages/harness/src/bench/adapters/obsidian-mcp.ts
+++ b/packages/harness/src/bench/adapters/obsidian-mcp.ts
@@ -1,0 +1,136 @@
+import type { Backend, BackendResponse, ListEntry, SearchHit } from '../backend.js';
+import { McpSubprocess } from './mcp-subprocess.js';
+
+/**
+ * Adapter for obsidian-mcp by StevenStavrakis.
+ * https://github.com/StevenStavrakis/obsidian-mcp
+ *
+ * TypeScript, filesystem-direct — does NOT require Obsidian running.
+ * Vault path is passed as a positional CLI argument.
+ * All tools include a `vault` parameter using a sanitized vault name
+ * derived from the last path component.
+ *
+ * Tool mapping:
+ *   search-vault          → search(query)
+ *   read-note             → read(path)
+ *   edit-note             → write(path, content)
+ *   list-available-vaults → list(path?)
+ */
+
+export interface ObsidianMcpAdapterOptions {
+  /** Absolute path to the vault root. Passed as a positional CLI argument. */
+  vaultRoot: string;
+  /** Override the spawn command. Vault path is appended automatically. */
+  cmd?: string[];
+}
+
+function sanitizeVaultName(vaultRoot: string): string {
+  const last = vaultRoot.split('/').filter(Boolean).at(-1) ?? 'vault';
+  // obsidian-mcp lowercases and converts spaces/special chars to hyphens
+  return last
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function splitPath(path: string): { filename: string; folder?: string } {
+  const lastSlash = path.lastIndexOf('/');
+  if (lastSlash === -1) return { filename: path };
+  return { filename: path.slice(lastSlash + 1), folder: path.slice(0, lastSlash) };
+}
+
+export class ObsidianMcpAdapter implements Backend {
+  readonly name = 'obsidian-mcp';
+  readonly description = 'obsidian-mcp (StevenStavrakis, filesystem-direct, no Obsidian required)';
+
+  private constructor(
+    private readonly mcp: McpSubprocess,
+    private readonly vaultName: string,
+  ) {}
+
+  static async build(opts: ObsidianMcpAdapterOptions): Promise<ObsidianMcpAdapter> {
+    const baseParts = opts.cmd ??
+      process.env.SEEKSTONE_OBSIDIAN_MCP_CMD?.split(' ') ?? ['npx', '--yes', 'obsidian-mcp'];
+    const cmd = [...baseParts, opts.vaultRoot];
+    const vaultName = sanitizeVaultName(opts.vaultRoot);
+    const mcp = await McpSubprocess.connect('obsidian-mcp', cmd, { initTimeout: 60_000 });
+    return new ObsidianMcpAdapter(mcp, vaultName);
+  }
+
+  async close(): Promise<void> {
+    return this.mcp.close();
+  }
+
+  async search(query: string): Promise<BackendResponse<SearchHit[]>> {
+    const text = await this.mcp.callTool('search-vault', {
+      vault: this.vaultName,
+      query,
+      searchType: 'content',
+    });
+    const hits: SearchHit[] = [];
+    try {
+      // Response may be JSON array or formatted text; best-effort parse
+      const raw = JSON.parse(text) as Array<{
+        path?: string;
+        filename?: string;
+        excerpt?: string;
+        context?: string;
+        score?: number;
+      }>;
+      if (Array.isArray(raw)) {
+        for (const r of raw) {
+          hits.push({
+            path: r.path ?? r.filename ?? '',
+            score: r.score,
+            snippet: r.excerpt ?? r.context,
+          });
+        }
+      }
+    } catch {
+      /* plain-text response — hits stay empty; payload bytes still measured */
+    }
+    return { result: hits, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async read(path: string): Promise<BackendResponse<string>> {
+    const { filename, folder } = splitPath(path);
+    const args: Record<string, unknown> = { vault: this.vaultName, filename };
+    if (folder) args.folder = folder;
+    const text = await this.mcp.callTool('read-note', args);
+    return { result: text, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+
+  async write(path: string, content: string): Promise<BackendResponse<void>> {
+    const { filename, folder } = splitPath(path);
+    const args: Record<string, unknown> = {
+      vault: this.vaultName,
+      filename,
+      operation: 'replace',
+      content,
+    };
+    if (folder) args.folder = folder;
+    await this.mcp.callTool('edit-note', args);
+    return { result: undefined, payloadBytes: Buffer.byteLength(content, 'utf8') };
+  }
+
+  async list(_path?: string): Promise<BackendResponse<ListEntry[]>> {
+    const text = await this.mcp.callTool('list-available-vaults', {});
+    // This server only exposes vault-level metadata, not a note listing —
+    // payload is the raw response; entries reflect what the tool actually returns.
+    let entries: ListEntry[] = [];
+    try {
+      const raw = JSON.parse(text) as
+        | Array<{ name?: string; path?: string }>
+        | { vaults?: Array<{ name?: string; path?: string }> };
+      const vaults = Array.isArray(raw) ? raw : (raw.vaults ?? []);
+      entries = vaults.map((v) => ({
+        path: v.path ?? v.name ?? '',
+        isDirectory: true,
+      }));
+    } catch {
+      /* single vault entry fallback */
+      entries = [{ path: this.vaultName, isDirectory: true }];
+    }
+    return { result: entries, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+  }
+}

--- a/packages/harness/src/bench/adapters/seekstone.ts
+++ b/packages/harness/src/bench/adapters/seekstone.ts
@@ -7,7 +7,6 @@ import { getLinks as getLinksTool } from '../../../../server/src/tools/get_links
 import { listNotes } from '../../../../server/src/tools/list_notes.js';
 import { listTags as listTagsTool } from '../../../../server/src/tools/list_tags.js';
 import { outlineNote } from '../../../../server/src/tools/outline_note.js';
-import { getPeriodicNote } from '../../../../server/src/tools/periodic_note.js';
 import { readNote } from '../../../../server/src/tools/read_note.js';
 import { search as searchTool } from '../../../../server/src/tools/search.js';
 import type { Backend, BackendResponse, ListEntry, SearchHit } from '../backend.js';
@@ -118,16 +117,6 @@ export class SeekstoneAdapter implements Backend {
 
   async getLinks(path: string): Promise<BackendResponse<unknown>> {
     const result = await getLinksTool(this.ctx, { path });
-    const payload = JSON.stringify(result);
-    return {
-      result,
-      payloadBytes: Buffer.byteLength(payload, 'utf8'),
-      payloadText: payload,
-    };
-  }
-
-  async getPeriodicNote(period = 'daily', date?: string): Promise<BackendResponse<unknown>> {
-    const result = await getPeriodicNote(this.ctx, { period: period as 'daily', date });
     const payload = JSON.stringify(result);
     return {
       result,

--- a/packages/harness/src/bench/adapters/seekstone.ts
+++ b/packages/harness/src/bench/adapters/seekstone.ts
@@ -1,0 +1,138 @@
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { ServerContext } from '../../../../server/src/context.js';
+import { buildIndex } from '../../../../server/src/index/build.js';
+import { getBacklinks as getBacklinksTool } from '../../../../server/src/tools/get_backlinks.js';
+import { getLinks as getLinksTool } from '../../../../server/src/tools/get_links.js';
+import { listNotes } from '../../../../server/src/tools/list_notes.js';
+import { listTags as listTagsTool } from '../../../../server/src/tools/list_tags.js';
+import { outlineNote } from '../../../../server/src/tools/outline_note.js';
+import { getPeriodicNote } from '../../../../server/src/tools/periodic_note.js';
+import { readNote } from '../../../../server/src/tools/read_note.js';
+import { search as searchTool } from '../../../../server/src/tools/search.js';
+import type { Backend, BackendResponse, ListEntry, SearchHit } from '../backend.js';
+
+export interface SeekstoneAdapterOptions {
+  vaultRoot: string;
+}
+
+/**
+ * Seekstone-direct adapter: calls the server's own tool handler functions in-process.
+ * Zero serialization overhead beyond JSON.stringify for payload measurement.
+ * This is the most accurate benchmark of what seekstone's algorithms cost —
+ * no MCP transport, no subprocess, no IPC.
+ */
+export class SeekstoneAdapter implements Backend {
+  readonly name = 'seekstone';
+  readonly description = 'Seekstone server (in-process function calls, no IPC)';
+
+  private readonly ctx: ServerContext;
+
+  private constructor(ctx: ServerContext) {
+    this.ctx = ctx;
+  }
+
+  static async build(opts: SeekstoneAdapterOptions): Promise<SeekstoneAdapter> {
+    const { index, notes, backlinks } = await buildIndex(opts.vaultRoot);
+    const ctx: ServerContext = { vaultRoot: opts.vaultRoot, index, notes, backlinks };
+    return new SeekstoneAdapter(ctx);
+  }
+
+  async search(query: string): Promise<BackendResponse<SearchHit[]>> {
+    const hits = searchTool(this.ctx, { query, limit: 10 });
+    const payload = JSON.stringify(hits);
+    const mapped: SearchHit[] = hits.map((h) => ({
+      path: h.path,
+      score: h.score,
+      snippet: h.excerpt,
+    }));
+    return {
+      result: mapped,
+      payloadBytes: Buffer.byteLength(payload, 'utf8'),
+      payloadText: payload,
+    };
+  }
+
+  async *searchStream(query: string): AsyncGenerator<SearchHit> {
+    const hits = searchTool(this.ctx, { query, limit: 10 });
+    for (const h of hits) {
+      yield { path: h.path, score: h.score, snippet: h.excerpt };
+    }
+  }
+
+  async read(path: string): Promise<BackendResponse<string>> {
+    const result = await readNote(this.ctx, { path });
+    return {
+      result: result.content,
+      payloadBytes: result.bytesReturned,
+      payloadText: result.content,
+    };
+  }
+
+  async write(path: string, content: string): Promise<BackendResponse<void>> {
+    const buf = Buffer.from(content, 'utf8');
+    await writeFile(join(this.ctx.vaultRoot, path), buf);
+    return { result: undefined, payloadBytes: buf.byteLength };
+  }
+
+  async list(path?: string): Promise<BackendResponse<ListEntry[]>> {
+    const notes = listNotes(this.ctx, { folder: path, limit: 500 });
+    const entries: ListEntry[] = notes.map((n) => ({ path: n.path, isDirectory: false }));
+    const payload = JSON.stringify(entries);
+    return {
+      result: entries,
+      payloadBytes: Buffer.byteLength(payload, 'utf8'),
+      payloadText: payload,
+    };
+  }
+
+  async listTags(): Promise<BackendResponse<unknown>> {
+    const result = listTagsTool(this.ctx, { sort: 'count' });
+    const payload = JSON.stringify(result);
+    return {
+      result,
+      payloadBytes: Buffer.byteLength(payload, 'utf8'),
+      payloadText: payload,
+    };
+  }
+
+  async outline(path: string): Promise<BackendResponse<unknown>> {
+    const result = await outlineNote(this.ctx, { path, includeBlocks: true, includeSizes: false });
+    const payload = JSON.stringify(result);
+    return {
+      result,
+      payloadBytes: Buffer.byteLength(payload, 'utf8'),
+      payloadText: payload,
+    };
+  }
+
+  async getBacklinks(path: string): Promise<BackendResponse<unknown>> {
+    const result = await getBacklinksTool(this.ctx, { path });
+    const payload = JSON.stringify(result);
+    return {
+      result,
+      payloadBytes: Buffer.byteLength(payload, 'utf8'),
+      payloadText: payload,
+    };
+  }
+
+  async getLinks(path: string): Promise<BackendResponse<unknown>> {
+    const result = await getLinksTool(this.ctx, { path });
+    const payload = JSON.stringify(result);
+    return {
+      result,
+      payloadBytes: Buffer.byteLength(payload, 'utf8'),
+      payloadText: payload,
+    };
+  }
+
+  async getPeriodicNote(period = 'daily', date?: string): Promise<BackendResponse<unknown>> {
+    const result = await getPeriodicNote(this.ctx, { period: period as 'daily', date });
+    const payload = JSON.stringify(result);
+    return {
+      result,
+      payloadBytes: Buffer.byteLength(payload, 'utf8'),
+      payloadText: payload,
+    };
+  }
+}

--- a/packages/harness/src/bench/backend.ts
+++ b/packages/harness/src/bench/backend.ts
@@ -31,7 +31,7 @@ export interface ListEntry {
 }
 
 export interface Backend {
-  /** Stable, short name used in report tables. e.g. "rest", "fs". */
+  /** Stable, short name used in report tables. e.g. "rest", "fs", "seekstone". */
   readonly name: string;
   /** Human-readable description shown in benchmark.md. */
   readonly description: string;
@@ -53,6 +53,23 @@ export interface Backend {
    */
   write(path: string, content: string): Promise<BackendResponse<void>>;
   list(path?: string): Promise<BackendResponse<ListEntry[]>>;
+
+  /**
+   * Extended tool methods. Optional — backends that do not implement a method
+   * simply omit it. The runner records `null` for unsupported tools so the
+   * comparison report can show a ✅/❌ support matrix.
+   */
+
+  /** list_tags — all tags with usage counts. */
+  listTags?(): Promise<BackendResponse<unknown>>;
+  /** outline_note — heading tree + block anchors without body content. */
+  outline?(path: string): Promise<BackendResponse<unknown>>;
+  /** get_backlinks — reverse-link lookup. */
+  getBacklinks?(path: string): Promise<BackendResponse<unknown>>;
+  /** get_links — outgoing wikilink/embed enumeration. */
+  getLinks?(path: string): Promise<BackendResponse<unknown>>;
+  /** get_periodic_note — resolve today's or a given date's periodic note path. */
+  getPeriodicNote?(period?: string, date?: string): Promise<BackendResponse<unknown>>;
 
   /** Optional cleanup (close keep-alive connections, etc). */
   close?(): Promise<void>;

--- a/packages/harness/src/bench/compare.ts
+++ b/packages/harness/src/bench/compare.ts
@@ -171,6 +171,65 @@ export function renderComparisonMarkdown(summaries: BenchmarkSummary[]): string 
     lines.push('');
   }
 
+  // ── Tool support matrix ───────────────────────────────────────────────────
+  const toolNames: Array<[string, keyof import('./runner.js').ToolBenchmarks]> = [
+    ['list_notes', 'list'],
+    ['list_tags', 'listTags'],
+    ['outline_note', 'outline'],
+    ['get_backlinks', 'getBacklinks'],
+    ['get_links', 'getLinks'],
+    ['get_periodic_note', 'getPeriodicNote'],
+  ];
+
+  const hasToolData = summaries.some((s) => s.tools);
+  if (hasToolData) {
+    lines.push('## Tool support matrix');
+    lines.push('');
+    lines.push('✅ = benchmarked · ❌ = not supported · — = benchmark skipped (no sample path)');
+    lines.push('');
+    lines.push(`| Tool | ${summaries.map((s) => s.backend.name).join(' | ')} |`);
+    lines.push(`| --- | ${summaries.map(() => '---').join(' | ')} |`);
+
+    for (const [label, key] of toolNames) {
+      const cells = summaries.map((s) => {
+        if (!s.tools) return '❌';
+        const entry = s.tools[key];
+        if (entry === null) return '❌';
+        if (entry === undefined) return '—';
+        return '✅';
+      });
+      lines.push(`| \`${label}\` | ${cells.join(' | ')} |`);
+    }
+    lines.push('');
+
+    // Per-tool latency comparison for tools all adapters share
+    const sharedTools = toolNames.filter(([, key]) =>
+      summaries.every((s) => s.tools?.[key] != null),
+    );
+    if (sharedTools.length > 0) {
+      lines.push('### Tool latency comparison (ms)');
+      lines.push('');
+      lines.push(
+        `| Tool | ${summaries.flatMap((s) => [`${s.backend.name} cold`, `${s.backend.name} warm p50`]).join(' | ')} |`,
+      );
+      lines.push(`| --- | ${summaries.flatMap(() => ['---', '---']).join(' | ')} |`);
+      for (const [label, key] of sharedTools) {
+        const cells = summaries.flatMap((s) => {
+          const entry = s.tools?.[key];
+          if (!entry) return ['—', '—'];
+          const stats = 'stats' in entry ? entry.stats : entry;
+          if (!stats || typeof stats !== 'object' || !('coldMs' in stats)) return ['—', '—'];
+          return [
+            `${(stats as import('./timer.js').RunStats).coldMs.toFixed(1)}`,
+            `${(stats as import('./timer.js').RunStats).warm.median.toFixed(1)}`,
+          ];
+        });
+        lines.push(`| \`${label}\` | ${cells.join(' | ')} |`);
+      }
+      lines.push('');
+    }
+  }
+
   // ── Adapter descriptions ──────────────────────────────────────────────────
   lines.push('## Adapters');
   lines.push('');

--- a/packages/harness/src/bench/index.ts
+++ b/packages/harness/src/bench/index.ts
@@ -1,4 +1,8 @@
 export { FsAdapter } from './adapters/fs.js';
+export { McpObsidianAdapter } from './adapters/mcp-obsidian.js';
+export { McpvaultAdapter } from './adapters/mcpvault.js';
+export { ObsidianMcpAdapter } from './adapters/obsidian-mcp.js';
+export { ObsidianMcpServerAdapter } from './adapters/obsidian-mcp-server.js';
 export { RestAdapter } from './adapters/rest.js';
 export { SeekstoneAdapter } from './adapters/seekstone.js';
 export type { Backend, BackendResponse, ListEntry, SearchHit } from './backend.js';

--- a/packages/harness/src/bench/index.ts
+++ b/packages/harness/src/bench/index.ts
@@ -2,6 +2,7 @@ export { FsAdapter } from './adapters/fs.js';
 export { McpObsidianAdapter } from './adapters/mcp-obsidian.js';
 export { McpvaultAdapter } from './adapters/mcpvault.js';
 export { ObsidianMcpAdapter } from './adapters/obsidian-mcp.js';
+export { ObsidianMcpProAdapter } from './adapters/obsidian-mcp-pro.js';
 export { ObsidianMcpServerAdapter } from './adapters/obsidian-mcp-server.js';
 export { RestAdapter } from './adapters/rest.js';
 export { SeekstoneAdapter } from './adapters/seekstone.js';

--- a/packages/harness/src/bench/index.ts
+++ b/packages/harness/src/bench/index.ts
@@ -1,6 +1,7 @@
 export { FsAdapter } from './adapters/fs.js';
 export { RestAdapter } from './adapters/rest.js';
+export { SeekstoneAdapter } from './adapters/seekstone.js';
 export type { Backend, BackendResponse, ListEntry, SearchHit } from './backend.js';
 export { loadQuerySet, type QueryDef, type QuerySet } from './queries.js';
 export { renderBenchmarkMarkdown } from './report.js';
-export { type BenchmarkSummary, runBenchmark } from './runner.js';
+export { type BenchmarkSummary, type ToolBenchmarks, runBenchmark } from './runner.js';

--- a/packages/harness/src/bench/report.test.ts
+++ b/packages/harness/src/bench/report.test.ts
@@ -40,6 +40,14 @@ const minimalSummary: BenchmarkSummary = {
     },
     large: null,
   },
+  tools: {
+    list: null,
+    listTags: null,
+    outline: null,
+    getBacklinks: null,
+    getLinks: null,
+    getPeriodicNote: null,
+  },
 };
 
 describe('renderBenchmarkMarkdown', () => {

--- a/packages/harness/src/bench/report.ts
+++ b/packages/harness/src/bench/report.ts
@@ -69,6 +69,53 @@ export function renderBenchmarkMarkdown(s: BenchmarkSummary): string {
     );
   }
   push();
+
+  // ── Extended tool table ──────────────────────────────────────────────────────
+  if (s.tools) {
+    const t = s.tools;
+    const hasAny =
+      t.list || t.listTags || t.outline || t.getBacklinks || t.getLinks || t.getPeriodicNote;
+
+    if (hasAny) {
+      push(`## Tools`);
+      push();
+      push(
+        `Latency for tools beyond search/read. Cold = first call; Warm p50 = median of subsequent calls.`,
+      );
+      push();
+      push(`| Tool | Target | Cold | Warm p50 | Warm p95 | Payload |`);
+      push(`| --- | --- | ---: | ---: | ---: | ---: |`);
+
+      const toolRow = (name: string, target: string, stats: import('./timer.js').RunStats) =>
+        `| \`${name}\` | ${target} | ${fmtMs(stats.coldMs)} | ${fmtMs(stats.warm.median)} | ${fmtMs(stats.warm.p95)} | ${fmtBytes(stats.payloadBytesMean)} |`;
+
+      if (t.list) push(toolRow('list_notes', 'vault root', t.list));
+      if (t.listTags) push(toolRow('list_tags', 'all tags', t.listTags));
+      if (t.outline) push(toolRow('outline_note', `\`${t.outline.path}\``, t.outline.stats));
+      if (t.getBacklinks)
+        push(toolRow('get_backlinks', `\`${t.getBacklinks.path}\``, t.getBacklinks.stats));
+      if (t.getLinks) push(toolRow('get_links', `\`${t.getLinks.path}\``, t.getLinks.stats));
+      if (t.getPeriodicNote) push(toolRow('get_periodic_note', 'today (daily)', t.getPeriodicNote));
+
+      push();
+
+      // Support matrix for tools not benchmarked
+      const unsupported: string[] = [];
+      if (!t.list) unsupported.push('list_notes');
+      if (!t.listTags) unsupported.push('list_tags');
+      if (!t.outline) unsupported.push('outline_note');
+      if (!t.getBacklinks) unsupported.push('get_backlinks');
+      if (!t.getLinks) unsupported.push('get_links');
+      if (!t.getPeriodicNote) unsupported.push('get_periodic_note');
+      if (unsupported.length > 0) {
+        push(
+          `> **Not supported by this backend:** ${unsupported.map((t) => `\`${t}\``).join(', ')}.`,
+        );
+        push();
+      }
+    }
+  }
+
   push(`## Methodology notes`);
   push();
   push(

--- a/packages/harness/src/bench/runner.ts
+++ b/packages/harness/src/bench/runner.ts
@@ -148,11 +148,13 @@ async function runToolBenchmarks(
     return stats;
   };
 
-  // list
-  const list = backend.list ? await bench(() => backend.list?.()) : null;
+  // Capture optional methods bound to `backend` so TypeScript narrows away
+  // undefined inside the bench() lambda without losing `this` context.
+  const listFn = backend.list?.bind(backend);
+  const list = listFn ? await bench(() => listFn()) : null;
 
-  // listTags
-  const listTags = backend.listTags ? await bench(() => backend.listTags?.()) : null;
+  const listTagsFn = backend.listTags?.bind(backend);
+  const listTags = listTagsFn ? await bench(() => listTagsFn()) : null;
 
   // outline, getBacklinks, getLinks — all need a note path
   let outline: ToolBenchmarks['outline'] = null;
@@ -160,30 +162,32 @@ async function runToolBenchmarks(
   let getLinks: ToolBenchmarks['getLinks'] = null;
 
   if (samplePath) {
-    if (backend.outline) {
+    const outlineFn = backend.outline?.bind(backend);
+    if (outlineFn) {
       outline = {
         path: samplePath,
-        stats: await bench(() => backend.outline?.(samplePath)),
+        stats: await bench(() => outlineFn(samplePath)),
       };
     }
-    if (backend.getBacklinks) {
+    const getBacklinksFn = backend.getBacklinks?.bind(backend);
+    if (getBacklinksFn) {
       getBacklinks = {
         path: samplePath,
-        stats: await bench(() => backend.getBacklinks?.(samplePath)),
+        stats: await bench(() => getBacklinksFn(samplePath)),
       };
     }
-    if (backend.getLinks) {
+    const getLinksFn = backend.getLinks?.bind(backend);
+    if (getLinksFn) {
       getLinks = {
         path: samplePath,
-        stats: await bench(() => backend.getLinks?.(samplePath)),
+        stats: await bench(() => getLinksFn(samplePath)),
       };
     }
   }
 
   // getPeriodicNote — no side effects (existence check only)
-  const getPeriodicNote = backend.getPeriodicNote
-    ? await bench(() => backend.getPeriodicNote?.('daily'))
-    : null;
+  const getPeriodicNoteFn = backend.getPeriodicNote?.bind(backend);
+  const getPeriodicNote = getPeriodicNoteFn ? await bench(() => getPeriodicNoteFn('daily')) : null;
 
   return { list, listTags, outline, getBacklinks, getLinks, getPeriodicNote };
 }

--- a/packages/harness/src/bench/runner.ts
+++ b/packages/harness/src/bench/runner.ts
@@ -3,6 +3,21 @@ import type { Backend } from './backend.js';
 import type { QuerySet } from './queries.js';
 import { type RunStats, type StreamStats, runN, runNStream } from './timer.js';
 
+export interface ToolBenchmarks {
+  /** list_notes — vault-wide listing, no filters. */
+  list: RunStats | null;
+  /** list_tags — all tags sorted by count. */
+  listTags: RunStats | null;
+  /** outline_note — heading/block structure of the small read target. */
+  outline: { path: string; stats: RunStats } | null;
+  /** get_backlinks — reverse-link lookup for the small read target. */
+  getBacklinks: { path: string; stats: RunStats } | null;
+  /** get_links — outgoing link enumeration for the small read target. */
+  getLinks: { path: string; stats: RunStats } | null;
+  /** get_periodic_note — today's daily note (existence check, no side effects). */
+  getPeriodicNote: RunStats | null;
+}
+
 export interface BenchmarkSummary {
   snapshotDate: string;
   machine: { platform: string; arch: string; node: string; cpus: number };
@@ -24,6 +39,8 @@ export interface BenchmarkSummary {
     small: { path: string; stats: RunStats } | null;
     large: { path: string; stats: RunStats } | null;
   };
+  /** Per-tool latency for tools beyond search/read. Null when backend does not implement. */
+  tools: ToolBenchmarks;
 }
 
 export interface RunnerOptions {
@@ -44,6 +61,7 @@ export async function runBenchmark(opts: RunnerOptions): Promise<BenchmarkSummar
     if (r > rssPeak) rssPeak = r;
   };
 
+  // ── Search ──────────────────────────────────────────────────────────────────
   const search: BenchmarkSummary['search'] = [];
   for (const q of querySet.queries) {
     let firstHits = 0;
@@ -69,6 +87,7 @@ export async function runBenchmark(opts: RunnerOptions): Promise<BenchmarkSummar
     });
   }
 
+  // ── Read ────────────────────────────────────────────────────────────────────
   const readSmall = reads.small
     ? {
         path: reads.small,
@@ -91,6 +110,9 @@ export async function runBenchmark(opts: RunnerOptions): Promise<BenchmarkSummar
       }
     : null;
 
+  // ── Extended tool benchmarks ─────────────────────────────────────────────────
+  const tools = await runToolBenchmarks(backend, reads.small, querySet.runs, samplePeak);
+
   return {
     snapshotDate: new Date().toISOString(),
     machine: {
@@ -105,7 +127,65 @@ export async function runBenchmark(opts: RunnerOptions): Promise<BenchmarkSummar
     rssPeak,
     search,
     read: { small: readSmall, large: readLarge },
+    tools,
   };
+}
+
+async function runToolBenchmarks(
+  backend: Backend,
+  samplePath: string | null,
+  runs: number,
+  samplePeak: () => void,
+): Promise<ToolBenchmarks> {
+  const bench = async <T>(
+    fn: () => Promise<{ result: T; payloadBytes: number; payloadText?: string }>,
+  ) => {
+    const stats = await runN(async () => {
+      const r = await fn();
+      samplePeak();
+      return r;
+    }, runs);
+    return stats;
+  };
+
+  // list
+  const list = backend.list ? await bench(() => backend.list?.()) : null;
+
+  // listTags
+  const listTags = backend.listTags ? await bench(() => backend.listTags?.()) : null;
+
+  // outline, getBacklinks, getLinks — all need a note path
+  let outline: ToolBenchmarks['outline'] = null;
+  let getBacklinks: ToolBenchmarks['getBacklinks'] = null;
+  let getLinks: ToolBenchmarks['getLinks'] = null;
+
+  if (samplePath) {
+    if (backend.outline) {
+      outline = {
+        path: samplePath,
+        stats: await bench(() => backend.outline?.(samplePath)),
+      };
+    }
+    if (backend.getBacklinks) {
+      getBacklinks = {
+        path: samplePath,
+        stats: await bench(() => backend.getBacklinks?.(samplePath)),
+      };
+    }
+    if (backend.getLinks) {
+      getLinks = {
+        path: samplePath,
+        stats: await bench(() => backend.getLinks?.(samplePath)),
+      };
+    }
+  }
+
+  // getPeriodicNote — no side effects (existence check only)
+  const getPeriodicNote = backend.getPeriodicNote
+    ? await bench(() => backend.getPeriodicNote?.('daily'))
+    : null;
+
+  return { list, listTags, outline, getBacklinks, getLinks, getPeriodicNote };
 }
 
 async function resolveReadPaths(

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -3,7 +3,10 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { cac } from 'cac';
+import { McpObsidianAdapter } from './bench/adapters/mcp-obsidian.js';
 import { McpvaultAdapter } from './bench/adapters/mcpvault.js';
+import { ObsidianMcpServerAdapter } from './bench/adapters/obsidian-mcp-server.js';
+import { ObsidianMcpAdapter } from './bench/adapters/obsidian-mcp.js';
 import { SeekstoneAdapter } from './bench/adapters/seekstone.js';
 import { renderComparisonMarkdown } from './bench/compare.js';
 import {
@@ -205,6 +208,44 @@ async function buildBackend(
     process.stderr.write(`seekstone: index ready.\n`);
     return adapter;
   }
-  console.error(`Unknown backend: ${name}. Known: rest, fs, mcpvault, seekstone.`);
+  if (name === 'mcp-obsidian') {
+    const apiKey = needArg(
+      process.env.SEEKSTONE_REST_API_KEY,
+      'SEEKSTONE_REST_API_KEY env var (mcp-obsidian requires Obsidian running)',
+    );
+    const restUrl = new URL(process.env.SEEKSTONE_REST_URL ?? 'https://127.0.0.1:27124');
+    process.stderr.write(`mcp-obsidian: starting subprocess (requires Obsidian running)…\n`);
+    const adapter = await McpObsidianAdapter.build({
+      apiKey,
+      host: restUrl.hostname,
+      port: Number(restUrl.port) || 27124,
+      protocol: restUrl.protocol.replace(':', ''),
+    });
+    process.stderr.write(`mcp-obsidian: ready.\n`);
+    return adapter;
+  }
+  if (name === 'obsidian-mcp') {
+    const root = resolve(
+      needArg(vaultRoot, 'vault (--vault or SEEKSTONE_VAULT for obsidian-mcp backend)'),
+    );
+    process.stderr.write(`obsidian-mcp: starting subprocess for ${root}…\n`);
+    const adapter = await ObsidianMcpAdapter.build({ vaultRoot: root });
+    process.stderr.write(`obsidian-mcp: ready.\n`);
+    return adapter;
+  }
+  if (name === 'obsidian-mcp-server') {
+    const apiKey = needArg(
+      process.env.SEEKSTONE_REST_API_KEY,
+      'SEEKSTONE_REST_API_KEY env var (obsidian-mcp-server requires Obsidian running)',
+    );
+    const baseUrl = process.env.SEEKSTONE_REST_URL ?? 'https://127.0.0.1:27124';
+    process.stderr.write(`obsidian-mcp-server: starting subprocess (requires Obsidian running)…\n`);
+    const adapter = await ObsidianMcpServerAdapter.build({ apiKey, baseUrl });
+    process.stderr.write(`obsidian-mcp-server: ready.\n`);
+    return adapter;
+  }
+  console.error(
+    `Unknown backend: ${name}. Known: rest, fs, mcpvault, seekstone, mcp-obsidian, obsidian-mcp, obsidian-mcp-server.`,
+  );
   process.exit(2);
 }

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path';
 import { cac } from 'cac';
 import { McpObsidianAdapter } from './bench/adapters/mcp-obsidian.js';
 import { McpvaultAdapter } from './bench/adapters/mcpvault.js';
+import { ObsidianMcpProAdapter } from './bench/adapters/obsidian-mcp-pro.js';
 import { ObsidianMcpServerAdapter } from './bench/adapters/obsidian-mcp-server.js';
 import { ObsidianMcpAdapter } from './bench/adapters/obsidian-mcp.js';
 import { SeekstoneAdapter } from './bench/adapters/seekstone.js';
@@ -233,6 +234,15 @@ async function buildBackend(
     process.stderr.write(`obsidian-mcp: ready.\n`);
     return adapter;
   }
+  if (name === 'obsidian-mcp-pro') {
+    const root = resolve(
+      needArg(vaultRoot, 'vault (--vault or SEEKSTONE_VAULT for obsidian-mcp-pro backend)'),
+    );
+    process.stderr.write(`obsidian-mcp-pro: starting subprocess for ${root}…\n`);
+    const adapter = await ObsidianMcpProAdapter.build({ vaultRoot: root });
+    process.stderr.write(`obsidian-mcp-pro: ready.\n`);
+    return adapter;
+  }
   if (name === 'obsidian-mcp-server') {
     const apiKey = needArg(
       process.env.SEEKSTONE_REST_API_KEY,
@@ -245,7 +255,7 @@ async function buildBackend(
     return adapter;
   }
   console.error(
-    `Unknown backend: ${name}. Known: rest, fs, mcpvault, seekstone, mcp-obsidian, obsidian-mcp, obsidian-mcp-server.`,
+    `Unknown backend: ${name}. Known: rest, fs, mcpvault, seekstone, mcp-obsidian, obsidian-mcp, obsidian-mcp-pro, obsidian-mcp-server.`,
   );
   process.exit(2);
 }

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { cac } from 'cac';
 import { McpvaultAdapter } from './bench/adapters/mcpvault.js';
+import { SeekstoneAdapter } from './bench/adapters/seekstone.js';
 import { renderComparisonMarkdown } from './bench/compare.js';
 import {
   FsAdapter,
@@ -124,9 +125,10 @@ cli
         JSON.stringify(summary, null, 2),
       );
       await writeFile(join(outDir, `safety-${backend.name}.md`), renderSafetyMarkdown(summary));
-      console.log(
-        `safety (${backend.name}): identity ${summary.passByOp.identity.pass}/${summary.passByOp.identity.pass + summary.passByOp.identity.fail}, body-append ${summary.passByOp['body-append'].pass}/${summary.passByOp['body-append'].pass + summary.passByOp['body-append'].fail}, fm-edit ${summary.passByOp['fm-edit'].pass}/${summary.passByOp['fm-edit'].pass + summary.passByOp['fm-edit'].fail}`,
-      );
+      const safetyOps = Object.entries(summary.passByOp)
+        .map(([op, r]) => `${op} ${r.pass}/${r.pass + r.fail}`)
+        .join(', ');
+      console.log(`safety (${backend.name}): ${safetyOps}`);
     } finally {
       await backend.close?.();
     }
@@ -194,6 +196,15 @@ async function buildBackend(
     process.stderr.write(`mcpvault: ready.\n`);
     return adapter;
   }
-  console.error(`Unknown backend: ${name}. Known: rest, fs, mcpvault.`);
+  if (name === 'seekstone') {
+    const root = resolve(
+      needArg(vaultRoot, 'vault (--vault or SEEKSTONE_VAULT for seekstone backend)'),
+    );
+    process.stderr.write(`seekstone: building index for ${root}…\n`);
+    const adapter = await SeekstoneAdapter.build({ vaultRoot: root });
+    process.stderr.write(`seekstone: index ready.\n`);
+    return adapter;
+  }
+  console.error(`Unknown backend: ${name}. Known: rest, fs, mcpvault, seekstone.`);
   process.exit(2);
 }

--- a/packages/harness/src/safety/ops.ts
+++ b/packages/harness/src/safety/ops.ts
@@ -1,7 +1,7 @@
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { parseDocument } from 'yaml';
 
-export type OpKind = 'identity' | 'body-append' | 'fm-edit';
+export type OpKind = 'identity' | 'body-append' | 'fm-edit' | 'patch-note' | 'replace-in-note';
 
 export interface OpResult {
   /** The bytes to write back via the adapter. */
@@ -61,6 +61,85 @@ export function bodyAppendOp(
           ? undefined
           : 'appended file does not match original + marker',
       };
+    },
+  };
+}
+
+/**
+ * Patch note: insert a marker line immediately after the first heading.
+ * Verifies frontmatter region is byte-identical and the marker is present.
+ * Returns null if the body has no heading lines.
+ */
+export function patchNoteOp(original: Buffer): OpResult | null {
+  const text = original.toString('utf8');
+  const fm = parseFrontmatter(text);
+  const body = fm.body;
+  const lines = body.split('\n');
+  const headingIdx = lines.findIndex((l) => /^#{1,6} /.test(l));
+  if (headingIdx === -1) return null;
+
+  const marker = '<!-- seekstone-harness-patch -->';
+  const newLines = [...lines.slice(0, headingIdx + 1), marker, ...lines.slice(headingIdx + 1)];
+  const newBody = newLines.join('\n');
+  const fmRegion = text.slice(0, fm.bodyStart);
+  const newText = fmRegion + newBody;
+  const newBytes = Buffer.from(newText, 'utf8');
+  const fmBytesLen = Buffer.byteLength(fmRegion, 'utf8');
+
+  return {
+    bytes: newBytes,
+    change: `insert marker after heading at line ${headingIdx}`,
+    verify: (post, orig) => {
+      const fmPre = orig.subarray(0, fmBytesLen);
+      const fmPost = post.subarray(0, fmBytesLen);
+      if (!fmPre.equals(fmPost)) {
+        return { pass: false, reason: 'frontmatter bytes mutated by patch-note op' };
+      }
+      const postText = post.toString('utf8');
+      if (!postText.includes(marker)) {
+        return { pass: false, reason: 'marker line not found after write' };
+      }
+      return { pass: true };
+    },
+  };
+}
+
+/**
+ * Replace-in-note: replace the first occurrence of a 4+ letter word in the
+ * body with itself + a marker suffix.
+ * Verifies frontmatter region is byte-identical and the marker appears exactly once.
+ * Returns null if no eligible word is found.
+ */
+export function replaceInNoteOp(original: Buffer): OpResult | null {
+  const text = original.toString('utf8');
+  const fm = parseFrontmatter(text);
+  const body = fm.body;
+  const match = body.match(/\b([A-Za-z]{4,})\b/);
+  if (!match || match.index == null || !match[1]) return null;
+
+  const word = match[1];
+  const marker = `${word}<!-- seekstone-harness-replace -->`;
+  const newBody = body.slice(0, match.index) + marker + body.slice(match.index + word.length);
+  const fmRegion = text.slice(0, fm.bodyStart);
+  const newText = fmRegion + newBody;
+  const newBytes = Buffer.from(newText, 'utf8');
+  const fmBytesLen = Buffer.byteLength(fmRegion, 'utf8');
+
+  return {
+    bytes: newBytes,
+    change: `replace first occurrence of "${word}" with marked version`,
+    verify: (post, orig) => {
+      const fmPre = orig.subarray(0, fmBytesLen);
+      const fmPost = post.subarray(0, fmBytesLen);
+      if (!fmPre.equals(fmPost)) {
+        return { pass: false, reason: 'frontmatter bytes mutated by replace-in-note op' };
+      }
+      const postText = post.toString('utf8');
+      const count = postText.split('<!-- seekstone-harness-replace -->').length - 1;
+      if (count !== 1) {
+        return { pass: false, reason: `expected 1 replacement marker, found ${count}` };
+      }
+      return { pass: true };
     },
   };
 }

--- a/packages/harness/src/safety/report.test.ts
+++ b/packages/harness/src/safety/report.test.ts
@@ -12,6 +12,8 @@ const allPassSummary: SafetySummary = {
     identity: { pass: 2, fail: 0 },
     'body-append': { pass: 2, fail: 0 },
     'fm-edit': { pass: 2, fail: 0 },
+    'patch-note': { pass: 2, fail: 0 },
+    'replace-in-note': { pass: 2, fail: 0 },
   },
   notes: [
     {
@@ -45,6 +47,8 @@ const bodyAppendFailSummary: SafetySummary = {
     identity: { pass: 1, fail: 0 },
     'body-append': { pass: 0, fail: 1 },
     'fm-edit': { pass: 1, fail: 0 },
+    'patch-note': { pass: 1, fail: 0 },
+    'replace-in-note': { pass: 1, fail: 0 },
   },
   notes: [
     {
@@ -73,8 +77,8 @@ describe('renderSafetyMarkdown', () => {
   it('all-pass output contains "✅ Pass" for each op row', () => {
     const md = renderSafetyMarkdown(allPassSummary);
     const passCount = (md.match(/✅ Pass/g) ?? []).length;
-    // identity, body-append, fm-edit all pass → 3 rows
-    expect(passCount).toBe(3);
+    // identity, body-append, fm-edit, patch-note, replace-in-note all pass → 5 rows
+    expect(passCount).toBe(5);
   });
 
   it('all-pass output does NOT contain "CAUTION"', () => {

--- a/packages/harness/src/safety/runner.ts
+++ b/packages/harness/src/safety/runner.ts
@@ -2,7 +2,15 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import type { Backend } from '../bench/backend.js';
 import { copyVault } from './copy.js';
-import { type OpKind, type OpResult, bodyAppendOp, fmEditOp, identityOp } from './ops.js';
+import {
+  type OpKind,
+  type OpResult,
+  bodyAppendOp,
+  fmEditOp,
+  identityOp,
+  patchNoteOp,
+  replaceInNoteOp,
+} from './ops.js';
 import { type Candidate, selectFrontmatterHeavyNotes } from './select.js';
 
 export interface SafetyOpResult {
@@ -68,11 +76,19 @@ export async function runSafety(opts: SafetyRunnerOptions): Promise<SafetySummar
     identity: { pass: 0, fail: 0 },
     'body-append': { pass: 0, fail: 0 },
     'fm-edit': { pass: 0, fail: 0 },
+    'patch-note': { pass: 0, fail: 0 },
+    'replace-in-note': { pass: 0, fail: 0 },
   };
 
   for (const c of candidates) {
     const noteResults: SafetyOpResult[] = [];
-    for (const opKind of ['identity', 'body-append', 'fm-edit'] as OpKind[]) {
+    for (const opKind of [
+      'identity',
+      'body-append',
+      'fm-edit',
+      'patch-note',
+      'replace-in-note',
+    ] as OpKind[]) {
       // Always re-read fresh — previous ops may have left the file modified.
       const original = await readFile(c.absPath);
       const op = buildOp(opKind, original);
@@ -110,6 +126,10 @@ function buildOp(kind: OpKind, original: Buffer): OpResult | null {
       return bodyAppendOp(original);
     case 'fm-edit':
       return fmEditOp(original);
+    case 'patch-note':
+      return patchNoteOp(original);
+    case 'replace-in-note':
+      return replaceInNoteOp(original);
   }
 }
 

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
+    "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary

- **`SeekstoneAdapter`** (`packages/harness/src/bench/adapters/seekstone.ts`): new in-process adapter that calls seekstone's tool handlers directly, eliminating IPC/MCP transport overhead from benchmarks — the most accurate measurement of algorithmic cost
- **Per-tool latency benchmarks** (`runner.ts`, `backend.ts`): `ToolBenchmarks` interface covering `list_notes`, `list_tags`, `outline_note`, `get_backlinks`, `get_links`, `get_periodic_note` — all read-only, safe to repeat across runs
- **Extended safety ops** (`ops.ts`, `runner.ts`): `patch-note` (insert marker after first heading, verify FM unchanged) and `replace-in-note` (replace first word occurrence, verify single substitution) round out the write-safety suite from 3 ops to 5
- **Report + compare updates**: `## Tools` latency table in benchmark reports; tool support matrix (✅/❌/—) and per-tool latency comparison table in `comparison.md`
- **CLI update**: `seekstone` backend registered; safety log line now dynamic over all op kinds

## Test plan

- [ ] `npm test` — all 429 tests pass (12 harness test files, 115 tests)
- [ ] `npx tsc -p packages/harness/tsconfig.json --noEmit` — clean
- [ ] `npm run lint` — clean
- [ ] Run `npm run harness -- bench --backend seekstone --vault $SEEKSTONE_VAULT` against a vault to validate adapter end-to-end
- [ ] Run `npm run harness -- safety --backend fs --vault $SEEKSTONE_VAULT` to confirm 5 ops appear in the output