### PR TITLE
docs: add npm total and weekly downloads badges (SHA-130, SHA-133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/obsidian-mcp-seekstone"><img src="https://img.shields.io/npm/v/obsidian-mcp-seekstone?color=cb3837&logo=npm&label=obsidian-mcp-seekstone" alt="npm" /></a>
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/v/seekstone?color=cb3837&logo=npm&label=seekstone" alt="npm (seekstone)" /></a>
+  <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/dt/seekstone?color=7c3aed&label=downloads" alt="npm total downloads" /></a>
+  <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/dw/seekstone?color=7c3aed&label=downloads%2Fwk" alt="npm weekly downloads" /></a>
   <a href="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml"><img src="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A522-339933?logo=node.js&logoColor=white" alt="Node.js ≥ 22" />


### PR DESCRIPTION
## Summary

Adds two purple shields.io badges to the README header row, grouped with the existing npm version badges:

- **Total downloads** (`/npm/dt/`) — all-time cumulative installs
- **Weekly downloads** (`/npm/dw/`) — week-over-week traction

Both use `?color=7c3aed` (purple) and link to the seekstone npm page. Pulls live data directly from the npm public API — no accounts, secrets, or CI changes required.

Closes SHA-130, closes SHA-133.

## Test plan

- [ ] Badge row renders correctly in GitHub README preview
- [ ] Both badges are purple and link to https://www.npmjs.com/package/seekstone
- [ ] CI passes (no code changes)