### PR TITLE
docs: remove GitHub Stars and bundle size badges (SHA-137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/v/seekstone?color=cb3837&logo=npm&label=seekstone" alt="npm (seekstone)" /></a>
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/dt/seekstone?color=7c3aed&label=downloads" alt="npm total downloads" /></a>
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/dw/seekstone?color=7c3aed&label=downloads%2Fwk" alt="npm weekly downloads" /></a>
-  <a href="https://github.com/shaqmughal/seekstone"><img src="https://img.shields.io/github/stars/shaqmughal/seekstone?color=7c3aed&label=stars&logo=github" alt="GitHub Stars" /></a>
-  <a href="https://bundlephobia.com/package/seekstone"><img src="https://img.shields.io/bundlephobia/minzip/seekstone?color=7c3aed&label=minzipped" alt="Bundle size" /></a>
   <a href="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml"><img src="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A522-339933?logo=node.js&logoColor=white" alt="Node.js ≥ 22" />


### PR DESCRIPTION
## Summary

Removes two badges from the README header row:
- **GitHub Stars** — low star count reads as a negative signal early in a project's life
- **Bundle size (bundlephobia)** — badge is broken; bundlephobia doesn't resolve the package correctly

All other badges unchanged.

Closes SHA-137.

## Test plan

- [ ] Badge row renders correctly in GitHub preview (no broken images)
- [ ] CI passes