### PR TITLE
fix(watcher): fix flaky CI tests — ignored guard + settle + timeout (SHA-138)

### DIFF
--- a/.changeset/fix-watcher-ignored-guard.md
+++ b/.changeset/fix-watcher-ignored-guard.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Fix `ignored` predicate in watcher to correctly handle vault roots that are subdirectories; add event-loop settle after `ready` and increase test timeout to reduce flaky CI failures.

--- a/packages/server/src/watcher.test.ts
+++ b/packages/server/src/watcher.test.ts
@@ -21,7 +21,7 @@ function freshCtx(vaultRoot: string): ServerContext {
   return { vaultRoot, index, notes: new Map(), backlinks: new Map() };
 }
 
-async function waitFor(condition: () => boolean, timeoutMs = 30000): Promise<void> {
+async function waitFor(condition: () => boolean, timeoutMs = 60_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!condition()) {
     if (Date.now() > deadline) throw new Error('waitFor timeout');
@@ -47,6 +47,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
     const { stop, ready } = startWatcher(ctx, undefined, { usePolling: true });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await writeFile(join(tmpDir, 'watch-new.md'), 'watcher_unique_abc', 'utf8');
       await waitFor(() => ctx.notes.has('watch-new.md'));
       expect(ctx.index.search('watcher_unique_abc').some((h) => h.id === 'watch-new.md')).toBe(
@@ -63,6 +64,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
     const { stop, ready } = startWatcher(ctx, undefined, { usePolling: true });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await writeFile(join(tmpDir, 'watch-mod.md'), 'new_unique_modified_xyz', 'utf8');
       await waitFor(
         () => ctx.notes.get('watch-mod.md')?.body?.includes('new_unique_modified_xyz') ?? false,
@@ -92,6 +94,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
     const { stop, ready } = startWatcher(ctx, undefined, { usePolling: true });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await rm(join(tmpDir, 'watch-del.md'));
       await waitFor(() => !ctx.notes.has('watch-del.md'));
       expect(ctx.notes.has('watch-del.md')).toBe(false);
@@ -109,6 +112,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
     const { stop, ready } = startWatcher(ctx, undefined, { usePolling: true });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await writeFile(join(tmpDir, 'a', 'b', 'c', 'deep.md'), 'nested_unique_def', 'utf8');
       await waitFor(() => ctx.notes.has('a/b/c/deep.md'));
       expect(ctx.notes.get('a/b/c/deep.md')?.body).toContain('nested_unique_def');
@@ -124,6 +128,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
     const { stop, ready } = startWatcher(ctx, undefined, { usePolling: true });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await writeFile(join(spaced, 'spaced note.md'), 'spaced_unique_ghi', 'utf8');
       await waitFor(() => ctx.notes.has('spaced note.md'));
       expect(ctx.notes.get('spaced note.md')?.body).toContain('spaced_unique_ghi');
@@ -146,6 +151,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
     const { stop, ready } = startWatcher(ctx, log, { usePolling: true });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await writeFile(join(tmpDir, 'watch-log.md'), 'logged_body_qrs', 'utf8');
       await waitFor(() =>
         events.some((e) => e.msg === 'index updated' && e.fields?.path === 'watch-log.md'),

--- a/packages/server/src/watcher.ts
+++ b/packages/server/src/watcher.ts
@@ -109,7 +109,7 @@ export function startWatcher(
     // lives — matched on the path relative to the vault root.
     ignored: (p: string) => {
       const rel = relative(ctx.vaultRoot, p);
-      if (!rel || rel === '.') return false;
+      if (!rel || rel === '.' || rel.startsWith('..')) return false;
       return rel
         .split(sep)
         .filter(Boolean)

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     // load (worse under coverage instrumentation), event delivery can lag many
     // seconds. A generous per-test timeout prevents false failures (passing
     // assertions still resolve immediately).
-    testTimeout: 35000,
+    testTimeout: 65000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

Three targeted fixes for the intermittent `waitFor timeout` failures in `watcher.test.ts` (SHA-138).

### 1. Fix `ignored` predicate bug in `watcher.ts`

When `vaultRoot` is a subdirectory, chokidar can call `ignored()` with ancestor paths. `relative(vaultRoot, ancestor)` returns `'..'`, and `'..'.startsWith('.')` is `true` — incorrectly marking the ancestor as ignored. Added a `rel.startsWith('..')` guard to prevent this.

```ts
// before
if (!rel || rel === '.') return false;

// after
if (!rel || rel === '.' || rel.startsWith('..')) return false;
```

This directly explains why "handles a vault path containing spaces" was the specific test failing on Windows — it's the only test that uses a subdirectory as `vaultRoot`.

### 2. Settle event loop after `ready` in all watcher tests

The chokidar `ready` event fires when the initial scan completes, but the first polling tick may not have run yet. A `setImmediate` yield after `await ready` ensures the polling timer has had at least one opportunity to fire before we write test files.

### 3. Bump `waitFor` timeout 30s → 60s and `testTimeout` 35s → 65s

Provides a larger buffer against CI timer starvation on loaded runners.

## Test plan

- [ ] All 3 platforms green in CI
- [ ] `watcher.test.ts` 8/8 pass locally ✅
- [ ] No new test skips
- [ ] Changeset not required (no publishable src changes... wait, `watcher.ts` is a src fix — changeset needed)

Closes SHA-138