### PR TITLE
test(watcher): add diagnostic instrumentation for flaky CI failures (SHA-138)

### DIFF
--- a/packages/server/src/watcher.test.ts
+++ b/packages/server/src/watcher.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import MiniSearch from 'minisearch';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ServerContext } from './context.js';
@@ -21,7 +21,7 @@ function freshCtx(vaultRoot: string): ServerContext {
   return { vaultRoot, index, notes: new Map(), backlinks: new Map() };
 }
 
-async function waitFor(condition: () => boolean, timeoutMs = 30000): Promise<void> {
+async function waitFor(condition: () => boolean, timeoutMs = 60_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!condition()) {
     if (Date.now() > deadline) throw new Error('waitFor timeout');
@@ -106,11 +106,22 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
     // delivery (modify/delete handlers are covered by the flat tests above).
     const ctx = freshCtx(tmpDir);
     await mkdir(join(tmpDir, 'a', 'b', 'c'), { recursive: true });
-    const { stop, ready } = startWatcher(ctx, undefined, { usePolling: true });
+    const rawEvents: string[] = [];
+    const { stop, ready } = startWatcher(ctx, undefined, {
+      usePolling: true,
+      onRawEvent: (event, abs, rel) => rawEvents.push(`${event} abs=${abs} rel=${rel}`),
+    });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await writeFile(join(tmpDir, 'a', 'b', 'c', 'deep.md'), 'nested_unique_def', 'utf8');
-      await waitFor(() => ctx.notes.has('a/b/c/deep.md'));
+      try {
+        await waitFor(() => ctx.notes.has('a/b/c/deep.md'));
+      } catch {
+        throw new Error(
+          `waitFor timeout — diagnostics:\n  platform=${process.platform} sep=${JSON.stringify(sep)}\n  vaultRoot=${tmpDir}\n  ctx.notes keys=[${[...ctx.notes.keys()].join(', ')}]\n  rawEvents(${rawEvents.length}):\n    ${rawEvents.join('\n    ') || '(none)'}`,
+        );
+      }
       expect(ctx.notes.get('a/b/c/deep.md')?.body).toContain('nested_unique_def');
     } finally {
       stop();
@@ -121,11 +132,22 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
     const spaced = join(tmpDir, 'My Vault');
     await mkdir(spaced, { recursive: true });
     const ctx = freshCtx(spaced);
-    const { stop, ready } = startWatcher(ctx, undefined, { usePolling: true });
+    const rawEvents: string[] = [];
+    const { stop, ready } = startWatcher(ctx, undefined, {
+      usePolling: true,
+      onRawEvent: (event, abs, rel) => rawEvents.push(`${event} abs=${abs} rel=${rel}`),
+    });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await writeFile(join(spaced, 'spaced note.md'), 'spaced_unique_ghi', 'utf8');
-      await waitFor(() => ctx.notes.has('spaced note.md'));
+      try {
+        await waitFor(() => ctx.notes.has('spaced note.md'));
+      } catch {
+        throw new Error(
+          `waitFor timeout — diagnostics:\n  platform=${process.platform} sep=${JSON.stringify(sep)}\n  vaultRoot=${spaced}\n  ctx.notes keys=[${[...ctx.notes.keys()].join(', ')}]\n  rawEvents(${rawEvents.length}):\n    ${rawEvents.join('\n    ') || '(none)'}`,
+        );
+      }
       expect(ctx.notes.get('spaced note.md')?.body).toContain('spaced_unique_ghi');
     } finally {
       stop();

--- a/packages/server/src/watcher.ts
+++ b/packages/server/src/watcher.ts
@@ -30,6 +30,14 @@ export interface WatcherOptions {
    * SEEKSTONE_WATCH_POLL=1.
    */
   usePolling?: boolean;
+  /**
+   * Diagnostic hook fired for every raw chokidar event, before .md filtering
+   * and before the index is updated. Receives the chokidar event name, the
+   * absolute path as chokidar reported it, and the vault-relative key as
+   * computed by toRel(). Use in tests only to capture what chokidar actually
+   * emits when a failure needs investigation.
+   */
+  onRawEvent?: (event: 'add' | 'change' | 'unlink', absPath: string, relPath: string) => void;
 }
 
 function removeNoteBacklinks(ctx: ServerContext, relPath: string): void {
@@ -96,6 +104,7 @@ export function startWatcher(
 
   const onUpsert = (op: 'add' | 'change') => (abs: string) => {
     const relPath = toRel(abs);
+    opts?.onRawEvent?.(op, abs, relPath);
     if (relPath.endsWith('.md')) void upsert(relPath, op);
   };
 
@@ -122,6 +131,7 @@ export function startWatcher(
     .on('change', onUpsert('change'))
     .on('unlink', (abs: string) => {
       const relPath = toRel(abs);
+      opts?.onRawEvent?.('unlink', abs, relPath);
       if (relPath.endsWith('.md')) remove(relPath);
     });
 

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     // load (worse under coverage instrumentation), event delivery can lag many
     // seconds. A generous per-test timeout prevents false failures (passing
     // assertions still resolve immediately).
-    testTimeout: 35000,
+    testTimeout: 65000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

The two intermittently failing watcher tests ("handles a vault path containing spaces" on Windows, "detects a new note in a nested folder" on Ubuntu) time out without any signal as to why. This PR instruments them so the next failure produces a complete diagnosis.

### Changes

**`watcher.ts` — `onRawEvent` hook on `WatcherOptions`**

```ts
onRawEvent?: (event: 'add' | 'change' | 'unlink', absPath: string, relPath: string) => void;
```

Called for every raw chokidar event before `.md` filtering, capturing:
- The exact absolute path chokidar reported
- The vault-relative key as computed by `toRel()`

This tells us: did chokidar fire at all? With what path? Did `toRel` produce the right key? Is the event being silently dropped by the `.endsWith('.md')` guard?

**`watcher.test.ts` — diagnostic error on timeout**

The two flaky tests now catch `waitFor` timeout and re-throw with:
```
waitFor timeout — diagnostics:
  platform=win32 sep="\\"
  vaultRoot=C:\...\My Vault
  ctx.notes keys=[]
  rawEvents(0):
    (none)
```

Also: `waitFor` timeout 30s→60s, `setImmediate` yield after `await ready`, `testTimeout` 35s→65s.

### What this tells us when it fails next

| rawEvents | ctx.notes | Diagnosis |
|-----------|-----------|-----------|
| empty | empty | chokidar never fired — `ignored` filtering or polling not started |
| has entry, wrong rel | empty | `toRel` path normalisation bug |
| has correct entry | empty | async `upsert` is failing silently |
| has correct entry | has entry | `waitFor` key mismatch — test bug |

No production behaviour changed. The real fix follows once we have the output.

Closes SHA-138 (partial — diagnostic step)