### PR TITLE
docs(init): document intentional execFileSync usage — Socket.dev shellAccess (SHA-139)

### DIFF
--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -1,3 +1,7 @@
+// execFileSync is used (not exec/execSync) because it bypasses the shell
+// entirely — it exec's the named binary directly. There is no shell injection
+// risk. Socket.dev flags the child_process import as "shellAccess" regardless
+// of which function is used; that score penalty is accepted. See SHA-139.
 import { execFileSync } from 'node:child_process';
 import type { Dirent } from 'node:fs';
 import { access, copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
@@ -289,6 +293,10 @@ export async function runInit(
         deps.spawnClaudeMcp ??
         ((args: string[]) => {
           try {
+            // Runs `claude mcp add …` — the canonical way to register an MCP
+            // server with Claude Code. execFileSync (no shell) is intentional;
+            // writing ~/.claude.json directly would couple us to an internal
+            // format Anthropic can change without notice.
             execFileSync('claude', args, { stdio: 'inherit' });
             return { ok: true };
           } catch (err) {


### PR DESCRIPTION
## Summary

Adds two comments in `init.ts` explaining the intentional use of `execFileSync` and why the Socket.dev shellAccess score penalty is accepted.

Socket.dev flags seekstone with a Medium "Shell access" alert because `init.ts` imports from `node:child_process`. This PR ensures that decision is documented in the code so any future contributor has full context without needing to dig through issue history.

### Comments added

**At the import site** — explains `execFileSync` vs `exec`/`execSync`, no shell is invoked, and references SHA-139 for the full decision trail.

**At the call site** — explains why `claude mcp add` is used instead of writing `~/.claude.json` directly (coupling to an internal format Anthropic can change is a worse trade-off).

### What was NOT changed

- No behaviour change
- No production logic change
- `execFileSync` is kept as-is — the decision is to accept the score hit

Closes SHA-139
Ref: https://socket.dev/alerts/shellAccess