### PR TITLE
feat: add OpenSSF Scorecard workflow and badge (SHA-140)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="https://socket.dev/npm/package/seekstone"><img src="https://socket.dev/api/badge/npm/package/seekstone" alt="Socket.dev security" /></a>
   <a href="https://snyk.io/test/github/shaqmughal/seekstone"><img src="https://snyk.io/test/github/shaqmughal/seekstone/badge.svg?targetFile=packages/server/package.json" alt="Known vulnerabilities" /></a>
   <a href="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml"><img src="https://github.com/shaqmughal/seekstone/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/shaqmughal/seekstone"><img src="https://api.scorecard.dev/projects/github.com/shaqmughal/seekstone/badge" alt="OpenSSF Scorecard" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/Node.js-%E2%89%A522-339933?logo=node.js&logoColor=white" alt="Node.js ≥ 22" />
   <a href="https://glama.ai/mcp/servers/shaqmughal/seekstone"><img src="https://glama.ai/mcp/servers/shaqmughal/seekstone/badges/score.svg" alt="shaqmughal/seekstone MCP server" /></a>


### PR DESCRIPTION
## Summary

Adds the OpenSSF Scorecard automated security assessment to seekstone.

- **`.github/workflows/scorecard.yml`** — runs Scorecard on every push to main, weekly on Mondays, and on branch protection changes. Publishes results to the public Scorecard API (enables the live badge) and uploads a SARIF report to GitHub's code-scanning dashboard.
- **`README.md`** — adds the Scorecard badge between CI and License.

## What's already passing (no changes needed)

| Check | Status |
|---|---|
| `Security-Policy` | ✅ `SECURITY.md` already present |
| `CI-Tests` | ✅ 3-platform matrix already running |
| `License` | ✅ MIT |
| `Maintained` | ✅ Active commits |

## Expected score gaps on first run

- `Pinned-Dependencies` — Actions use version tags, not full SHA pins (follow-up)
- `Dependency-Update-Tool` — no Dependabot yet
- `Token-Permissions` — existing ci.yml/release.yml don't declare explicit permissions

The Scorecard report at `scorecard.dev/viewer/?uri=github.com/shaqmughal/seekstone` will show exact findings after first run.

Closes SHA-140