### PR TITLE
fix: harden workflows for OpenSSF Scorecard (SHA-142)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
 
+permissions: read-all
+
 jobs:
   test:
     name: test (${{ matrix.os }})
@@ -17,15 +19,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build server
         run: npm run build -w seekstone
@@ -52,7 +54,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/server/coverage/lcov.info
@@ -67,7 +69,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.head_ref != 'changeset-release/main'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,19 +8,20 @@ on:
 # Never run two releases at once.
 concurrency: release-${{ github.ref }}
 
-permissions:
-  contents: write # changesets opens the version PR and pushes tags
-  pull-requests: write # changesets opens the version PR
-  id-token: write # npm provenance attestation
+permissions: read-all
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # changesets opens the version PR and pushes tags
+      pull-requests: write # changesets opens the version PR
+      id-token: write # npm provenance attestation
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -29,17 +30,17 @@ jobs:
       # with no token that line is empty and shadows OIDC (configured auth wins),
       # causing an unauthenticated publish → E404. Omitting it lets npm's
       # automatic OIDC trusted publishing handle auth against the default registry.
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'
 
       # OIDC trusted publishing requires npm >= 11.5.1.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.16.0
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build server
         run: npm run build -w seekstone
@@ -66,7 +67,7 @@ jobs:
       # a no-op, so this is safe to re-run.
       - name: Create release PR or publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
         with:
           version: npm run version-packages
           publish: npm run release

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,25 +21,25 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- **Token-Permissions**: adds `permissions: read-all` at top level in `ci.yml`; moves write permissions to job level in `release.yml` so the top level is no longer `contents: write`
- **Pinned-Dependencies**: pins all `uses:` references to full commit SHAs (with tag comments); switches `npm install` → `npm ci` in both CI and release; pins `npm install -g npm@11.16.0` (was `@latest`)
- **Dependency-Update-Tool**: creates `.github/dependabot.yml` monitoring `github-actions` and `npm` on a weekly schedule

Addresses three Scorecard check failures surfaced after SHA-140.

## Test plan

- [ ] CI matrix (ubuntu/macos/windows) passes with `npm ci`
- [ ] Release workflow still publishes correctly (changesets job has job-level write permissions)
- [ ] After merge: Scorecard run clears Token-Permissions, Pinned-Dependencies, and Dependency-Update-Tool alerts in Code Scanning