### PR TITLE
feat: add CodeQL SAST workflow (SHA-143)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: javascript-typescript
+
+      - uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+
+      - uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` running CodeQL analysis for `javascript-typescript`
- Triggers on push to `main`, all PRs, and weekly (Monday midnight)
- Fixes the OpenSSF Scorecard **SAST** check (currently score 0)
- `permissions: read-all` at top level; job-level override grants only `security-events: write` needed to upload SARIF results
- All actions pinned to commit SHAs (consistent with SHA-142)

## Test plan

- [ ] CodeQL analysis job passes on this PR
- [ ] SARIF results appear in the Security → Code Scanning tab
- [ ] After SHA-142 + this PR merge: Scorecard SAST check clears