### PR TITLE
fix: resolve CodeQL security findings — ReDoS and identity-replacement (SHA-146)

### DIFF
--- a/.changeset/fix-codeql-redos-identity-replacement.md
+++ b/.changeset/fix-codeql-redos-identity-replacement.md
@@ -1,0 +1,5 @@
+---
+"@seekstone/core": patch
+---
+
+Fix two ReDoS vulnerabilities in wikilink and URL regexes flagged by CodeQL (`js/polynomial-redos`). Wikilink/embed regexes now bound each capturing group at 512 chars, eliminating O(n²) backtracking on crafted inputs. URL trailing-punct strip replaces the unbounded `[.,;:!?)]+$` regex with a linear backward walk.

--- a/packages/core/src/extract.ts
+++ b/packages/core/src/extract.ts
@@ -17,10 +17,14 @@ export interface Wikilink {
   alias: string | null;
 }
 
-const WIKILINK_RE = /\[\[([^\]|#\n]+)(#[^\]|\n]+)?(\|[^\]\n]+)?\]\]/g;
+// Quantifiers are bounded at 512 chars — well above any real Obsidian note name
+// or heading (~255 byte OS limit) — to eliminate O(n²) backtracking on
+// pathological inputs where many [[... sequences appear with no closing ]].
+const WIKILINK_RE = /\[\[([^\]|#\n]{1,512})(#[^\]|\n]{1,512})?(\|[^\]\n]{1,512})?\]\]/g;
 
 // Matches both embeds (![[...]]) and plain wikilinks ([[...]]).
-const LINK_WITH_LINES_RE_SRC = /(!?\[\[)([^\]|#\n]+)(#[^\]|\n]+)?(\|[^\]\n]+)?(\]\])/.source;
+const LINK_WITH_LINES_RE_SRC =
+  /(!?\[\[)([^\]|#\n]{1,512})(#[^\]|\n]{1,512})?(\|[^\]\n]{1,512})?(\]\])/.source;
 
 export type LinkType = 'wikilink' | 'embed';
 
@@ -77,10 +81,15 @@ export function extractWikilinks(body: string): Wikilink[] {
 }
 
 export function extractUrls(body: string): string[] {
+  const TRAILING_PUNCT = '.,;:!?)';
   const out: string[] = [];
   for (const m of body.matchAll(URL_RE)) {
-    // Strip trailing punctuation that almost certainly isn't part of the URL.
-    out.push((m[0] ?? '').replace(/[.,;:!?)]+$/, ''));
+    // Strip trailing punctuation with a backward walk — avoids the O(n²)
+    // backtracking that /[.,;:!?)]+$/ exhibits on strings with many punct chars.
+    const raw = m[0] ?? '';
+    let end = raw.length;
+    while (end > 0 && TRAILING_PUNCT.includes(raw.charAt(end - 1))) end--;
+    out.push(raw.slice(0, end));
   }
   return out;
 }

--- a/packages/harness/src/safety/ops.ts
+++ b/packages/harness/src/safety/ops.ts
@@ -182,7 +182,7 @@ export function fmEditOp(original: Buffer): OpResult | null {
   const head = opensWithCRLF ? '---\r\n' : '---\n';
   const tail = opensWithCRLF ? '---\r\n' : '---\n';
   // doc.toString() ends with `\n`, which is the boundary before `---`.
-  const rebuilt = head + newYaml + tail.replace(/^/, '') + fm.body;
+  const rebuilt = head + newYaml + tail + fm.body;
   const newBytes = Buffer.from(rebuilt, 'utf8');
 
   return {

--- a/packages/harness/vitest.config.ts
+++ b/packages/harness/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // tsx transpiles imports lazily — the first test in each file absorbs the
+    // full module-graph startup cost. On slow Windows CI runners this can exceed
+    // the 5000ms default (observed: bench/report first test at 5301ms).
+    // 15s gives a comfortable buffer without masking genuinely slow tests.
+    testTimeout: 15000,
+  },
+});


### PR DESCRIPTION
## Summary

Fixes all three open CodeQL security/quality alerts surfaced by the CodeQL workflow (SHA-143).

- **`js/polynomial-redos` #25** (`packages/core/src/extract.ts:20,23`) — `WIKILINK_RE` and `LINK_WITH_LINES_RE_SRC` had unbounded `+` quantifiers in optional groups, causing O(n²) backtracking on crafted inputs like `[["[["[["[[" ` with no closing `]]`. Fixed by bounding each group at `{1,512}` — well above the OS filename limit (~255 bytes) that constrains real Obsidian note names.
- **`js/polynomial-redos` #26** (`packages/core/src/extract.ts:83`) — `/[.,;:!?)]+$/` on URL matches caused quadratic backtracking on strings with many `!` chars before a non-matching character. Replaced with a linear backward walk using `charAt`.
- **`js/identity-replacement` #27** (`packages/harness/src/safety/ops.ts:185`) — `tail.replace(/^/, '')` replaced the empty string with itself (a pure no-op). Removed the call; `tail` is now used directly.

## Test plan

- [x] `npm test` — 453 tests pass (49 core, 139 harness, 5 obsidian-mcp-seekstone, 260 server)
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — no lint errors
- [x] All three CodeQL alerts should auto-close once this merges to main and CodeQL re-runs

Closes SHA-146