### PR TITLE
feat: upload lcov coverage to Codacy (SHA-148)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
           flags: server
           fail_ci_if_error: false
 
+      - name: Upload coverage to Codacy
+        if: matrix.os == 'ubuntu-latest'
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: packages/server/coverage/lcov.info
+
   changeset:
     name: changeset check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a Codacy coverage upload step to CI so the coverage metric appears on the Codacy dashboard and the >60% coverage goal is tracked.

## What changed

Single new step in `.github/workflows/ci.yml`, running only on `ubuntu-latest` after the existing Coverage gate:

```yaml
- name: Upload coverage to Codacy
  if: matrix.os == 'ubuntu-latest'
  uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
  with:
    project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
    coverage-reports: packages/server/coverage/lcov.info
```

The lcov file is already generated by the existing Coverage gate step — this just forwards it to Codacy.

## Prerequisites

- `CODACY_PROJECT_TOKEN` secret added to GitHub repo ✅

Closes SHA-148