### PR TITLE
chore: triage Codacy error-prone findings — apply vetted subset (SHA-151)

### DIFF
--- a/.changeset/codacy-error-prone-triage.md
+++ b/.changeset/codacy-error-prone-triage.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: apply a vetted subset of Codacy "error-prone" lint suggestions — void-expression block bodies in `log.ts`/`watcher.ts` and redundant optional-chaining removals in tests/harness. Behavior-neutral (no API or runtime change), so no version bump.

--- a/packages/harness/src/bench/adapters/mcpvault.ts
+++ b/packages/harness/src/bench/adapters/mcpvault.ts
@@ -113,7 +113,11 @@ export class McpvaultAdapter implements Backend {
   async close(): Promise<void> {
     this.rl.close();
     this.proc.kill();
-    await new Promise<void>((resolve) => this.proc.once('exit', () => resolve()));
+    await new Promise<void>((resolve) => {
+      this.proc.once('exit', () => {
+        resolve();
+      });
+    });
   }
 
   async search(query: string): Promise<BackendResponse<SearchHit[]>> {

--- a/packages/obsidian-mcp-seekstone/src/shim.test.ts
+++ b/packages/obsidian-mcp-seekstone/src/shim.test.ts
@@ -74,7 +74,7 @@ describe('obsidian-mcp-seekstone smoke: full boot via shim', () => {
         child.kill();
         resolve({ stderr, stdout });
       }, 3000);
-      t.unref?.();
+      t.unref();
     });
     expect(result.stderr).toContain('ready');
     expect(result.stdout).toBe('');

--- a/packages/server/src/log.test.ts
+++ b/packages/server/src/log.test.ts
@@ -122,7 +122,9 @@ describe('createLogger file sink', () => {
     const log = createLogger({ env: { SEEKSTONE_LOG_FILE: bad }, stderr: s.write, now });
     // Warns about the file, then keeps logging to stderr without throwing.
     expect(s.lines.some((l) => l.includes('cannot write log file'))).toBe(true);
-    expect(() => log.info('still works')).not.toThrow();
+    expect(() => {
+      log.info('still works');
+    }).not.toThrow();
     expect(s.lines.some((l) => l.includes('still works'))).toBe(true);
   });
 });

--- a/packages/server/src/log.ts
+++ b/packages/server/src/log.ts
@@ -73,9 +73,9 @@ export function createLogger(opts: LoggerOptions = {}): Logger {
   const stderr = opts.stderr ?? ((line: string): void => void process.stderr.write(line));
   const now = opts.now ?? ((): Date => new Date());
 
-  const level = parseLevel(env.SEEKSTONE_LOG_LEVEL, (m) =>
-    stderr(`WARN  ${now().toISOString()} ${m}\n`),
-  );
+  const level = parseLevel(env.SEEKSTONE_LOG_LEVEL, (m) => {
+    stderr(`WARN  ${now().toISOString()} ${m}\n`);
+  });
   const threshold = ORDER.indexOf(level);
 
   const filePath = env.SEEKSTONE_LOG_FILE;
@@ -125,9 +125,17 @@ export function createLogger(opts: LoggerOptions = {}): Logger {
 
   return {
     level,
-    error: (m, f) => emit('error', m, f),
-    warn: (m, f) => emit('warn', m, f),
-    info: (m, f) => emit('info', m, f),
-    debug: (m, f) => emit('debug', m, f),
+    error: (m, f) => {
+      emit('error', m, f);
+    },
+    warn: (m, f) => {
+      emit('warn', m, f);
+    },
+    info: (m, f) => {
+      emit('info', m, f);
+    },
+    debug: (m, f) => {
+      emit('debug', m, f);
+    },
   };
 }

--- a/packages/server/src/watcher.test.ts
+++ b/packages/server/src/watcher.test.ts
@@ -65,7 +65,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       await ready;
       await writeFile(join(tmpDir, 'watch-mod.md'), 'new_unique_modified_xyz', 'utf8');
       await waitFor(
-        () => ctx.notes.get('watch-mod.md')?.body?.includes('new_unique_modified_xyz') ?? false,
+        () => ctx.notes.get('watch-mod.md')?.body.includes('new_unique_modified_xyz') ?? false,
       );
       expect(ctx.notes.get('watch-mod.md')?.body).toContain('new_unique_modified_xyz');
     } finally {
@@ -197,6 +197,8 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
   it('returns a stop function that closes the watcher', () => {
     const ctx = freshCtx(tmpDir);
     const { stop } = startWatcher(ctx, undefined, { usePolling: true });
-    expect(() => stop()).not.toThrow();
+    expect(() => {
+      stop();
+    }).not.toThrow();
   });
 });

--- a/packages/server/src/watcher.ts
+++ b/packages/server/src/watcher.ts
@@ -155,7 +155,9 @@ export function startWatcher(
     });
 
   const ready = new Promise<void>((resolve) => {
-    watcher.once('ready', () => resolve());
+    watcher.once('ready', () => {
+      resolve();
+    });
   });
 
   return {


### PR DESCRIPTION
## What

Triage of the 23 Codacy "Security / Error-prone" suggestions. None were real vulnerabilities — they're ESLint style-strictness rules (`no-unnecessary-condition`, `no-confusing-void-expression`, `await-thenable`) that the repo's own Biome linter does not enforce and that don't gate CI. This applies **only the type-safe, behavior-preserving subset**.

Closes SHA-151 (part of the SHA-150 quality epic).

## Applied (behavior-neutral)
- **Void-expression block bodies** (`() => x()` → `() => { x(); }`): `log.ts` (warn body + 4 logger methods), `watcher.ts`, `watcher.test.ts`, `log.test.ts`, `mcpvault.ts` (the `exit` promise only).
- **Redundant `?.` on type-guaranteed values**: `watcher.test.ts` (`IndexedNote.body` required), `shim.test.ts` (`NodeJS.Timeout.unref` required).

## Skipped — with reason
- **`init.test.ts` / `walk.test.ts`** — `tsc` proves these break: under `noUncheckedIndexedAccess`, array destructuring and `Record` index access yield `T | undefined`, so the `?.` is correct.
- **`compare.ts` / `runner.ts`** — removing `?.` on a required member (`s.tools`, `backend.list`) makes a downstream guard look unnecessary to Codacy (which doesn't know our `noUncheckedIndexedAccess`), so fixing one finding just creates another. Confirmed: an early revision flagged exactly this as "1 new issue" on the Codacy gate.
- **Adapter response-parsing guards** (`mcpvault.ts`, `mcp-subprocess.ts`) — kept; a malformed response would otherwise throw a raw `TypeError` instead of the clean error message.
- **`seekstone.ts`** — left the `await`; harmless today, guards against the tools later becoming async.

## Follow-up (manual, maintainer)
Disable these patterns in **Codacy → Repository Settings → Code patterns** so rules we deliberately don't enforce stop counting against the grade:
`ESLint8_@typescript-eslint_no-unnecessary-condition`, `…no-confusing-void-expression`, `…await-thenable`.

## Verification
biome clean · tsc clean (all packages) · **404 tests pass** · server bundle builds. Behavior-neutral → empty changeset.