### PR TITLE
fix: harden harness copyVault against Windows 8.3-path fs.cp flakiness (SHA-152)

### DIFF
--- a/packages/harness/src/safety/copy.test.ts
+++ b/packages/harness/src/safety/copy.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { copyVault, scratchPath } from './copy.js';
+import { copyVault, isCopyExcluded, scratchPath } from './copy.js';
 
 describe('scratchPath', () => {
   it('returns a string containing tmpdir() and the label', () => {
@@ -16,6 +16,31 @@ describe('scratchPath', () => {
     const a = scratchPath('label-a');
     const b = scratchPath('label-b');
     expect(a).not.toBe(b);
+  });
+});
+
+describe('isCopyExcluded', () => {
+  it('excludes .obsidian / .git / .trash with POSIX separators', () => {
+    expect(isCopyExcluded('/.obsidian')).toBe(true);
+    expect(isCopyExcluded('/sub/.obsidian/app.json')).toBe(true);
+    expect(isCopyExcluded('/.git')).toBe(true);
+    expect(isCopyExcluded('/notes/.trash/old.md')).toBe(true);
+  });
+
+  it('excludes the same dirs with Windows backslash separators', () => {
+    // fs.cp passes native paths; on Windows these arrive with backslashes.
+    expect(isCopyExcluded('\\.obsidian')).toBe(true);
+    expect(isCopyExcluded('\\sub\\.obsidian\\app.json')).toBe(true);
+    expect(isCopyExcluded('\\.git')).toBe(true);
+    expect(isCopyExcluded('\\notes\\.trash\\old.md')).toBe(true);
+  });
+
+  it('does not exclude the vault root, regular notes, or look-alike names', () => {
+    expect(isCopyExcluded('')).toBe(false); // root itself — must be copied
+    expect(isCopyExcluded('/note.md')).toBe(false);
+    expect(isCopyExcluded('\\folder\\note.md')).toBe(false);
+    expect(isCopyExcluded('/my.obsidian.md')).toBe(false); // substring, not a dir
+    expect(isCopyExcluded('/.obsidianfoo')).toBe(false); // prefix, not exact dir
   });
 });
 

--- a/packages/harness/src/safety/copy.ts
+++ b/packages/harness/src/safety/copy.ts
@@ -1,12 +1,29 @@
 import { cp, mkdir, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 
 export interface CopyResult {
   /** Absolute, real path of the safety copy. */
   copyRoot: string;
   /** Absolute, real path of the original (for the guard check). */
   originalRoot: string;
+}
+
+/**
+ * Vault-relative paths skipped when copying a scratch vault: the big
+ * .obsidian / .git / .trash dirs that write-safety tests don't need and that
+ * would blow the scratch budget on large vaults.
+ *
+ * Separator-agnostic: fs.cp passes native paths (backslashes on Windows), so
+ * we normalise before matching — otherwise these exclusions silently never
+ * fire on Windows.
+ */
+export function isCopyExcluded(rel: string): boolean {
+  const norm = rel.replaceAll('\\', '/');
+  for (const dir of ['.obsidian', '.trash', '.git']) {
+    if (norm.includes(`/${dir}/`) || norm.endsWith(`/${dir}`)) return true;
+  }
+  return false;
 }
 
 /**
@@ -24,29 +41,31 @@ export async function copyVault(
 ): Promise<CopyResult> {
   const srcAbs = await realpath(resolve(srcRoot));
   const label = opts.label ?? `seekstone-safety-${Date.now()}`;
-  const destAbs = resolve(tmpdir(), label);
+  // realpath the tmpdir base so destAbs is the same (long) form as srcAbs.
+  // On Windows, os.tmpdir() can return an 8.3 short path (e.g. RUNNER~1);
+  // leaving it unresolved makes the dest==src / inside-source guards compare
+  // mismatched path forms (so they never fire) and feeds fs.cp a short path it
+  // intermittently mis-resolves into a spurious ENOENT. Same root cause as the
+  // watcher fix in SHA-144; see SHA-152.
+  const destAbs = resolve(await realpath(tmpdir()), label);
 
   if (destAbs === srcAbs) {
     throw new Error(`Refusing to copy: destination equals source (${srcAbs}).`);
   }
-  if (destAbs.startsWith(`${srcAbs}/`)) {
+  if (destAbs.startsWith(`${srcAbs}${sep}`)) {
     throw new Error(`Refusing to copy: destination is inside source.`);
   }
 
   await mkdir(destAbs, { recursive: true });
   await cp(srcAbs, destAbs, {
     recursive: true,
-    force: true,
+    // force defaults to true, which makes fs.cp unlink-before-overwrite — a
+    // step that intermittently throws a spurious ENOENT on Windows. The dest is
+    // a freshly created, uniquely-labelled empty dir, so there is nothing to
+    // overwrite and force buys us nothing.
+    force: false,
     preserveTimestamps: true,
-    // Skip the giant .obsidian/.git/.trash dirs — write-safety tests don't need them
-    // and copying them blows the scratch budget on big vaults.
-    filter: (src) => {
-      const rel = src.slice(srcAbs.length);
-      if (rel.includes('/.obsidian/') || rel.endsWith('/.obsidian')) return false;
-      if (rel.includes('/.trash/') || rel.endsWith('/.trash')) return false;
-      if (rel.includes('/.git/') || rel.endsWith('/.git')) return false;
-      return true;
-    },
+    filter: (src) => !isCopyExcluded(src.slice(srcAbs.length)),
   });
 
   return {


### PR DESCRIPTION
## Problem

Two intermittent Windows CI failures in the dev-only `@seekstone/harness`, "fixed" only by re-run (so they quietly train us to reflexively rerun Windows — which can mask real failures):

- `safety/runner.test.ts` → `ENOENT: unlink 'C:\Users\RUNNER~1\…\seekstone-safety-…\note.md'`
- `bench/report.test.ts` → `Test timed out in 5000ms` — **collateral**: that test is a pure in-memory render with zero I/O, so the timeout means the concurrent `fs.cp` starved the Windows runner's event loop.

## Root cause (`packages/harness/src/safety/copy.ts`)

Same root-cause family as SHA-144 (8.3 short paths), in the safety harness rather than the watcher: `copyVault` built `destAbs` from the raw `os.tmpdir()` (the 8.3 short path `RUNNER~1`) while `srcAbs` was `realpath`'d. The short/long mismatch fed `fs.cp` a path it intermittently mis-resolves into a spurious `ENOENT` on the (default) unlink-before-overwrite step.

## Fix

1. **`realpath` the tmpdir base** so `destAbs` matches the realpath'd source (mirrors SHA-144). Bonus: the `dest==src` / inside-source safety guards now actually fire — they were dead on macOS too, silently relying on `fs.cp` raising `EINVAL`.
2. **`force: false`** — the dest is always a fresh, uniquely-labelled empty dir, so the default unlink-before-overwrite (the `ENOENT` source) buys nothing.
3. **Separator-agnostic** exclude filter + inside-source guard. The `.obsidian/.git/.trash` filter used POSIX `/` and so **never fired on Windows** (needless copying, scratch-budget risk). Extracted a pure `isCopyExcluded()` helper with cross-platform unit tests.

## Verification

- `tsc` + `biome` clean; **456 tests pass** locally (harness +3 new `isCopyExcluded` tests).
- Real proof is Windows CI staying green across repeated runs — I'll re-run the Windows job a couple times on this PR to confirm the flake is gone.
- Harness-only (dev, unpublished) → no changeset required by the CI gate.

Closes SHA-152 (under the SHA-150 quality epic). Distinct from SHA-144 (watcher), which stays correctly closed.