### PR TITLE
fix: add unhandledRejection guard to server + clear Codacy HIGH false positives (SHA-154)

### DIFF
--- a/.changeset/server-unhandled-rejection-guard.md
+++ b/.changeset/server-unhandled-rejection-guard.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Add a process-level `unhandledRejection` guard to the server entrypoint. A stray unhandled promise rejection now logs to stderr and the long-lived stdio session stays up (preserving the in-memory index) instead of crashing the user's MCP session. `uncaughtException` is intentionally left to Node's default crash behaviour.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,6 +12,7 @@ import { dispatch } from './dispatch.js';
 import { buildIndex } from './index/build.js';
 import { parseInitArgs, runInit } from './init.js';
 import { createLogger } from './log.js';
+import { installProcessGuards } from './process-guards.js';
 import { startWatcher } from './watcher.js';
 
 // Inlined at build time by tsup (see tsup.config.ts); falls back in tsx dev.
@@ -40,6 +41,10 @@ if (intent === 'init') {
 }
 
 const log = createLogger();
+
+// Long-lived stdio session: keep the server alive (and its in-memory index)
+// on a stray unhandled rejection rather than crashing the user's session.
+installProcessGuards(log);
 
 const vaultRoot = process.env.SEEKSTONE_VAULT;
 if (!vaultRoot) {

--- a/packages/server/src/process-guards.test.ts
+++ b/packages/server/src/process-guards.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from './log.js';
+import { installProcessGuards } from './process-guards.js';
+
+type CapturedError = { msg: string; fields?: Record<string, unknown> };
+
+function fakeLogger(): Logger & { errors: CapturedError[] } {
+  const errors: CapturedError[] = [];
+  return {
+    errors,
+    level: 'debug',
+    error: (msg, fields) => void errors.push({ msg, fields }),
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+  };
+}
+
+let dispose: (() => void) | undefined;
+
+afterEach(() => {
+  dispose?.();
+  dispose = undefined;
+});
+
+describe('installProcessGuards', () => {
+  it('logs an unhandledRejection via the logger and keeps the process alive', () => {
+    const log = fakeLogger();
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit should not be called');
+    }) as never);
+
+    dispose = installProcessGuards(log);
+    process.emit('unhandledRejection', new Error('boom'), Promise.resolve());
+
+    expect(log.errors).toHaveLength(1);
+    expect(log.errors[0]?.fields).toMatchObject({ error: 'boom' });
+    expect(exit).not.toHaveBeenCalled();
+    exit.mockRestore();
+  });
+
+  it('stringifies non-Error rejection reasons', () => {
+    const log = fakeLogger();
+    dispose = installProcessGuards(log);
+
+    process.emit('unhandledRejection', 'plain string reason', Promise.resolve());
+
+    expect(log.errors[0]?.fields).toMatchObject({ error: 'plain string reason' });
+  });
+
+  it('disposer removes the listener', () => {
+    const log = fakeLogger();
+    const before = process.listenerCount('unhandledRejection');
+    const off = installProcessGuards(log);
+    expect(process.listenerCount('unhandledRejection')).toBe(before + 1);
+    off();
+    expect(process.listenerCount('unhandledRejection')).toBe(before);
+  });
+});

--- a/packages/server/src/process-guards.ts
+++ b/packages/server/src/process-guards.ts
@@ -1,0 +1,27 @@
+import type { Logger } from './log.js';
+
+/**
+ * Install a process-level safety net for the long-lived stdio server session.
+ *
+ * The server's known async paths (dispatch, watcher) already guard themselves,
+ * so a stray `unhandledRejection` is unexpected — but crashing the whole MCP
+ * session (and discarding the in-memory index, which is expensive to rebuild)
+ * is a worse outcome than logging it and staying up. So we log via stderr and
+ * keep running. `uncaughtException` is deliberately left to Node's default
+ * crash behaviour: continuing after a truly uncaught throw risks corrupt state.
+ *
+ * Returns a disposer that removes the listener (used by tests to avoid leaking
+ * handlers across cases).
+ */
+export function installProcessGuards(log: Logger): () => void {
+  const onUnhandledRejection = (reason: unknown): void => {
+    const error = reason instanceof Error ? reason.message : String(reason);
+    log.error('unhandled promise rejection (server kept alive)', { error });
+  };
+
+  process.on('unhandledRejection', onUnhandledRejection);
+
+  return () => {
+    process.off('unhandledRejection', onUnhandledRejection);
+  };
+}

--- a/scripts/smoke-install.mjs
+++ b/scripts/smoke-install.mjs
@@ -72,7 +72,7 @@ try {
   writeFileSync(join(vault, 'Notes', 'Hello.md'), '---\ntitle: Hi\n---\n# Hi\nbody\n');
 
   // 4. Boot each bin and verify: ready on stderr, clean stdout.
-  async function bootAndVerify(binPath, label) {
+  const bootAndVerify = async (binPath, label) => {
     console.log(`• booting ${label}…`);
     await new Promise((resolve, reject) => {
       const child = spawn(process.execPath, [binPath], {
@@ -100,7 +100,7 @@ try {
       }, 4000);
       timer.unref?.();
     });
-  }
+  };
 
   const seekstoneEntry = join(proj, 'node_modules', 'seekstone', 'dist', 'index.js');
   await bootAndVerify(seekstoneEntry, 'seekstone');


### PR DESCRIPTION
Triages Codacy's **28 HIGH findings**. A grounded code review (2 Explore passes + direct reads) found **0 real bugs** — all 28 are false positives from ESLint security/xss rules the repo's Biome linter doesn't enforce and that don't gate CI (repo grade is already A). Continues the SHA-151 / SHA-153 precedent of "apply the vetted subset, suppress the rest."

## Triage

| Family | Count | Verdict |
| -- | -- | -- |
| `detect-object-injection` | 16 | All FP — keys are loop indices / zod-validated enums / const-array literals; server validates all input via zod, harness is dev-only |
| `detect-unhandled-async-errors` | 8 | All FP — the scary-looking one (`watcher.ts:124 void upsert`) is safe because `upsert()` wraps its whole body in try/catch; the rest are awaited-and-caught or vitest tests |
| `xss/no-mixed-html` | 2 | FP — CLI help text + a variable literally named `output` |
| `detect-possible-timing-attacks` | 1 | FP — `pass` is a note count, not a password |
| `no-inner-declarations` | 1 | FP — function at function scope is valid JS (dev-only smoke script) |

## What this PR changes

- **`process-guards.ts` (new)** + wired into the server entrypoint — a process-level `unhandledRejection` guard. The one genuinely useful idea behind the `detect-unhandled-async-errors` noise: a stray rejection now logs to stderr and the **long-lived stdio session stays up** (preserving the expensive in-memory index) instead of crashing the user's MCP session. `uncaughtException` is deliberately left to Node's default crash (continuing after a true uncaught throw risks corrupt state). Extracted to a testable module with coverage.
- **`smoke-install.mjs`** — convert `bootAndVerify` to a `const` arrow, clearing the lone `no-inner-declarations` finding **in code** so we keep that (legitimate) rule enabled rather than disabling a whole family for one dev-script hit.

## Follow-up (manual, not in this PR)

Disable these 4 noisy FP families repo-wide in the Codacy coding standard, per the `detect-non-literal-fs-filename` precedent:

- `ESLint8_security_detect-object-injection`
- `ESLint8_security-node_detect-unhandled-async-errors` (now backstopped by the runtime guard)
- `ESLint8_xss_no-mixed-html`
- `ESLint8_security_detect-possible-timing-attacks`

## Verification

- `npm test` — full matrix green (server now 24 test files incl. new `process-guards.test.ts`)
- `npx tsc -p packages/{server,core,harness}/tsconfig.json --noEmit` — clean
- `npm run lint` (biome) — clean

Closes SHA-154.