### PR TITLE
fix(ci): skip coverage upload on Dependabot PRs (SHA-155)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,11 @@ jobs:
           SEEKSTONE_COVERAGE: '1'
         run: npx vitest run --coverage --root packages/server
 
+      # Coverage upload is a reporting side-effect, not a correctness gate.
+      # Skip it for Dependabot PRs: GitHub withholds repo secrets from
+      # Dependabot-triggered runs, so the token is empty and the step fails.
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -62,7 +65,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage to Codacy
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
## Problem

The `Upload coverage to Codacy` step fails on **every Dependabot PR**:

> `Invalid configuration: Either a project or account API token must be provided`

GitHub deliberately withholds repository secrets (`CODACY_PROJECT_TOKEN`) from Dependabot-triggered workflow runs, so the step can never authenticate — turning `test (ubuntu-latest)` red even when the bump itself is fine. This currently makes **#114, #116, #117, #119** look broken on their coverage step alone, and recurs on every future Dependabot PR.

## Fix

Gate both coverage-upload steps (Codacy + Codecov, for consistency) on `github.actor != 'dependabot[bot]'`. Coverage upload is a reporting side-effect, not a correctness gate, so skipping it on dependency PRs is safe. It still runs on normal pushes/PRs to `main`.

Used the actor guard rather than a `secrets.* != ''` check because secrets aren't reliably evaluable in `if:` conditions.

## Verification

- This PR is authored by a human, so the coverage steps **still run here** — confirming normal PRs are unaffected.
- After merge, re-running CI on a Dependabot PR (e.g. #116) will show the coverage step **skipped** and `test (ubuntu-latest)` green.

Closes SHA-155.