### PR TITLE
chore(deps): adopt Biome 2.5 — migrate config + reformat (SHA-157)

### DIFF
--- a/.changeset/adopt-biome-2.md
+++ b/.changeset/adopt-biome-2.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: adopt the Biome 2.5 toolchain (`biome migrate` config update + 2.x import-ordering/formatting). Touches some server source files for formatting only — no API or runtime change, so no version bump.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": { "ignoreUnknown": true },
   "formatter": {
@@ -11,7 +11,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": {
         "useImportType": "warn",
         "useNodejsImportProtocol": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "devDependencies": {
         "@anthropic-ai/mcpb": "^2.1.2",
-        "@biomejs/biome": "^1.9.4",
+        "@biomejs/biome": "^2.5.0",
         "@changesets/cli": "^2.31.0",
         "@types/node": "^25.9.3",
         "@vitest/coverage-v8": "^4.1.8",
@@ -119,9 +119,10 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.9.4",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.0.tgz",
+      "integrity": "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
         "biome": "bin/biome"
@@ -134,18 +135,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.9.4",
-        "@biomejs/cli-darwin-x64": "1.9.4",
-        "@biomejs/cli-linux-arm64": "1.9.4",
-        "@biomejs/cli-linux-arm64-musl": "1.9.4",
-        "@biomejs/cli-linux-x64": "1.9.4",
-        "@biomejs/cli-linux-x64-musl": "1.9.4",
-        "@biomejs/cli-win32-arm64": "1.9.4",
-        "@biomejs/cli-win32-x64": "1.9.4"
+        "@biomejs/cli-darwin-arm64": "2.5.0",
+        "@biomejs/cli-darwin-x64": "2.5.0",
+        "@biomejs/cli-linux-arm64": "2.5.0",
+        "@biomejs/cli-linux-arm64-musl": "2.5.0",
+        "@biomejs/cli-linux-x64": "2.5.0",
+        "@biomejs/cli-linux-x64-musl": "2.5.0",
+        "@biomejs/cli-win32-arm64": "2.5.0",
+        "@biomejs/cli-win32-x64": "2.5.0"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.9.4",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.0.tgz",
+      "integrity": "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw==",
       "cpu": [
         "arm64"
       ],
@@ -160,9 +163,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.0.tgz",
+      "integrity": "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ==",
       "cpu": [
         "x64"
       ],
@@ -177,13 +180,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.0.tgz",
+      "integrity": "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -194,13 +200,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.0.tgz",
+      "integrity": "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -211,13 +220,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.0.tgz",
+      "integrity": "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -228,13 +240,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.0.tgz",
+      "integrity": "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -245,9 +260,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.0.tgz",
+      "integrity": "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw==",
       "cpu": [
         "arm64"
       ],
@@ -262,9 +277,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.0.tgz",
+      "integrity": "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "description": "Obsidian MCP server — filesystem-direct, low context-tax. Currently scaffolded as a measurement + benchmark harness against the Local REST API plugin baseline.",
   "type": "module",
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "engines": {
     "node": ">=22"
   },
@@ -25,7 +27,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^2.1.2",
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "^2.5.0",
     "@changesets/cli": "^2.31.0",
     "@types/node": "^25.9.3",
     "@vitest/coverage-v8": "^4.1.8",

--- a/packages/harness/src/bench/adapters/fs.ts
+++ b/packages/harness/src/bench/adapters/fs.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import fg from 'fast-glob';

--- a/packages/harness/src/bench/adapters/mcp-subprocess.ts
+++ b/packages/harness/src/bench/adapters/mcp-subprocess.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from 'node:child_process';
-import { type Interface, createInterface } from 'node:readline';
+import { createInterface, type Interface } from 'node:readline';
 
 interface JsonRpcRequest {
   jsonrpc: '2.0';

--- a/packages/harness/src/bench/adapters/mcpvault.ts
+++ b/packages/harness/src/bench/adapters/mcpvault.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from 'node:child_process';
-import { type Interface, createInterface } from 'node:readline';
+import { createInterface, type Interface } from 'node:readline';
 import type { Backend, BackendResponse, ListEntry, SearchHit } from '../backend.js';
 
 /**

--- a/packages/harness/src/bench/index.ts
+++ b/packages/harness/src/bench/index.ts
@@ -9,4 +9,4 @@ export { SeekstoneAdapter } from './adapters/seekstone.js';
 export type { Backend, BackendResponse, ListEntry, SearchHit } from './backend.js';
 export { loadQuerySet, type QueryDef, type QuerySet } from './queries.js';
 export { renderBenchmarkMarkdown } from './report.js';
-export { type BenchmarkSummary, type ToolBenchmarks, runBenchmark } from './runner.js';
+export { type BenchmarkSummary, runBenchmark, type ToolBenchmarks } from './runner.js';

--- a/packages/harness/src/bench/queries.test.ts
+++ b/packages/harness/src/bench/queries.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';

--- a/packages/harness/src/bench/runner.ts
+++ b/packages/harness/src/bench/runner.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import type { Backend } from './backend.js';
 import type { QuerySet } from './queries.js';
-import { type RunStats, type StreamStats, runN, runNStream } from './timer.js';
+import { type RunStats, runN, runNStream, type StreamStats } from './timer.js';
 
 export interface ToolBenchmarks {
   /** list_notes — vault-wide listing, no filters. */

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -1,19 +1,18 @@
 #!/usr/bin/env -S npx tsx
-import { mkdir, writeFile } from 'node:fs/promises';
-import { readFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { cac } from 'cac';
 import { McpObsidianAdapter } from './bench/adapters/mcp-obsidian.js';
 import { McpvaultAdapter } from './bench/adapters/mcpvault.js';
+import { ObsidianMcpAdapter } from './bench/adapters/obsidian-mcp.js';
 import { ObsidianMcpProAdapter } from './bench/adapters/obsidian-mcp-pro.js';
 import { ObsidianMcpServerAdapter } from './bench/adapters/obsidian-mcp-server.js';
-import { ObsidianMcpAdapter } from './bench/adapters/obsidian-mcp.js';
 import { SeekstoneAdapter } from './bench/adapters/seekstone.js';
 import { renderComparisonMarkdown } from './bench/compare.js';
 import {
   FsAdapter,
-  RestAdapter,
   loadQuerySet,
+  RestAdapter,
   renderBenchmarkMarkdown,
   runBenchmark,
 } from './bench/index.js';

--- a/packages/harness/src/safety/index.ts
+++ b/packages/harness/src/safety/index.ts
@@ -1,4 +1,4 @@
 export { copyVault } from './copy.js';
-export { selectFrontmatterHeavyNotes } from './select.js';
 export { renderSafetyMarkdown } from './report.js';
 export { prepareSafetyVault, runSafety, type SafetySummary } from './runner.js';
+export { selectFrontmatterHeavyNotes } from './select.js';

--- a/packages/harness/src/safety/report.ts
+++ b/packages/harness/src/safety/report.ts
@@ -115,7 +115,7 @@ function detectSystemicFailures(s: SafetySummary): SystemicFinding[] {
   return findings;
 }
 
-function opVerdict(op: string, pass: number, fail: number, total: number): string {
+function opVerdict(_op: string, pass: number, fail: number, total: number): string {
   if (fail === 0) return '✅ Pass';
   if (pass === 0) return `❌ **Fail — all ${total} notes** (systemic)`;
   return `⚠️ Partial — ${fail}/${total} failed`;

--- a/packages/harness/src/safety/runner.ts
+++ b/packages/harness/src/safety/runner.ts
@@ -3,15 +3,15 @@ import { join, resolve } from 'node:path';
 import type { Backend } from '../bench/backend.js';
 import { copyVault } from './copy.js';
 import {
-  type OpKind,
-  type OpResult,
   bodyAppendOp,
   fmEditOp,
   identityOp,
+  type OpKind,
+  type OpResult,
   patchNoteOp,
   replaceInNoteOp,
 } from './ops.js';
-import { type Candidate, selectFrontmatterHeavyNotes } from './select.js';
+import { selectFrontmatterHeavyNotes } from './select.js';
 
 export interface SafetyOpResult {
   op: OpKind;

--- a/packages/obsidian-mcp-seekstone/package.json
+++ b/packages/obsidian-mcp-seekstone/package.json
@@ -40,7 +40,11 @@
   "bin": {
     "obsidian-mcp-seekstone": "./bin/seekstone.js"
   },
-  "files": ["bin", "README.md", "LICENSE"],
+  "files": [
+    "bin",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "vitest run"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,7 +41,9 @@
     "seekstone": "./dist/index.js"
   },
   "main": "./dist/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/server/src/dispatch.test.ts
+++ b/packages/server/src/dispatch.test.ts
@@ -3,10 +3,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { ServerContext } from './context.js';
-import { HANDLED_TOOLS, dispatch } from './dispatch.js';
+import { dispatch, HANDLED_TOOLS } from './dispatch.js';
 import { buildIndex } from './index/build.js';
-import { createLogger } from './log.js';
 import type { Logger } from './log.js';
+import { createLogger } from './log.js';
 
 interface LogRecord {
   level: string;

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -13,8 +13,8 @@ import { PatchFrontmatterInput, patchFrontmatter } from './tools/patch_frontmatt
 import { PatchNoteInput, patchNote } from './tools/patch_note.js';
 import {
   AppendPeriodicNoteInput,
-  GetPeriodicNoteInput,
   appendPeriodicNote,
+  GetPeriodicNoteInput,
   getPeriodicNote,
 } from './tools/periodic_note.js';
 import { ReadNoteInput, readNote } from './tools/read_note.js';

--- a/packages/server/src/index/build.test.ts
+++ b/packages/server/src/index/build.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -33,9 +33,6 @@ afterAll(async () => {
 
 describe('buildIndex', () => {
   it('index contains all .md files in vault', async () => {
-    const { index } = await buildIndex(vaultRoot);
-    // MiniSearch doesn't expose a direct count, but search for common words
-    // and count unique ids — instead use notes map
     const { notes } = await buildIndex(vaultRoot);
     expect(notes.size).toBe(2);
   });

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -4,7 +4,7 @@
 // of which function is used; that score penalty is accepted. See SHA-139.
 import { execFileSync } from 'node:child_process';
 import type { Dirent } from 'node:fs';
-import { access, copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { access, copyFile, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import path, { dirname, join } from 'node:path';
 
 /**

--- a/packages/server/src/tools/create_note.test.ts
+++ b/packages/server/src/tools/create_note.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import MiniSearch from 'minisearch';

--- a/packages/server/src/tools/get_links.ts
+++ b/packages/server/src/tools/get_links.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
-import { extractLinksWithLines } from '@seekstone/core/extract';
 import type { LinkType } from '@seekstone/core/extract';
+import { extractLinksWithLines } from '@seekstone/core/extract';
 import { z } from 'zod';
 import type { ServerContext } from '../context.js';
 import { resolveLink } from '../index/resolve.js';


### PR DESCRIPTION
Supersedes Dependabot **#115** (`@biomejs/biome` 1.9.4 → 2.5.0). Dependabot rebased its branch mid-work, so this is a clean re-do off current `main`.

## Why #115 was red

Biome 2.x is a major release: the old `biome.json` used the 1.9.4 `$schema` + deprecated `recommended` field, and 2.x changed formatter/linter rules → `biome check` failed Lint on all 3 OSes.

## What this PR does

- Bump `@biomejs/biome` 1.9.4 → **2.5.0**.
- `biome migrate` → `biome.json` updated to the 2.5 schema (`recommended: true` → `preset: "recommended"`).
- Apply 2.x formatting (import ordering, multi-line JSON arrays) across the repo.
- Clear the findings newly surfaced by the 2.x recommended preset — all behavior-neutral:
  - remove genuinely unused imports/vars in a few tests,
  - prefix `opVerdict`'s unused `op` param with `_`,
  - drop a dead `const { index } = …` destructure in `build.test.ts`.

No runtime/API change → **no-bump changeset** (matches the SHA-151 internal-change precedent).

## Verification

- `npm run lint` (Biome 2.5) — clean, exit 0
- `npx tsc -p packages/{core,harness,server}/tsconfig.json --noEmit` — clean (on TS 6.0)
- `npm test` — full matrix green (24 server test files, etc.)

Closes SHA-157. Closes #115.