### PR TITLE
feat(ci): attest MCPB build provenance for signed releases (SHA-159)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
     permissions:
       contents: write # changesets opens the version PR and pushes tags
       pull-requests: write # changesets opens the version PR
-      id-token: write # npm provenance attestation
+      id-token: write # npm provenance + sigstore signing
+      attestations: write # write the MCPB build-provenance attestation
     defaults:
       run:
         shell: bash
@@ -86,11 +87,24 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: npm run build:mcpb
 
-      - name: Attach MCPB to GitHub Release
+      # Keyless (OIDC → Fulcio → Rekor) SLSA build-provenance attestation for the
+      # exact bytes of the shipped bundle. Verifiable with `gh attestation verify`.
+      - name: Attest build provenance for MCPB
+        id: attest
+        if: steps.changesets.outputs.published == 'true'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: seekstone.mcpb
+
+      - name: Attach MCPB + provenance to GitHub Release
         if: steps.changesets.outputs.published == 'true'
         run: |
           VERSION=$(node -p "require('./packages/server/package.json').version")
-          gh release upload "seekstone@${VERSION}" seekstone.mcpb --clobber
+          # Upload the attestation under a Scorecard-recognized extension so the
+          # Signed-Releases check detects it as a release signature asset.
+          cp "${{ steps.attest.outputs.bundle-path }}" seekstone.mcpb.intoto.jsonl
+          gh release upload "seekstone@${VERSION}" \
+            seekstone.mcpb seekstone.mcpb.intoto.jsonl --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Why

OpenSSF Scorecard **Signed-Releases = 0** — the one concrete remaining lever in SHA-141 (Scorecard now 6.3). The `seekstone@X` release attaches `seekstone.mcpb` but **no signature/attestation**. npm provenance is already enabled, but Scorecard's check inspects **GitHub Release assets**, not the npm registry — so it scores 0.

## What this does (`release.yml` only)

1. Add `attestations: write` to the release job (already had `id-token: write`).
2. After `Build MCP Bundle`, run `actions/attest-build-provenance@v4.1.0` (SHA-pinned) on `seekstone.mcpb` — **keyless Sigstore** (OIDC → Fulcio → Rekor) SLSA build provenance, no key management.
3. Upload the attestation bundle as a release asset **`seekstone.mcpb.intoto.jsonl`** (a Scorecard-recognized signature extension), alongside the `.mcpb`.

Consumers can verify:
```bash
gh attestation verify seekstone.mcpb --repo shaqmughal/seekstone
```

## Verification

This is a **release-only** workflow (steps gate on `published == 'true'`), so it can't be exercised by a normal PR. After the next publish (e.g. the held #105 "version packages" PR):
- the `seekstone@X` release should carry **two assets**: `seekstone.mcpb` + `seekstone.mcpb.intoto.jsonl`
- `gh attestation verify` passes
- the next Scorecard scan shows Signed-Releases > 0 (overall crosses ~7 with the merged SHA-158 vuln fix)

Static checks done: YAML valid, the new `uses:` is SHA-pinned (Pinned-Dependencies preserved), and `attest-build-provenance@v4.1.0` exposes `subject-path`/`bundle-path` as used.

## Known limitation

Releases come in pairs (`seekstone@X` + `obsidian-mcp-seekstone@X` shim); the shim has no binary artifact to sign, so Scorecard (averaged over recent releases) may land Signed-Releases **partial (~5)**, not 10. Still clears the ≥7 target. Maxing it is an optional follow-up (noted in SHA-141).

No changeset — workflow files aren't a publishable path.

Closes SHA-159.