### PR TITLE
fix(ci): drop redundant obsidian-mcp-seekstone GitHub Release (SHA-161)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # `seekstone` and `obsidian-mcp-seekstone` are linked in changesets, so the
+      # action cuts a GitHub Release for BOTH tags every version. The alias is a
+      # pure npm-discoverability redirect (its only dep is `seekstone`), and the
+      # install bundle is a signed/attested artifact that should have ONE canonical
+      # home — `seekstone@X`. So we delete the redundant alias Release here, keeping
+      # the git tag (no --cleanup-tag) for provenance and leaving the npm package
+      # untouched. Idempotent: re-runs where it's already gone are a no-op.
+      - name: Remove redundant alias GitHub Release
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          VERSION=$(node -p "require('./packages/obsidian-mcp-seekstone/package.json').version")
+          if gh release view "obsidian-mcp-seekstone@${VERSION}" >/dev/null 2>&1; then
+            gh release delete "obsidian-mcp-seekstone@${VERSION}" --yes
+          else
+            echo "No obsidian-mcp-seekstone@${VERSION} release to delete; skipping."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install mcp-publisher
         if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: |


### PR DESCRIPTION
## Problem

`seekstone` and `obsidian-mcp-seekstone` are `linked` in `.changeset/config.json`, so `changesets/action` cuts a GitHub Release for **both** tags every version. The install bundle is attached only to `seekstone@X` (`release.yml` ~L106), leaving `obsidian-mcp-seekstone@X` a near-empty peer showing just GitHub's auto-generated source zip/tar.gz — confusing, and it looks broken to anyone who lands on it.

## Fix

Don't duplicate a signed/attested artifact across two releases (one canonical home — matches VS Code `.vsix`, pnpm, CLI-binary convention). Instead, delete the redundant alias **GitHub Release** in a post-publish step.

`changesets/action`'s `createGithubReleases` is all-or-nothing in v1.9.0 — you can't natively skip one package's release ([combined-release feature is still an open request](https://github.com/changesets/action/issues/505)) — so a post-step delete is the clean lever.

### Keep vs. remove

| Thing | Created by | Outcome |
|---|---|---|
| npm package `obsidian-mcp-seekstone` | `npm publish` (`release` step) | **Kept** — the npm-search discoverability alias |
| git tag `obsidian-mcp-seekstone@X` | changesets | **Kept** (no `--cleanup-tag`) — needed for provenance |
| GitHub Release page `obsidian-mcp-seekstone@X` | `changesets/action` | **Removed** |

Discoverability is unaffected — npm searchers hit the npm listing, not the GitHub Release page.

The new step is existence-guarded (`gh release view ... || skip`) so workflow re-runs stay idempotent.

## Testing

CI-only workflow change — no unit-testable code surface. Validated `release.yml` parses and the new `Remove redundant alias GitHub Release` step is ordered after the MCPB attach and before the registry publish. Behaviour is verifiable only on the next real release; acceptance criteria tracked in the issue.

Closes SHA-161.