### PR TITLE
docs: link seekstone.dev across README, llms.txt, package homepages (SHA-120)

### DIFF
--- a/.changeset/seekstone-dev-homepage.md
+++ b/.changeset/seekstone-dev-homepage.md
@@ -1,0 +1,6 @@
+---
+"seekstone": patch
+"obsidian-mcp-seekstone": patch
+---
+
+Point package `homepage` at the new site, https://seekstone.dev (was the GitHub readme).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 <p align="center"><strong>The fastest Obsidian MCP server for Claude — search and edit your vault in milliseconds, without burning context.</strong></p>
 <p align="center"><em>Filesystem-direct · 16 tools · No plugins · No Obsidian app required · macOS · Linux · Windows</em></p>
 
+<p align="center"><a href="https://seekstone.dev"><strong>seekstone.dev →</strong></a></p>
+
 <p align="center">
   <a href="https://www.npmjs.com/package/obsidian-mcp-seekstone"><img src="https://img.shields.io/npm/v/obsidian-mcp-seekstone?color=cb3837&logo=npm&label=obsidian-mcp-seekstone" alt="npm" /></a>
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/v/seekstone?color=cb3837&logo=npm&label=seekstone" alt="npm (seekstone)" /></a>

--- a/llms.txt
+++ b/llms.txt
@@ -2,6 +2,8 @@
 
 > Seekstone is an Obsidian MCP server that connects Claude (and any Model Context Protocol client) to your Obsidian vault. It reads the vault directly from disk — no Obsidian app, no Local REST API plugin, no network calls. Works on macOS, Linux, and Windows.
 
+Website: https://seekstone.dev
+
 Seekstone is published to npm under two names:
 - `obsidian-mcp-seekstone` — the discoverable name (search "obsidian mcp" on npm)
 - `seekstone` — the short canonical name

--- a/packages/obsidian-mcp-seekstone/package.json
+++ b/packages/obsidian-mcp-seekstone/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "author": "Shaq Mughal",
-  "homepage": "https://github.com/shaqmughal/seekstone#readme",
+  "homepage": "https://seekstone.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/shaqmughal/seekstone.git",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "author": "Shaq Mughal",
-  "homepage": "https://github.com/shaqmughal/seekstone#readme",
+  "homepage": "https://seekstone.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/shaqmughal/seekstone.git",


### PR DESCRIPTION
Part of **SHA-120** — post-launch propagation of the now-live `seekstone.dev` into the repo's surfaces.

## Changes
- **README** — added a `seekstone.dev →` link in the header, above the badge row.
- **llms.txt** — added `Website: https://seekstone.dev` near the top. AI crawlers read llms.txt first, so this directly feeds the GEO/citation strategy.
- **`packages/server` (`seekstone`)** + **`packages/obsidian-mcp-seekstone`** — set `"homepage"` to `https://seekstone.dev` (was the GitHub readme), so both npm package pages link to the site.

## Notes
- The site is live and verified (canonical `seekstone.dev`, the two `.com`s 308-redirect to it, valid SSL).
- The `homepage` change surfaces on npm on the **next publish** of each package.

## Still open in SHA-120 (manual, your side)
- GitHub repo **"Website"** field → set to `https://seekstone.dev` (repo Settings — a dashboard click).
- Registry listings (Glama, PulseMCP, mcp.so, MCPMarket, OpenTools) + community posts (Reddit / Discord / Forum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)