### PR TITLE
fix(mcpb): shard bundle under Claude Desktop's ~108KB per-file install cap (SHA-169)

### DIFF
--- a/.changeset/mcpb-shard-per-file-cap.md
+++ b/.changeset/mcpb-shard-per-file-cap.md
@@ -1,0 +1,11 @@
+---
+"seekstone": patch
+---
+
+fix(mcpb): shard the bundle under Claude Desktop's ~108KB per-file install cap
+
+The `.mcpb` one-click install silently broke as of v0.4.0: Claude Desktop's
+local install preview rejects a bundle if any single file exceeds ~108KB, and
+the fully-bundled `dist/index.js` is ~1.7MB. The bundle is now split into <95KB
+shards that a small loader reassembles at startup, so the install dialog appears
+again. A build-time guard fails the build if any packed file exceeds the cap.

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -17,6 +17,11 @@ exclude_paths:
   - "dist/**"
   - "packages/**/dist/**"
 
+  # .mcpb distribution shim. Its one intentional dynamic import() — of a
+  # content-hashed temp file we wrote ourselves from local shards (SHA-169) —
+  # trips Codacy's "unsafe import" heuristic with no external input involved.
+  - "packages/server/mcpb-loader.mjs"
+
   # Coverage artefacts.
   - "coverage/**"
   - "packages/**/coverage/**"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # build outputs
 dist/
 *.tsbuildinfo
+.mcpb-build/
 
 # coverage reports
 coverage/

--- a/packages/server/mcpb-loader.mjs
+++ b/packages/server/mcpb-loader.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Entry point for the .mcpb bundle (shipped as `dist/index.js`).
+ *
+ * The real server is a single large ESM bundle. Claude Desktop's local install
+ * preview silently rejects a bundle if any file inside it exceeds ~108KB
+ * (SHA-169), so the bundle is split into sub-cap shards (`index.NNN.part`).
+ * This loader concatenates the shards back into one module and imports it.
+ *
+ * Reassembly goes through a temp file (not a `data:` URL) because the bundle's
+ * banner calls `createRequire(import.meta.url)`, which needs a real file URL to
+ * resolve Node built-ins. The temp file is keyed by a content hash and reused
+ * across launches, so it is written at most once per bundle version.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const dir = fileURLToPath(new URL('.', import.meta.url));
+const parts = readdirSync(dir)
+  .filter((f) => /^index\.\d+\.part$/.test(f))
+  .sort();
+
+if (parts.length === 0) {
+  throw new Error(`seekstone: no bundle shards (index.NNN.part) found in ${dir}`);
+}
+
+const code = Buffer.concat(parts.map((p) => readFileSync(join(dir, p))));
+const hash = createHash('sha256').update(code).digest('hex').slice(0, 16);
+const out = join(tmpdir(), `seekstone-bundle-${hash}.mjs`);
+
+if (!existsSync(out) || statSync(out).size !== code.length) {
+  writeFileSync(out, code);
+}
+
+await import(pathToFileURL(out).href);

--- a/packages/server/tsup.mcpb.config.ts
+++ b/packages/server/tsup.mcpb.config.ts
@@ -7,6 +7,11 @@ const { version } = JSON.parse(readFileSync(new URL('./package.json', import.met
 // its built-in Node.js in an isolated directory — no node_modules available.
 // Everything must be inlined; nothing can remain external.
 //
+// scripts/build-mcpb.mjs then shards this single file into <95KB pieces, because
+// Claude Desktop's install preview silently rejects any bundle file >~108KB
+// (SHA-169). Sourcemaps are off: the .map would be a multi-MB file we'd only
+// have to drop anyway, and it ships no value to end users.
+//
 // Banner trick: yaml's node build is CJS and calls require('process'). tsup's
 // ESM __require shim checks `typeof require !== "undefined"` at init time.
 // Injecting `var require = createRequire(...)` in the banner runs BEFORE that
@@ -25,6 +30,6 @@ export default defineConfig({
   },
   define: { __SEEKSTONE_VERSION__: JSON.stringify(version) },
   dts: false,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
 });

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -5,40 +5,96 @@
  * Steps:
  *   1. Read the current version from packages/server/package.json.
  *   2. Stamp it into packages/server/manifest.json (keeps them in sync).
- *   3. Build the server (npx tsup in packages/server).
- *   4. Pack packages/server/ into seekstone.mcpb at the repo root.
+ *   3. Build the fully-bundled ESM server (npx tsup, all deps inlined).
+ *   4. Stage manifest + metadata + the sharded bundle into a clean dir.
+ *   5. Guard: fail if any staged file exceeds the per-file cap.
+ *   6. Pack the staging dir into seekstone.mcpb at the repo root.
+ *
+ * Why sharding: Claude Desktop's local .mcpb install preview silently rejects a
+ * bundle if *any* file inside it exceeds ~108KB (SHA-169) — no dialog, no error.
+ * The bundled server is ~1.7MB, so it is split into <95KB shards that the loader
+ * (packages/server/mcpb-loader.mjs, shipped as dist/index.js) reassembles at
+ * startup. The guard below makes a future oversized file fail the build loudly
+ * instead of silently breaking one-click install.
  */
 
 import { execSync } from 'node:child_process';
-import { readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import {
+  cpSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { MAX_FILE_BYTES, MAX_SHARD_BYTES, shard } from './shard.mjs';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const serverDir = join(root, 'packages', 'server');
 const manifestPath = join(serverDir, 'manifest.json');
+const stage = join(root, '.mcpb-build');
 const output = join(root, 'seekstone.mcpb');
 
-// 1. Read version from package.json.
-const pkg = JSON.parse(await readFile(join(serverDir, 'package.json'), 'utf8'));
-const { version } = pkg;
-
-// 2. Stamp version into manifest.json.
-const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+// 1 + 2. Stamp version into manifest.json.
+const { version } = JSON.parse(readFileSync(join(serverDir, 'package.json'), 'utf8'));
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 manifest.version = version;
-await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 console.log(`Stamped manifest.json with version ${version}`);
 
-// 3. Build a fully-bundled version for the mcpb (all deps inlined — no node_modules
-//    available when Claude Desktop runs it with built-in Node.js).
+// 3. Build the fully-bundled server (all deps inlined — no node_modules at runtime).
 console.log('Building server (mcpb — all deps bundled)...');
 execSync('npx tsup --config tsup.mcpb.config.ts', { stdio: 'inherit', cwd: serverDir });
 
-// 4. Pack into seekstone.mcpb.
-console.log('Packing...');
-execSync(`npx @anthropic-ai/mcpb pack "${serverDir}" "${output}"`, {
-  stdio: 'inherit',
-  cwd: root,
+// 4. Stage metadata + the sharded bundle.
+console.log('Staging + sharding...');
+rmSync(stage, { recursive: true, force: true });
+mkdirSync(join(stage, 'dist'), { recursive: true });
+for (const file of ['manifest.json', 'package.json', 'README.md', 'LICENSE']) {
+  cpSync(join(serverDir, file), join(stage, file));
+}
+const bundle = readFileSync(join(serverDir, 'dist', 'index.js'));
+const shards = shard(bundle, MAX_SHARD_BYTES);
+shards.forEach((part, i) => {
+  writeFileSync(join(stage, 'dist', `index.${String(i).padStart(3, '0')}.part`), part);
 });
+// The loader becomes the entry point (dist/index.js) named in the manifest.
+cpSync(join(serverDir, 'mcpb-loader.mjs'), join(stage, 'dist', 'index.js'));
+console.log(
+  `Split ${bundle.length} bytes into ${shards.length} shards (max ${MAX_SHARD_BYTES} bytes each)`,
+);
 
-console.log(`\nBuilt: seekstone.mcpb (v${version})`);
+// 5. Guard: nothing in the bundle may exceed the per-file cap, or Claude Desktop
+//    silently rejects it (SHA-169).
+for (const file of walk(stage)) {
+  const { size } = statSync(file);
+  if (size > MAX_FILE_BYTES) {
+    throw new Error(
+      `mcpb: ${relative(root, file)} is ${size} bytes (> ${MAX_FILE_BYTES} cap). ` +
+        'Claude Desktop will silently reject the bundle — see SHA-169.',
+    );
+  }
+}
+
+// 6. Pack.
+console.log('Packing...');
+execSync(`npx @anthropic-ai/mcpb pack "${stage}" "${output}"`, { stdio: 'inherit', cwd: root });
+rmSync(stage, { recursive: true, force: true });
+
+console.log(
+  `\nBuilt: seekstone.mcpb (v${version}) — sharded, every file < ${MAX_FILE_BYTES} bytes`,
+);
+
+/** Recursively yield every file path under `dir`. */
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}

--- a/scripts/shard.mjs
+++ b/scripts/shard.mjs
@@ -1,0 +1,30 @@
+/**
+ * Split a buffer into byte-slices no larger than `max`.
+ *
+ * The .mcpb server bundle is a single large ESM file. Claude Desktop's local
+ * install preview silently rejects a bundle if *any* file inside it exceeds
+ * ~108KB (SHA-169) — no dialog, no error. So we ship the bundle as a set of
+ * sub-cap shards (`index.NNN.part`) that the loader concatenates back at
+ * startup. Splitting is a plain byte slice; reassembly is plain concatenation,
+ * so the round-trip is exact.
+ */
+
+// Shard ceiling. Held comfortably below the observed ~108KB cap so the metadata
+// files (manifest/package.json/README) and any zip overhead also stay clear.
+export const MAX_SHARD_BYTES = 95 * 1024;
+
+// Hard guard for the whole bundle: no packed file may exceed this. Margin below
+// the ~108KB cap leaves room without being so tight it risks a silent reject.
+export const MAX_FILE_BYTES = 100 * 1024;
+
+/**
+ * @param {Buffer} buf
+ * @param {number} [max]
+ * @returns {Buffer[]} byte-slices whose concatenation equals `buf`
+ */
+export function shard(buf, max = MAX_SHARD_BYTES) {
+  if (max <= 0) throw new Error(`shard: max must be positive, got ${max}`);
+  const parts = [];
+  for (let i = 0; i < buf.length; i += max) parts.push(buf.subarray(i, i + max));
+  return parts;
+}

--- a/scripts/shard.test.ts
+++ b/scripts/shard.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_SHARD_BYTES, shard } from './shard.mjs';
+
+describe('shard', () => {
+  it('round-trips: concatenated shards equal the original bytes', () => {
+    const buf = Buffer.from('seekstone'.repeat(50_000)); // ~450KB
+    const parts = shard(buf, 95 * 1024);
+    expect(Buffer.concat(parts).equals(buf)).toBe(true);
+  });
+
+  it('keeps every shard at or under the cap', () => {
+    const buf = Buffer.alloc(1_700_000, 7);
+    const max = 95 * 1024;
+    for (const part of shard(buf, max)) expect(part.length).toBeLessThanOrEqual(max);
+  });
+
+  it('produces the expected number of shards', () => {
+    const buf = Buffer.alloc(250, 1);
+    expect(shard(buf, 100)).toHaveLength(3); // 100 + 100 + 50
+  });
+
+  it('returns a single shard when the buffer fits', () => {
+    const buf = Buffer.from('small');
+    expect(shard(buf, MAX_SHARD_BYTES)).toHaveLength(1);
+  });
+
+  it('returns no shards for an empty buffer', () => {
+    expect(shard(Buffer.alloc(0))).toHaveLength(0);
+  });
+
+  it('rejects a non-positive max', () => {
+    expect(() => shard(Buffer.from('x'), 0)).toThrow(/positive/);
+  });
+});


### PR DESCRIPTION
## Problem

The `.mcpb` one-click install stopped working as of **v0.4.0** — double-clicking the bundle logs `Handling DXT/MCPB file` then silently dead-ends: no install dialog, no error. **v0.3.0 was the last working release.**

**Root cause:** Claude Desktop's local `.mcpb` install preview **silently rejects a bundle if any single file exceeds ~108KB**. SHA-81's `noExternal: [/.*/]` turned `dist/index.js` into one ~1.7MB file, which trips the cap on every release since v0.4.0. (v0.3.0 shipped a 41KB externalized dist, so it slipped under.)

## How it was confirmed

Controlled A/B against a real vault, holding `manifest_version` and the `@anthropic-ai/mcpb` packer constant — the only variable was `dist/index.js`:

| Test | Result |
|---|---|
| single file 41 / 64 / 100 / 105 KB | ✅ dialog |
| single file 110 / 128 / 255 / 1700 KB | ❌ silent |
| 948KB total across 37 files, max 40KB/file | ✅ dialog |
| 40KB entry + one 200KB file | ❌ silent |

So the cap is **per-file**, applies to **every** file, and **total size is irrelevant**. (`manifest_version "0.4"` was also tested and ruled out.) The documented zip guards in `app.asar` are 512MB/file — this ~108KB limit is undocumented and surfaces no error. Tracked upstream separately.

## Fix

Keep the fully-bundled ESM build, but split it into <95KB shards and ship a small loader that reassembles them at startup.

- **`scripts/shard.mjs`** — byte-splitter + cap constants (`MAX_SHARD_BYTES` 95KB, `MAX_FILE_BYTES` 100KB)
- **`scripts/shard.test.ts`** — round-trip (concat of shards == original) + cap + count tests
- **`packages/server/mcpb-loader.mjs`** — ships as `dist/index.js`; concatenates `index.NNN.part` shards and imports the reassembled module (temp file keyed by content hash, written once per version)
- **`scripts/build-mcpb.mjs`** — build → stage → shard → **guard (fails the build if any packed file >100KB)** → pack. The guard turns a future regression into a loud build failure instead of a silent broken install.
- **`tsup.mcpb.config.ts`** — drop the multi-MB sourcemap (would itself exceed the cap)

## Performance

One-time startup cost only; nothing on the hot path:

| | boot to first output |
|---|---|
| monolithic bundle | ~93 ms |
| sharded loader | ~100 ms |

~7ms added to process boot (read 18 shards + sha256 + first-launch temp write), dwarfed by vault indexing on any real vault. Tool calls run the byte-identical bundle.

## Verification

- 265 existing tests + 6 new shard tests pass; lint + `tsc` clean (server + harness)
- Production `build:mcpb` → 18 shards, largest file 97,280 B < 102,400 cap; guard passes
- Packed bundle **boots healthy** against a real vault, and the install **dialog appears + installs** (manually confirmed end-to-end)
- `smoke-install.mjs` (npm path) unaffected

Closes SHA-169.