### PR TITLE
Keep server.json in sync with the published npm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Guard: server.json (the MCP registry manifest) must match the package
+      # versions. A manual `mcp-publisher publish` reads this file as-is, so a
+      # stale version here would regress the registry. Runs once (Linux).
+      - name: server.json version sync
+        if: matrix.os == 'ubuntu-latest'
+        run: node scripts/sync-server-json.mjs --check
+
       # Coverage gate runs once (Linux) — thresholds live in the server's
       # vitest config and fail the build if logic coverage regresses.
       - name: Coverage gate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,14 +132,13 @@ jobs:
         run: |
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
+      # Belt-and-suspenders: server.json is normally kept current by
+      # `version-packages` (see scripts/sync-server-json.mjs), but re-sync here
+      # in case this publish runs without a fresh version bump (e.g. manual
+      # workflow_dispatch). Same script the version step and CI guard use.
       - name: Sync server.json version
         if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
-        run: |
-          VERSION=$(node -p "require('./packages/server/package.json').version")
-          OMCP_VERSION=$(node -p "require('./packages/obsidian-mcp-seekstone/package.json').version")
-          jq --arg v "$VERSION" --arg ov "$OMCP_VERSION" \
-            '.version = $v | .packages[] |= if .identifier == "seekstone" then .version = $v elif .identifier == "obsidian-mcp-seekstone" then .version = $ov else . end' \
-            server.json > server.tmp && mv server.tmp server.json
+        run: node scripts/sync-server-json.mjs
 
       - name: Publish to MCP Registry
         if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "publish:shim": "npm publish -w obsidian-mcp-seekstone",
     "build:mcpb": "node scripts/build-mcpb.mjs",
     "smoke": "node scripts/smoke-install.mjs",
-    "version-packages": "changeset version && biome format --write .",
+    "version-packages": "changeset version && node scripts/sync-server-json.mjs && biome format --write .",
     "release": "changeset publish"
   },
   "overrides": {

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Keep server.json (the Official MCP Registry manifest) in lockstep with the
+// published npm versions. `server.json` is the source the `mcp-publisher` CLI
+// reads, so its `version` and each `packages[].version` must match the package
+// they describe — otherwise a manual `mcp-publisher publish` would push a stale
+// version and regress the registry.
+//
+// Source of truth: each package's own package.json `version`.
+//   .version                          ← packages/server  (the `seekstone` package)
+//   packages[id="seekstone"]          ← packages/server
+//   packages[id="obsidian-mcp-...]"]  ← packages/obsidian-mcp-seekstone
+//
+// Modes:
+//   (default)  rewrite server.json in place if it has drifted.
+//   --check    don't write; exit 1 if server.json is out of sync (CI guard).
+//
+// Wired into `version-packages` (so the changesets "Version Packages" PR bumps
+// server.json in the same commit) and run with --check in CI.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const repoRoot = new URL('..', import.meta.url).pathname;
+const check = process.argv.includes('--check');
+
+const read = (p) => JSON.parse(readFileSync(`${repoRoot}${p}`, 'utf8'));
+
+const serverVersion = read('packages/server/package.json').version;
+const aliasVersion = read('packages/obsidian-mcp-seekstone/package.json').version;
+
+// Map each server.json package identifier to its authoritative version.
+const versionFor = {
+  seekstone: serverVersion,
+  'obsidian-mcp-seekstone': aliasVersion,
+};
+
+const raw = readFileSync(`${repoRoot}server.json`, 'utf8');
+const manifest = JSON.parse(raw);
+
+manifest.version = serverVersion;
+for (const pkg of manifest.packages ?? []) {
+  const want = versionFor[pkg.identifier];
+  if (want === undefined) {
+    throw new Error(
+      `server.json lists unknown package identifier "${pkg.identifier}" — add it to versionFor in scripts/sync-server-json.mjs.`,
+    );
+  }
+  pkg.version = want;
+}
+
+// Preserve the file's 2-space indent + trailing newline. biome format runs after
+// this in `version-packages`, so exact formatting here is not load-bearing.
+const next = `${JSON.stringify(manifest, null, 2)}\n`;
+
+if (next === raw) {
+  console.log(`server.json already in sync (version ${serverVersion}).`);
+  process.exit(0);
+}
+
+if (check) {
+  console.error(
+    `server.json is out of sync with package versions (expected version ${serverVersion}).\n` +
+      'Run `node scripts/sync-server-json.mjs` (or `npm run version-packages`) and commit the result.',
+  );
+  process.exit(1);
+}
+
+writeFileSync(`${repoRoot}server.json`, next);
+console.log(`server.json synced to version ${serverVersion}.`);

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shaqmughal/seekstone",
   "description": "Filesystem-direct Obsidian MCP server — search and edit your vault with low context-tax.",
-  "version": "0.5.0",
+  "version": "0.6.3",
   "repository": {
     "url": "https://github.com/shaqmughal/seekstone",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "obsidian-mcp-seekstone",
-      "version": "0.5.0",
+      "version": "0.6.3",
       "transport": {
         "type": "stdio"
       },
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "seekstone",
-      "version": "0.5.0",
+      "version": "0.6.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Problem

`server.json` (the Official MCP Registry manifest) had `version` and both `packages[].version` pinned at **0.5.0**, while the published release is **0.6.3**.

The release workflow's "Sync server.json version" step `jq`-patched the version only in the CI runner and **never committed it back**, so the committed file drifted. Since `docs/REGISTRIES.md` documents a manual `mcp-publisher publish` path that reads the committed file as-is, running it would have **regressed the registry to 0.5.0**.

## Changes

- **`server.json`** — corrected to 0.6.3 (version + both `packages[].version`).
- **`scripts/sync-server-json.mjs`** (new) — single source of truth. Reads each package's own `package.json` version and writes it into `server.json`. `--check` mode writes nothing and exits 1 on drift; throws on an unknown package identifier.
- **`package.json`** — `version-packages` now runs the sync between `changeset version` and `biome format`, so the changesets "Version Packages" PR bumps `server.json` in the same commit. The committed file can no longer go stale.
- **`.github/workflows/ci.yml`** — Linux-only `--check` guard that fails the build on drift.
- **`.github/workflows/release.yml`** — replaced the duplicated inline `jq` block with the shared script (kept as a belt-and-suspenders re-sync for manual `workflow_dispatch`).

## Verification

- Script tested in all three paths: in-sync (exit 0), drift detected by `--check` (exit 1), auto-fix write.
- `npm run lint` clean across all 133 files.

## Out of scope

`docs/REGISTRIES.md` still says "8 tools" / lists 8 (should be 16) — tracked separately.

Closes SHA-177.