### PR TITLE
docs(registries): fix stale tool count (8→16) and guard against drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: node scripts/sync-server-json.mjs --check
 
+      # Guard: docs/REGISTRIES.md is the canonical copy pasted into every registry
+      # listing — its tool count/list must match the server's HANDLED_TOOLS, or
+      # stale numbers (e.g. "8 tools") propagate to every directory. Runs once (Linux).
+      - name: REGISTRIES.md tool list sync
+        if: matrix.os == 'ubuntu-latest'
+        run: node scripts/check-registries-tools.mjs
+
       # Coverage gate runs once (Linux) — thresholds live in the server's
       # vitest config and fail the build if logic coverage regresses.
       - name: Coverage gate

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -17,11 +17,11 @@ Both are published automatically by the release pipeline on every version bump.
 
 - **Name:** Seekstone (also: obsidian-mcp-seekstone)
 - **Tagline:** An Obsidian MCP server — filesystem-direct, low context-tax.
-- **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 8 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
+- **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 16 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
 - **Install:** `npx -y obsidian-mcp-seekstone` (also: `npx -y seekstone`); env `SEEKSTONE_VAULT=/path/to/vault`
 - **Repo:** https://github.com/shaqmughal/seekstone
 - **npm:** https://www.npmjs.com/package/obsidian-mcp-seekstone / https://www.npmjs.com/package/seekstone
-- **Tools:** search, read_note, list_notes, create_note, delete_note, move_note, append_note, patch_frontmatter
+- **Tools (16):** _Read_ — search, read_note, list_notes, list_tags, outline_note, get_backlinks, get_links, get_periodic_note · _Write_ — create_note, delete_note, move_note, append_note, patch_frontmatter, patch_note, replace_in_note, append_periodic_note
 - **Categories/tags:** obsidian, notes, knowledge-base, markdown, search, obsidian-mcp
 
 <!-- Note: the official registry caps server.json `description` at 100 characters. -->

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "publish:shim": "npm publish -w obsidian-mcp-seekstone",
     "build:mcpb": "node scripts/build-mcpb.mjs",
     "smoke": "node scripts/smoke-install.mjs",
+    "check:registries": "node scripts/check-registries-tools.mjs",
     "version-packages": "changeset version && node scripts/sync-server-json.mjs && biome format --write .",
     "release": "changeset publish"
   },

--- a/scripts/check-registries-tools.mjs
+++ b/scripts/check-registries-tools.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Guard: the tool count/list in docs/REGISTRIES.md must match the server's
+// actual tool surface. That file is the *canonical copy* people paste into every
+// registry/directory listing (Glama, mcp.so, awesome-* PRs), so a stale count
+// there propagates everywhere. It drifted to "8 tools" while the server grew to
+// 16 — this check stops that from happening again.
+//
+// Source of truth: HANDLED_TOOLS in packages/server/src/dispatch.ts.
+//
+// Mirrors scripts/sync-server-json.mjs --check (the server.json version guard).
+// Check-only: REGISTRIES.md interleaves prose with a hand-formatted Read/Write
+// split, so this fails CI on drift rather than rewriting the file.
+
+import { readFileSync } from 'node:fs';
+
+const repoRoot = new URL('..', import.meta.url).pathname;
+const read = (p) => readFileSync(`${repoRoot}${p}`, 'utf8');
+
+// --- source of truth: HANDLED_TOOLS ---
+const dispatch = read('packages/server/src/dispatch.ts');
+const block = dispatch.match(/export const HANDLED_TOOLS = \[([\s\S]*?)\] as const;/);
+if (!block) {
+  console.error(
+    'check-registries-tools: could not find HANDLED_TOOLS in packages/server/src/dispatch.ts.',
+  );
+  process.exit(1);
+}
+const tools = [...block[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+const toolSet = new Set(tools);
+const count = tools.length;
+
+// --- doc under guard ---
+const doc = read('docs/REGISTRIES.md');
+const errors = [];
+
+// 1. Description prose: "<N> tools over stdio".
+const prose = doc.match(/(\d+) tools over stdio/);
+if (!prose) {
+  errors.push('Description is missing the "<N> tools over stdio" count.');
+} else if (Number(prose[1]) !== count) {
+  errors.push(`Description says "${prose[1]} tools over stdio" but HANDLED_TOOLS has ${count}.`);
+}
+
+// 2. Canonical-copy heading: "**Tools (<N>):**".
+const head = doc.match(/\*\*Tools \((\d+)\):\*\*([^\n]*)/);
+if (!head) {
+  errors.push('Canonical copy is missing the "**Tools (<N>):**" line.');
+} else {
+  if (Number(head[1]) !== count) {
+    errors.push(`Tools line says "(${head[1]})" but HANDLED_TOOLS has ${count}.`);
+  }
+  // 3. Every tool is listed, and no stale tool lingers. A tool-name token is a
+  //    snake_case identifier, plus the lone single-word tool `search`.
+  const listed = new Set(
+    [...head[2].matchAll(/\b([a-z][a-z]*_[a-z_]+|search)\b/g)].map((m) => m[1]),
+  );
+  for (const tool of tools) {
+    if (!listed.has(tool)) errors.push(`Tools line is missing "${tool}".`);
+  }
+  for (const tool of listed) {
+    if (!toolSet.has(tool)) {
+      errors.push(`Tools line lists "${tool}", which is not in HANDLED_TOOLS (stale?).`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error('docs/REGISTRIES.md is out of sync with the server tool list:');
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error(
+    `\nThe server exposes ${count} tools: ${tools.join(', ')}.\n` +
+      'Update docs/REGISTRIES.md (count + Tools line) to match HANDLED_TOOLS.',
+  );
+  process.exit(1);
+}
+
+console.log(`docs/REGISTRIES.md tool count/list in sync (${count} tools).`);


### PR DESCRIPTION
## What

`docs/REGISTRIES.md` is the **canonical copy** pasted into every registry/directory listing (Glama, mcp.so, awesome-* PRs). It had drifted: the description and Tools line still said **8 tools** while the server now exposes **16** (`HANDLED_TOOLS` in `packages/server/src/dispatch.ts`). Every stale listing traces back to this file.

## Changes

- **Fix the count to 16** in the description prose (`16 tools over stdio`) and the Tools line.
- **List all 16 tools**, split Read/Write to mirror the README.
- **Add a CI guard** (`scripts/check-registries-tools.mjs`) that compares the doc's count/list against `HANDLED_TOOLS` and fails on drift *or* stale entries — mirroring the existing `server.json` version guard (`scripts/sync-server-json.mjs --check`).
- Wire the guard into CI (`REGISTRIES.md tool list sync` step) and add an npm `check:registries` script.

## Verification

- `npm run check:registries` → passes (`16 tools`).
- Negative-tested: breaking the count or injecting a stale tool name makes the guard exit 1 with a clear message.
- `npm run lint` clean. No changeset required (no publishable package source touched).

Closes SHA-178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)