### PR TITLE
fix(harness): scrub machine-local paths from committed baseline reports (SHA-194)

### DIFF
--- a/packages/harness/fixtures/baseline-reports/safety-fs.json
+++ b/packages/harness/fixtures/baseline-reports/safety-fs.json
@@ -4,8 +4,8 @@
     "name": "fs",
     "description": "Filesystem-direct (MiniSearch in-process, no HTTP round-trip)"
   },
-  "vaultCopyRoot": "/private/var/folders/xk/2wj3w8rd7rd96l26xsg18t1r0000gn/T/seekstone-safety-1782434474491",
-  "originalVaultRoot": "/Users/shaqmughal/code/seekstone/packages/harness/fixtures/vault",
+  "vaultCopyRoot": "<tmpdir>/seekstone-safety-1782434474491",
+  "originalVaultRoot": "packages/harness/fixtures/vault",
   "sampleSize": 25,
   "passByOp": {
     "identity": {

--- a/packages/harness/fixtures/baseline-reports/safety-fs.md
+++ b/packages/harness/fixtures/baseline-reports/safety-fs.md
@@ -3,8 +3,8 @@
 - **Adapter:** Filesystem-direct (MiniSearch in-process, no HTTP round-trip)
 - **Snapshot:** 2026-06-26T00:41:25.472Z
 - **Sample:** 25 frontmatter-heavy notes
-- **Vault copy:** `/private/var/folders/xk/2wj3w8rd7rd96l26xsg18t1r0000gn/T/seekstone-safety-1782434474491`
-- **Original (read-only, untouched):** `/Users/shaqmughal/code/seekstone/packages/harness/fixtures/vault`
+- **Vault copy:** `<tmpdir>/seekstone-safety-1782434474491`
+- **Original (read-only, untouched):** `packages/harness/fixtures/vault`
 
 ## Summary
 

--- a/packages/harness/fixtures/baseline-reports/vault-stats.json
+++ b/packages/harness/fixtures/baseline-reports/vault-stats.json
@@ -1,5 +1,5 @@
 {
-  "vaultRoot": "/Users/shaqmughal/code/seekstone/packages/harness/fixtures/vault",
+  "vaultRoot": "packages/harness/fixtures/vault",
   "snapshotDate": "2026-06-26T00:41:04.731Z",
   "machine": {
     "platform": "darwin",

--- a/packages/harness/fixtures/baseline-reports/vault-stats.md
+++ b/packages/harness/fixtures/baseline-reports/vault-stats.md
@@ -1,6 +1,6 @@
 # Vault Stats
 
-- **Vault:** `/Users/shaqmughal/code/seekstone/packages/harness/fixtures/vault`
+- **Vault:** `packages/harness/fixtures/vault`
 - **Snapshot:** 2026-06-26T00:41:04.731Z
 - **Machine:** darwin/arm64, Node v25.9.0, 16 logical CPUs
 

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -22,6 +22,7 @@ import { fetchCorpus, loadCorpus } from './fixtures/corpus.js';
 import { generateVault } from './fixtures/generate.js';
 import { profileVault } from './profiler/index.js';
 import { renderVaultStatsMarkdown } from './profiler/report.js';
+import { normalizeReportPath } from './report-paths.js';
 import { copyVault, renderSafetyMarkdown, runSafety } from './safety/index.js';
 
 // `npm run -w @seekstone/harness start` runs tsx with cwd = packages/harness,
@@ -48,8 +49,11 @@ cli
     const outDir = resolve(opts.out);
     await mkdir(outDir, { recursive: true });
     const stats = await profileVault({ vaultRoot: vault });
-    await writeFile(join(outDir, 'vault-stats.json'), JSON.stringify(stats, null, 2));
-    await writeFile(join(outDir, 'vault-stats.md'), renderVaultStatsMarkdown(stats));
+    // Scrub machine-local detail (username, tmpdir hash) so the committed report
+    // is identical regardless of whose machine produced it.
+    const report = { ...stats, vaultRoot: normalizeReportPath(stats.vaultRoot) };
+    await writeFile(join(outDir, 'vault-stats.json'), JSON.stringify(report, null, 2));
+    await writeFile(join(outDir, 'vault-stats.md'), renderVaultStatsMarkdown(report));
     console.log(`profile: ${stats.counts.notes} notes, ${stats.counts.totalFiles} files.`);
     console.log(`         wrote ${join(outDir, 'vault-stats.json')}`);
     console.log(`         wrote ${join(outDir, 'vault-stats.md')}`);
@@ -137,11 +141,15 @@ cli
         vaultCopyRoot: copyRoot,
         sampleSize: Number(opts.sample),
       });
-      await writeFile(
-        join(outDir, `safety-${backend.name}.json`),
-        JSON.stringify(summary, null, 2),
-      );
-      await writeFile(join(outDir, `safety-${backend.name}.md`), renderSafetyMarkdown(summary));
+      // Scrub machine-local detail (username, per-run tmpdir hash) from the
+      // committed report so it is reproducible across machines.
+      const report = {
+        ...summary,
+        originalVaultRoot: normalizeReportPath(summary.originalVaultRoot),
+        vaultCopyRoot: normalizeReportPath(summary.vaultCopyRoot),
+      };
+      await writeFile(join(outDir, `safety-${backend.name}.json`), JSON.stringify(report, null, 2));
+      await writeFile(join(outDir, `safety-${backend.name}.md`), renderSafetyMarkdown(report));
       const safetyOps = Object.entries(summary.passByOp)
         .map(([op, r]) => `${op} ${r.pass}/${r.pass + r.fail}`)
         .join(', ');

--- a/packages/harness/src/report-paths.test.ts
+++ b/packages/harness/src/report-paths.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeReportPath } from './report-paths.js';
+
+const REPO = '/Users/x/code/seekstone';
+const TMP = '/var/folders/xk/abc/T';
+const HOME = '/Users/x';
+const opts = { cwd: REPO, tmpdir: TMP, home: HOME };
+
+describe('normalizeReportPath', () => {
+  it('renders a path inside the repo as a repo-relative POSIX path', () => {
+    expect(normalizeReportPath(`${REPO}/packages/harness/fixtures/vault`, opts)).toBe(
+      'packages/harness/fixtures/vault',
+    );
+  });
+
+  it('renders the repo root itself as the empty-ish relative path, not absolute', () => {
+    // `relative(repo, repo)` is '' which we treat as "not inside" and fall through.
+    // A child one level down is the meaningful case and stays relative.
+    expect(normalizeReportPath(`${REPO}/reports`, opts)).toBe('reports');
+  });
+
+  it('maps an OS-tmpdir copy to <tmpdir>/<name>', () => {
+    expect(normalizeReportPath(`${TMP}/seekstone-safety-1782434474491`, opts)).toBe(
+      '<tmpdir>/seekstone-safety-1782434474491',
+    );
+  });
+
+  it('matches a macOS /private-prefixed tmpdir against the /var-form tmpdir', () => {
+    // os.tmpdir() yields /var/...; mkdtemp yields /private/var/... — must still match.
+    expect(normalizeReportPath(`/private${TMP}/seekstone-safety-99`, opts)).toBe(
+      '<tmpdir>/seekstone-safety-99',
+    );
+  });
+
+  it('renders the tmpdir root itself as <tmpdir>', () => {
+    expect(normalizeReportPath(TMP, opts)).toBe('<tmpdir>');
+  });
+
+  it('scrubs a username from a personal path under $HOME but outside the repo', () => {
+    expect(normalizeReportPath('/Users/x/Documents/My Vault', opts)).toBe(
+      '<home>/Documents/My Vault',
+    );
+  });
+
+  it('prefers the repo-relative form over the $HOME form when both apply', () => {
+    // The repo lives under HOME; branch order must pick repo-relative.
+    expect(normalizeReportPath(`${REPO}/packages`, opts)).toBe('packages');
+  });
+
+  it('leaves an unrelated absolute path unchanged', () => {
+    expect(normalizeReportPath('/opt/data/vault', opts)).toBe('/opt/data/vault');
+  });
+
+  it('does not leak a username for any path under $HOME', () => {
+    const out = normalizeReportPath('/Users/x/anything/here', opts);
+    expect(out).not.toContain('/Users/x');
+  });
+});

--- a/packages/harness/src/report-paths.ts
+++ b/packages/harness/src/report-paths.ts
@@ -1,0 +1,66 @@
+import os from 'node:os';
+import { isAbsolute, relative, sep } from 'node:path';
+
+/**
+ * Render a filesystem path for inclusion in a committed report so it carries no
+ * machine-local detail (the local username, a per-run macOS tmpdir hash, …).
+ *
+ * Reports are checked in (`fixtures/baseline-reports/`) and must be the same
+ * regardless of whose machine produced them. Three cases, in order:
+ *
+ *   1. Inside the repo (cwd) → a repo-relative POSIX path
+ *      (`/Users/x/code/seekstone/packages/.../vault` → `packages/.../vault`).
+ *   2. Inside the OS temp dir → `<tmpdir>/<name>` (drops the `/private/var/folders/<hash>`
+ *      prefix that `mkdtemp` produces).
+ *   3. Anywhere else under $HOME → `<home>/…` so a personal-vault path never
+ *      leaks a username.
+ *
+ * Anything that matches none of these is returned unchanged.
+ *
+ * `cwd` / `tmpdir` / `home` are injectable so the behaviour is deterministic in
+ * tests; in production they default to the live process values.
+ */
+export interface NormalizeReportPathOptions {
+  cwd?: string;
+  tmpdir?: string;
+  home?: string;
+}
+
+const toPosix = (p: string): string => (sep === '/' ? p : p.split(sep).join('/'));
+
+// macOS: `/var`, `/tmp`, `/etc` are symlinks under `/private`. `os.tmpdir()`
+// returns the `/var/...` form while `mkdtemp`/`realpath` yield `/private/var/...`,
+// so a naive prefix check misses. Strip the leading `/private` on both sides.
+const stripPrivate = (p: string): string =>
+  p.startsWith('/private/') ? p.slice('/private'.length) : p;
+
+function under(child: string, parent: string): string | null {
+  if (!parent) return null;
+  const c = stripPrivate(child);
+  const p = stripPrivate(parent);
+  if (c === p) return '';
+  if (c.startsWith(`${p}/`)) return c.slice(p.length + 1);
+  return null;
+}
+
+export function normalizeReportPath(p: string, opts: NormalizeReportPathOptions = {}): string {
+  const cwd = opts.cwd ?? process.cwd();
+  const tmp = opts.tmpdir ?? os.tmpdir();
+  const home = opts.home ?? os.homedir();
+
+  // 1) Inside the repo → repo-relative.
+  const rel = relative(cwd, p);
+  if (rel && !rel.startsWith('..') && !isAbsolute(rel)) {
+    return toPosix(rel);
+  }
+
+  // 2) Inside the OS temp dir → <tmpdir>/<name>.
+  const inTmp = under(p, tmp);
+  if (inTmp !== null) return inTmp ? `<tmpdir>/${toPosix(inTmp)}` : '<tmpdir>';
+
+  // 3) Elsewhere under $HOME → <home>/… (never leak the username).
+  const inHome = under(p, home);
+  if (inHome !== null) return inHome ? `<home>/${toPosix(inHome)}` : '<home>';
+
+  return p;
+}


### PR DESCRIPTION
## What

The committed harness baseline reports embedded machine-local absolute paths:

- `vault-stats.{json,md}` / `safety-fs.{json,md}` — `vaultRoot` / `originalVaultRoot` carried the local username (`/Users/shaqmughal/code/seekstone/...`)
- `safety-fs.{json,md}` — `vaultCopyRoot` carried a per-run macOS tmpdir hash (`/private/var/folders/xk/.../T/seekstone-safety-...`)

These leak local detail and make the committed fixtures non-reproducible (they'd differ by whoever last regenerated them). Low severity — the username is already public (it's the GitHub handle) — but the reports are meant to be machine-agnostic.

## How

- New `packages/harness/src/report-paths.ts` → `normalizeReportPath()`:
  - inside the repo (cwd) → repo-relative POSIX path
  - under the OS tmpdir → `<tmpdir>/<name>` (handles the macOS `/private` symlink so `/private/var/...` matches `os.tmpdir()`'s `/var/...`)
  - anywhere else under `$HOME` → `<home>/…` so a personal-vault path never leaks a username
- `cli.ts` applies it at the `profile` and `safety` write boundary, so future regenerations stay clean (JSON and markdown both normalized from one object).
- Re-normalized the four committed reports under `fixtures/baseline-reports/`.

## Tests

- 9 new cases in `report-paths.test.ts` (repo-relative, tmpdir, `/private` symlink, `$HOME` scrub, branch precedence, unrelated paths, no-username-leak invariant).
- Full suite green: harness 166, server 271. Typecheck + biome clean.

## Verification

```
grep -rnE '/Users/[a-z]+|/home/[a-z]+|/private/var/folders' packages/harness/fixtures/baseline-reports/ | grep -v 'fixtures/vault'
# (no output)
```

Closes SHA-194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)