### PR TITLE
test(harness): close unit-test gaps and add a coverage gate (SHA-195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
           SEEKSTONE_COVERAGE: '1'
         run: npx vitest run --coverage --root packages/server
 
+      # Harness coverage gate — thresholds live in the harness vitest config and
+      # fail the build if the measurement core / fixture primitives regress. The
+      # process- and network-driving adapters are excluded there (validated by
+      # running the real harness, not unit coverage). Runs once (Linux).
+      - name: Coverage gate (harness)
+        if: matrix.os == 'ubuntu-latest'
+        run: npx vitest run --coverage --root packages/harness
+
       # Coverage upload is a reporting side-effect, not a correctness gate.
       # Skip it for Dependabot PRs: GitHub withholds repo secrets from
       # Dependabot-triggered runs, so the token is empty and the step fails.
@@ -74,7 +82,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/server/coverage/lcov.info
+          files: packages/server/coverage/lcov.info,packages/harness/coverage/lcov.info
           flags: server
           fail_ci_if_error: false
 

--- a/packages/harness/src/bench/adapters/seekstone.test.ts
+++ b/packages/harness/src/bench/adapters/seekstone.test.ts
@@ -1,0 +1,126 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SeekstoneAdapter } from './seekstone.js';
+
+const NOTE1 = `---
+title: Alpha Note
+tags: [work, project]
+---
+# Alpha
+
+This is alpha content. It links to [[note2]].
+
+## Details
+
+More about alpha.
+`;
+
+const NOTE2 = `---
+title: Beta Note
+tags: [project]
+---
+This is beta content with some extra words about alpha.
+`;
+
+const NOTE3 = `# Gamma
+No frontmatter here, just plain text.
+`;
+
+describe('SeekstoneAdapter', () => {
+  let vaultDir: string;
+  let adapter: SeekstoneAdapter;
+
+  beforeAll(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'seekstone-adapter-test-'));
+    await writeFile(join(vaultDir, 'note1.md'), NOTE1, 'utf8');
+    await writeFile(join(vaultDir, 'note2.md'), NOTE2, 'utf8');
+    await mkdir(join(vaultDir, 'subdir'), { recursive: true });
+    await writeFile(join(vaultDir, 'subdir', 'note3.md'), NOTE3, 'utf8');
+    adapter = await SeekstoneAdapter.build({ vaultRoot: vaultDir });
+  });
+
+  afterAll(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('builds with name/description and the Backend surface', () => {
+    expect(adapter.name).toBe('seekstone');
+    expect(adapter.description).toContain('in-process');
+    for (const m of [
+      'search',
+      'read',
+      'write',
+      'list',
+      'listTags',
+      'outline',
+      'getBacklinks',
+      'getLinks',
+    ] as const) {
+      expect(typeof adapter[m]).toBe('function');
+    }
+  });
+
+  it('search() returns hits with a measured payload', async () => {
+    const { result, payloadBytes } = await adapter.search('alpha');
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result.map((h) => h.path)).toContain('note1.md');
+    expect(payloadBytes).toBeGreaterThan(0);
+  });
+
+  it('searchStream() yields the same hits as search()', async () => {
+    const streamed: string[] = [];
+    for await (const hit of adapter.searchStream('alpha')) {
+      streamed.push(hit.path);
+    }
+    expect(streamed).toContain('note1.md');
+  });
+
+  it('read() returns file content and a byte count', async () => {
+    const { result, payloadBytes } = await adapter.read('note1.md');
+    expect(result).toContain('alpha content');
+    expect(payloadBytes).toBeGreaterThan(0);
+  });
+
+  it('write() persists content to the vault and reports bytes written', async () => {
+    const body = '# Written\nfresh content\n';
+    const { payloadBytes } = await adapter.write('written.md', body);
+    expect(payloadBytes).toBe(Buffer.byteLength(body, 'utf8'));
+    const onDisk = await readFile(join(vaultDir, 'written.md'), 'utf8');
+    expect(onDisk).toBe(body);
+  });
+
+  it('list() enumerates notes', async () => {
+    const { result, payloadBytes } = await adapter.list();
+    const paths = result.map((e) => e.path);
+    expect(paths).toContain('note1.md');
+    expect(paths).toContain('note2.md');
+    expect(payloadBytes).toBeGreaterThan(0);
+  });
+
+  it('listTags() returns the tag cloud with a payload', async () => {
+    const { result, payloadBytes } = await adapter.listTags();
+    expect(result).toBeDefined();
+    expect(payloadBytes).toBeGreaterThan(0);
+  });
+
+  it('outline() returns a structural outline of a note', async () => {
+    const { result, payloadBytes } = await adapter.outline('note1.md');
+    expect(result).toBeDefined();
+    expect(payloadBytes).toBeGreaterThan(0);
+  });
+
+  it('getBacklinks() finds notes linking to the target', async () => {
+    const { result, payloadBytes } = await adapter.getBacklinks('note2.md');
+    expect(result).toBeDefined();
+    expect(payloadBytes).toBeGreaterThan(0);
+    expect(JSON.stringify(result)).toContain('note1');
+  });
+
+  it('getLinks() returns the outgoing links of a note', async () => {
+    const { result, payloadBytes } = await adapter.getLinks('note1.md');
+    expect(result).toBeDefined();
+    expect(payloadBytes).toBeGreaterThan(0);
+  });
+});

--- a/packages/harness/src/bench/compare.test.ts
+++ b/packages/harness/src/bench/compare.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { renderComparisonMarkdown } from './compare.js';
+import type { BenchmarkSummary } from './runner.js';
+import type { RunStats } from './timer.js';
+
+function stats(payloadBytesMean: number, coldMs = 5): RunStats {
+  const dist = { n: 4, min: 1, median: 2, p90: 3, p95: 4, p99: 5, max: 5, mean: 2.5 };
+  return {
+    coldMs,
+    runs: 5,
+    warm: dist,
+    all: dist,
+    payloadBytesMean,
+    payloadTokensMean: Math.round(payloadBytesMean / 4),
+  };
+}
+
+function summary(
+  name: string,
+  description: string,
+  overrides: Partial<BenchmarkSummary> = {},
+): BenchmarkSummary {
+  return {
+    snapshotDate: '2026-06-27T00:00:00.000Z',
+    machine: { platform: 'darwin', arch: 'arm64', node: 'v22.0.0', cpus: 8 },
+    backend: { name, description },
+    runs: 5,
+    rssBefore: 100 * 1024 * 1024,
+    rssPeak: 150 * 1024 * 1024,
+    search: [
+      {
+        id: 'q1',
+        kind: 'single',
+        query: 'hello world',
+        firstRunHitCount: 3,
+        ttfr: null,
+        stats: stats(2048),
+      },
+    ],
+    read: {
+      small: { path: 'notes/small.md', stats: stats(500) },
+      large: { path: 'notes/large.md', stats: stats(3 * 1024 * 1024) },
+    },
+    tools: {
+      list: stats(800),
+      listTags: stats(400),
+      outline: null,
+      getBacklinks: null,
+      getLinks: null,
+      getPeriodicNote: null,
+    },
+    ...overrides,
+  };
+}
+
+describe('renderComparisonMarkdown', () => {
+  it('renders a placeholder when there is no data', () => {
+    expect(renderComparisonMarkdown([])).toBe('# Benchmark Comparison\n\nNo data.\n');
+  });
+
+  it('renders the header, query, and adapter description for a single summary', () => {
+    const md = renderComparisonMarkdown([summary('fs', 'Filesystem-direct')]);
+    expect(md).toContain('# Obsidian MCP Server Benchmark Comparison');
+    expect(md).toContain('hello world');
+    expect(md).toContain('Filesystem-direct');
+    // formatBytes hits the KB and MB branches
+    expect(md).toContain('2.0 KB');
+    expect(md).toContain('3.00 MB');
+  });
+
+  it('computes a payload-size multiplier table against the fs baseline', () => {
+    const fs = summary('fs', 'Filesystem-direct');
+    // rest returns 4× the search payload and 8× the small-read payload of fs
+    const rest = summary('rest', 'REST proxy', {
+      backend: { name: 'rest', description: 'REST proxy' },
+      search: [
+        {
+          id: 'q1',
+          kind: 'single',
+          query: 'hello world',
+          firstRunHitCount: 3,
+          ttfr: null,
+          stats: stats(8192),
+        },
+      ],
+      read: {
+        small: { path: 'notes/small.md', stats: stats(4000) },
+        large: null,
+      },
+    });
+
+    const md = renderComparisonMarkdown([fs, rest]);
+    expect(md).toContain('## Payload size multiplier vs seekstone (fs)');
+    expect(md).toContain('Baseline: **fs**');
+    expect(md).toContain('4.0×'); // search payload multiplier
+    // rest has no large read → an em-dash cell appears
+    expect(md).toContain('—');
+  });
+
+  it('renders the tool support matrix and shared-tool latency for tools all adapters share', () => {
+    const fs = summary('fs', 'Filesystem-direct', {
+      tools: {
+        list: stats(800),
+        listTags: stats(400),
+        outline: { path: 'notes/o.md', stats: stats(600) },
+        getBacklinks: null,
+        getLinks: null,
+        getPeriodicNote: null,
+      },
+    });
+    const rest = summary('rest', 'REST proxy', {
+      backend: { name: 'rest', description: 'REST proxy' },
+    });
+
+    const md = renderComparisonMarkdown([fs, rest]);
+    expect(md).toContain('## Tool support matrix');
+    // list + listTags are non-null on both → shared latency table present
+    expect(md).toContain('### Tool latency comparison (ms)');
+    expect(md).toContain('`list_notes`');
+    expect(md).toContain('`list_tags`');
+    // outline supported on fs only → both ✅ and ❌ appear in the matrix
+    expect(md).toContain('✅');
+    expect(md).toContain('❌');
+  });
+
+  it('falls back to the query id when a query is missing from the first summary', () => {
+    const a = summary('fs', 'Filesystem-direct');
+    const b = summary('rest', 'REST proxy', {
+      backend: { name: 'rest', description: 'REST proxy' },
+      search: [
+        {
+          id: 'q2',
+          kind: 'single',
+          query: 'only-in-b',
+          firstRunHitCount: 1,
+          ttfr: null,
+          stats: stats(100),
+        },
+      ],
+    });
+    const md = renderComparisonMarkdown([a, b]);
+    // q2 is absent from the FIRST summary, so the label falls back to the id
+    // (`?? id`) and a's payload cell shows an em-dash.
+    expect(md).toContain('`q2`');
+    expect(md).toContain('—');
+  });
+});

--- a/packages/harness/src/fixtures/prng.test.ts
+++ b/packages/harness/src/fixtures/prng.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { Rng, zipfCdf, zipfPick } from './prng.js';
+
+describe('Rng', () => {
+  it('is deterministic: same seed → identical float sequence', () => {
+    const a = new Rng(42);
+    const b = new Rng(42);
+    const seqA = Array.from({ length: 10 }, () => a.next());
+    const seqB = Array.from({ length: 10 }, () => b.next());
+    expect(seqA).toEqual(seqB);
+  });
+
+  it('different seeds diverge', () => {
+    const a = new Rng(1);
+    const b = new Rng(2);
+    expect(a.next()).not.toBe(b.next());
+  });
+
+  it('next() stays within [0, 1)', () => {
+    const r = new Rng(7);
+    for (let i = 0; i < 1000; i++) {
+      const v = r.next();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it('int() is inclusive of both bounds and never escapes the range', () => {
+    const r = new Rng(99);
+    let sawMin = false;
+    let sawMax = false;
+    for (let i = 0; i < 2000; i++) {
+      const v = r.int(3, 6);
+      expect(v).toBeGreaterThanOrEqual(3);
+      expect(v).toBeLessThanOrEqual(6);
+      if (v === 3) sawMin = true;
+      if (v === 6) sawMax = true;
+    }
+    expect(sawMin).toBe(true);
+    expect(sawMax).toBe(true);
+  });
+
+  it('int(n, n) always returns n', () => {
+    const r = new Rng(5);
+    expect(r.int(4, 4)).toBe(4);
+  });
+
+  it('chance(1) is always true and chance(0) is always false', () => {
+    const r = new Rng(3);
+    for (let i = 0; i < 50; i++) {
+      expect(r.chance(1)).toBe(true);
+      expect(r.chance(0)).toBe(false);
+    }
+  });
+
+  it('pick() returns an element of the array', () => {
+    const r = new Rng(11);
+    const arr = ['a', 'b', 'c', 'd'];
+    for (let i = 0; i < 100; i++) {
+      expect(arr).toContain(r.pick(arr));
+    }
+  });
+
+  it('pick() throws on an empty array', () => {
+    expect(() => new Rng(1).pick([])).toThrow(/empty/);
+  });
+
+  it('shuffle() is a deterministic permutation that preserves the multiset', () => {
+    const original = [1, 2, 3, 4, 5, 6, 7, 8];
+    const a = new Rng(42).shuffle([...original]);
+    const b = new Rng(42).shuffle([...original]);
+    expect(a).toEqual(b);
+    expect([...a].sort((x, y) => x - y)).toEqual(original);
+  });
+
+  it('sample() returns n distinct elements without mutating the source', () => {
+    const src = Array.from({ length: 20 }, (_, i) => i);
+    const r = new Rng(42);
+    const picked = r.sample(src, 5);
+    expect(picked).toHaveLength(5);
+    expect(new Set(picked).size).toBe(5);
+    expect(picked.every((v) => src.includes(v))).toBe(true);
+    // source untouched
+    expect(src).toEqual(Array.from({ length: 20 }, (_, i) => i));
+  });
+
+  it('sample() caps at the source length when n exceeds it', () => {
+    expect(new Rng(1).sample([10, 20, 30], 10)).toHaveLength(3);
+  });
+});
+
+describe('zipfCdf', () => {
+  it('returns a normalized, strictly increasing CDF ending at 1', () => {
+    const cdf = zipfCdf(5);
+    expect(cdf).toHaveLength(5);
+    for (let i = 1; i < cdf.length; i++) {
+      expect(cdf[i] as number).toBeGreaterThan(cdf[i - 1] as number);
+    }
+    expect(cdf[cdf.length - 1]).toBeCloseTo(1, 10);
+  });
+
+  it('a single-item vocab maps to [1]', () => {
+    expect(zipfCdf(1)).toEqual([1]);
+  });
+});
+
+describe('zipfPick', () => {
+  it('returns an in-range 0-based rank', () => {
+    const cdf = zipfCdf(10);
+    const r = new Rng(42);
+    for (let i = 0; i < 500; i++) {
+      const rank = zipfPick(r, cdf);
+      expect(rank).toBeGreaterThanOrEqual(0);
+      expect(rank).toBeLessThan(10);
+    }
+  });
+
+  it('is head-biased: rank 0 is drawn far more often than the tail', () => {
+    const cdf = zipfCdf(20);
+    const r = new Rng(42);
+    let head = 0;
+    let tail = 0;
+    for (let i = 0; i < 5000; i++) {
+      const rank = zipfPick(r, cdf);
+      if (rank === 0) head++;
+      if (rank === 19) tail++;
+    }
+    expect(head).toBeGreaterThan(tail);
+  });
+
+  it('is deterministic given the same seed', () => {
+    const cdf = zipfCdf(15);
+    const a = new Rng(7);
+    const b = new Rng(7);
+    const seqA = Array.from({ length: 20 }, () => zipfPick(a, cdf));
+    const seqB = Array.from({ length: 20 }, () => zipfPick(b, cdf));
+    expect(seqA).toEqual(seqB);
+  });
+});

--- a/packages/harness/src/fixtures/tags.test.ts
+++ b/packages/harness/src/fixtures/tags.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { buildTagVocab, TAG_VOCAB } from './tags.js';
+
+describe('TAG_VOCAB', () => {
+  it('is non-empty and has no duplicates', () => {
+    expect(TAG_VOCAB.length).toBeGreaterThan(0);
+    expect(new Set(TAG_VOCAB).size).toBe(TAG_VOCAB.length);
+  });
+
+  it('leads with the broad head subjects', () => {
+    expect(TAG_VOCAB[0]).toBe('history');
+    expect(TAG_VOCAB.slice(0, 3)).toEqual(['history', 'science', 'geography']);
+  });
+});
+
+describe('buildTagVocab', () => {
+  it('returns exactly `target` tags when the target exceeds the base vocab', () => {
+    const v = buildTagVocab(320);
+    expect(v).toHaveLength(320);
+  });
+
+  it('produces no duplicates even after padding the tail', () => {
+    const v = buildTagVocab(320);
+    expect(new Set(v).size).toBe(v.length);
+  });
+
+  it('preserves the base vocab as a stable prefix (head stays broad)', () => {
+    const v = buildTagVocab(320);
+    expect(v.slice(0, TAG_VOCAB.length)).toEqual(TAG_VOCAB);
+  });
+
+  it('is deterministic across calls', () => {
+    expect(buildTagVocab(200)).toEqual(buildTagVocab(200));
+  });
+
+  it('truncates to the base vocab when the target is smaller than it', () => {
+    const v = buildTagVocab(5);
+    expect(v).toEqual(TAG_VOCAB.slice(0, 5));
+  });
+
+  it('defaults to a 320-tag vocabulary', () => {
+    expect(buildTagVocab()).toHaveLength(320);
+  });
+});

--- a/packages/harness/vitest.config.ts
+++ b/packages/harness/vitest.config.ts
@@ -7,5 +7,35 @@ export default defineConfig({
     // the 5000ms default (observed: bench/report first test at 5301ms).
     // 15s gives a comfortable buffer without masking genuinely slow tests.
     testTimeout: 15000,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      include: ['src/**/*.ts'],
+      // Excluded from the gate: adapters that drive an external process or HTTP
+      // server (validated by running the real harness, not unit coverage), the
+      // CLI wiring, the network corpus fetcher, the large fixture generator, and
+      // test files. Everything else — the measurement core (profiler, safety,
+      // bench report/runner/compare), the in-process fs/seekstone adapters, and
+      // the deterministic fixture primitives (prng, tags) — is gated.
+      exclude: [
+        'src/cli.ts',
+        'src/bench/adapters/rest.ts',
+        'src/bench/adapters/mcpvault.ts',
+        'src/bench/adapters/mcp-obsidian.ts',
+        'src/bench/adapters/mcp-subprocess.ts',
+        'src/bench/adapters/obsidian-mcp.ts',
+        'src/bench/adapters/obsidian-mcp-pro.ts',
+        'src/bench/adapters/obsidian-mcp-server.ts',
+        'src/fixtures/corpus.ts',
+        'src/fixtures/generate.ts',
+        '**/*.test.ts',
+      ],
+      thresholds: {
+        statements: 88,
+        lines: 88,
+        functions: 88,
+        branches: 70,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Why

A coverage audit found the **server** package healthy and gated (96.9% stmts / 84% branch / 99% funcs / 98% lines, enforced in CI), but the **harness** had **no coverage config and no CI enforcement** — ~47% overall, with several genuinely-testable modules at 0%. This closes that gap and adds a gate so the harness can't quietly regress.

## What

**New unit tests** for the pure / in-process modules (the process/network adapters are intentionally left to real-harness validation):

- `fixtures/prng.test.ts` — mulberry32 determinism (same seed → identical stream), `int`/`chance`/`pick`/`shuffle`/`sample` invariants, Zipf CDF normalization + head-biased picks. *Determinism under seed 42 is the whole fixture contract and was previously untested.*
- `fixtures/tags.test.ts` — vocab uniqueness, deterministic tail-padding, stable broad head, sub-base truncation.
- `bench/compare.test.ts` — comparison-table rendering, payload-size multipliers vs the fs baseline, tool-support matrix + shared-tool latency, empty-input and id-fallback branches.
- `bench/adapters/seekstone.test.ts` — in-process adapter round-trip (search/read/write/list/listTags/outline/getBacklinks/getLinks) over a temp vault.

**Coverage gate** — `packages/harness/vitest.config.ts` now runs v8 coverage at **88/88/88/70**, covering the measurement core (profiler, safety, bench report/runner/compare), the in-process fs/seekstone adapters, and the fixture primitives. Excludes (validated by running the real harness, not unit coverage): the process/network adapters (`rest`, `mcpvault`, `obsidian-mcp*`, `mcp-*`), `cli.ts`, `corpus.ts`, `generate.ts`. Covered set currently sits at **95.8 / 79.8 / 96.7 / 97.4**.

**CI** — added a `Coverage gate (harness)` step mirroring the server's; the harness lcov is included in the Codecov upload.

## Verification

- `npm test`: harness **196** tests (+30), server 271 — all green.
- Both gates pass locally: `vitest --coverage --root packages/server` and `--root packages/harness` exit 0.
- Typecheck + biome lint clean.

Closes SHA-195. Independent of #147 (SHA-194); branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)