### PR TITLE
chore(repo): standardize structure — run orphaned test, gate core, typecheck alias, de-dupe RELEASING (SHA-198)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           npx tsc -p packages/core/tsconfig.json --noEmit
           npx tsc -p packages/harness/tsconfig.json --noEmit
           npx tsc -p packages/server/tsconfig.json --noEmit
+          npx tsc -p packages/obsidian-mcp-seekstone/tsconfig.json --noEmit
 
       - name: Test
         run: npm test
@@ -74,6 +75,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: npx vitest run --coverage --root packages/harness
 
+      # Core coverage gate — thresholds live in the core vitest config. Core
+      # holds the safety-critical shared primitives (frontmatter round-trip,
+      # link extraction, outline), so a regression there fails the build too.
+      # Runs once (Linux).
+      - name: Coverage gate (core)
+        if: matrix.os == 'ubuntu-latest'
+        run: npx vitest run --coverage --root packages/core
+
       # Coverage upload is a reporting side-effect, not a correctness gate.
       # Skip it for Dependabot PRs: GitHub withholds repo secrets from
       # Dependabot-triggered runs, so the token is empty and the step fails.
@@ -82,7 +91,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/server/coverage/lcov.info,packages/harness/coverage/lcov.info
+          files: packages/server/coverage/lcov.info,packages/harness/coverage/lcov.info,packages/core/coverage/lcov.info
           flags: server
           fail_ci_if_error: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,5 +148,5 @@ jobs:
 
       # NOTE: a manual Glama release step is still required after every publish.
       # Glama has no public API for programmatic release creation (investigated SHA-85).
-      # See RELEASING.md for the manual steps and the placeholder curl command to
-      # drop in here once Glama exposes an API or webhook.
+      # See docs/RELEASING.md for the manual steps and the placeholder curl command
+      # to drop in here once Glama exposes an API or webhook.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,29 +1,5 @@
 # Releasing
 
-Releases are driven by [Changesets](https://github.com/changesets/changesets). The normal flow is:
-
-1. Add a changeset for each PR: `npx changeset`
-2. CI opens a "Version Packages" PR automatically on the next push to `main`.
-3. Merging that PR publishes to npm (OIDC provenance), creates GitHub Releases, and attaches the `.mcpb` bundle — all without manual steps.
-
-## Post-publish: Glama
-
-After every npm publish you need to create a new release on the Glama listing manually:
-
-1. Open <https://glama.ai/mcp/servers/shaqmughal/seekstone/admin/dockerfile>
-2. Click **"Create Release"** (or the equivalent button in the admin UI).
-3. Verify the new version appears on <https://glama.ai/mcp/servers/shaqmughal/seekstone>.
-
-**Why this isn't automated yet:** Glama has no public REST API or documented webhook for programmatic release creation (investigated in SHA-85, June 2026). The build spec uses `"pinnedCommit": null`, so the build itself always pulls the latest commit — only the release creation step is missing. If Glama adds an API or webhook in the future, the step would slot into `release.yml` after the MCPB upload:
-
-```yaml
-- name: Trigger Glama release
-  if: steps.changesets.outputs.published == 'true'
-  run: |
-    VERSION=$(node -p "require('./packages/server/package.json').version")
-    curl -fsSL -X POST "https://glama.ai/api/..." \
-      -H "Authorization: Bearer ${{ secrets.GLAMA_API_TOKEN }}" \
-      -d "{\"version\": \"${VERSION}\"}"
-```
-
-Until then, the manual step above is required to keep the Glama listing current.
+The release process — Changesets flow, pre-publish gates, OIDC trusted
+publishing, and the manual post-publish Glama step — is documented in
+**[docs/RELEASING.md](docs/RELEASING.md)**.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -35,3 +35,25 @@ The workflow publishes via **OIDC trusted publishing**: no npm token is stored, 
 - The `seekstone` package → **Settings → Trusted Publisher** → **GitHub Actions** → repository `shaqmughal/seekstone`, workflow filename `release.yml`.
 
 Once configured, the publish step authenticates automatically — there is no `NODE_AUTH_TOKEN`. The old `NPM_TOKEN` secret is no longer used and can be deleted.
+
+## Post-publish: Glama (manual)
+
+After every npm publish you need to create a new release on the Glama listing manually:
+
+1. Open <https://glama.ai/mcp/servers/shaqmughal/seekstone/admin/dockerfile>
+2. Click **"Create Release"** (or the equivalent button in the admin UI).
+3. Verify the new version appears on <https://glama.ai/mcp/servers/shaqmughal/seekstone>.
+
+**Why this isn't automated yet:** Glama has no public REST API or documented webhook for programmatic release creation (investigated in SHA-85, June 2026). The build spec uses `"pinnedCommit": null`, so the build itself always pulls the latest commit — only the release creation step is missing. If Glama adds an API or webhook in the future, the step would slot into `release.yml` after the MCPB upload:
+
+```yaml
+- name: Trigger Glama release
+  if: steps.changesets.outputs.published == 'true'
+  run: |
+    VERSION=$(node -p "require('./packages/server/package.json').version")
+    curl -fsSL -X POST "https://glama.ai/api/..." \
+      -H "Authorization: Bearer ${{ secrets.GLAMA_API_TOKEN }}" \
+      -d "{\"version\": \"${VERSION}\"}"
+```
+
+Until then, the manual step above is required to keep the Glama listing current.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "npm run -ws --if-present build",
-    "test": "npm run -ws --if-present test",
+    "test": "npm run -ws --if-present test && npm run test:scripts",
+    "test:scripts": "vitest run scripts/shard.test.ts",
     "lint": "biome check .",
     "format": "biome format --write .",
     "harness": "npm run -w @seekstone/harness start --",

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts'],
+      // @seekstone/core holds the safety-critical shared primitives (byte-aware
+      // frontmatter round-trip, link extraction, outline). Gate it like the
+      // server and harness so a regression in these fails the build. Thresholds
+      // sit below current coverage (96/82/100/99) with headroom.
+      thresholds: {
+        statements: 90,
+        lines: 90,
+        functions: 95,
+        branches: 75,
+      },
+    },
+  },
+});

--- a/packages/obsidian-mcp-seekstone/tsconfig.json
+++ b/packages/obsidian-mcp-seekstone/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    // This package has its own node_modules (vitest cache), which stops TS's
+    // automatic @types discovery from walking up to the hoisted root where
+    // @types/node lives. Name it explicitly so Node globals resolve.
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Why

A repo-structure audit (after a burst of changes) found the layout fundamentally sound but with five drift items — some **silently broken**, some inconsistent with the rest of the monorepo. This PR fixes the high/medium ones in one low-risk standardization pass.

## Changes

**1. 🔴 `scripts/shard.test.ts` ran in no test runner.** Workspaces are `packages/*` only and there's no root vitest config, so CI's `npm run -ws test` never executed it — a test rotting silently. Added a `test:scripts` npm script and chained it into `npm test`, so it runs everywhere (CI + release gates). *(6 tests, now executed.)*

**2/3. 🟡 `core` was tested but ungated.** 54 tests run, but the coverage gates were server + harness only — leaving the **most safety-critical** package (byte-aware frontmatter round-trip, link extraction, outline) with no floor. Added `packages/core/vitest.config.ts` (thresholds 90/90/95/75; current **96.3 / 81.9 / 100 / 98.6**) and a CI **Coverage gate (core)** step; core lcov added to the Codecov upload.

**4. 🟡 `obsidian-mcp-seekstone` shipped TS but was never typechecked.** CI ran `tsc` for core/harness/server only. Added `packages/obsidian-mcp-seekstone/tsconfig.json` (extends base) + a CI typecheck line. Needed an explicit `"types": ["node"]` because the package's local `node_modules` (vitest cache) blocks TS's automatic `@types` discovery from walking up to the hoisted root — documented inline.

**5. 🟡 Duplicate `RELEASING.md`.** Root and `docs/` had different content on the same topic. They were actually *complementary*: root uniquely documented the **Glama post-publish step** (referenced by `release.yml`), docs covered the Changesets/OIDC flow. Folded the Glama section into the canonical `docs/RELEASING.md`, made root a one-line pointer, and updated the `release.yml` comment reference. No content lost.

## Verification

- All **four** typechecks pass (incl. the newly-checked alias).
- All **three** coverage gates pass (server, harness, **core**).
- `npm test` green across workspaces **and** the shard test.
- biome lint clean; no dangling `RELEASING.md` links.

## Deferred (low-priority, not here)
`core` README; documenting the package-dir naming convention; documenting/trimming the committed fixture vaults (1k/5k/10k ≈ 16.5k files); moving `docs/PRD_TEMPLATE.md` under `docs/templates/`. Captured in SHA-198's description.

## Scope
Pure config/standardization — no product `src` changes, so no changeset required.

Closes SHA-198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)