### PR TITLE
fix(release): push the version PR branch with the PAT so required CI fires

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # Persist the PAT (not the default GITHUB_TOKEN) as the git credential so
+          # the "Version Packages" branch is PUSHED as a real user. changesets/action
+          # opens the PR via the API token in the step below (author = PAT owner), but
+          # it pushes the branch commits using checkout's persisted credentials. With
+          # the default token the push actor is github-actions[bot], and GitHub blocks
+          # pull_request CI on bot-pushed commits (loop prevention) — leaving the release
+          # PR permanently BLOCKED on the required test checks. Pushing with the PAT
+          # makes CI fire normally. (The PAT needs contents:write; no workflows scope —
+          # changesets only commits version/changelog files, never .github/workflows.)
+          token: ${{ secrets.GH_PAT }}
 
       # NOTE: no `registry-url` here on purpose. setup-node's registry-url
       # writes an ~/.npmrc with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`;
@@ -75,11 +85,11 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
-          # GH_PAT (fine-grained PAT, Contents+PRs read/write) is required here
-          # instead of GITHUB_TOKEN. PRs opened with GITHUB_TOKEN are created by
-          # github-actions[bot] and GitHub intentionally blocks pull_request CI
-          # events on them to prevent recursive workflow loops. A PAT makes the PR
-          # look like it came from a real user, so CI fires normally.
+          # GH_PAT (fine-grained PAT, Contents+PRs read/write) is the API token
+          # changesets uses to open the "Version Packages" PR, so its author is the
+          # PAT owner rather than github-actions[bot]. This pairs with the PAT on the
+          # checkout step above: authoring the PR via the PAT is not enough on its own —
+          # the branch must also be PUSHED with the PAT (see that comment) for CI to fire.
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           NPM_CONFIG_PROVENANCE: 'true'
 


### PR DESCRIPTION
## Problem

The release PR (`chore: version packages`) sits permanently **BLOCKED** on the required `test (ubuntu/macos/windows)` checks, so every release has to be unblocked by hand with a throwaway empty commit (as just happened for `seekstone@0.7.0`).

### Root cause

`GH_PAT` was wired into `changesets/action` **only as the API token** (`env.GITHUB_TOKEN`). That makes the PR's *author* the PAT owner, but it does **not** control how the branch is pushed. `actions/checkout` persists the default `GITHUB_TOKEN` as the git credential, so `changesets/action`'s `git push` of the branch commits runs as **`github-actions[bot]`**. GitHub deliberately blocks `pull_request` CI on bot-pushed commits (workflow-loop prevention) — so the required checks never report and the PR can't merge.

Authoring the PR via the PAT is necessary but not sufficient: the **push** is what creates the head commit that `pull_request` workflows key off, and that push must also be a real user.

## Fix

Persist `GH_PAT` as the `checkout` git credential (`token: ${{ secrets.GH_PAT }}`) so the branch is pushed as the PAT owner and CI fires automatically. The PAT only needs `contents: write` — changesets commits version/changelog files, never `.github/workflows`, so no `workflows` scope is required.

Comments on both the checkout and changesets steps updated to explain the two halves (API author + branch pusher).

## Testing

Workflow-only change — not exercisable by the unit suite. The real validation is the next release PR fires its `test (*)` checks without a manual nudge. Existing CI (lint/test/typecheck) runs on this PR unchanged.