### PR TITLE
feat(release): mint a GitHub App token for the release bot instead of a PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,19 +22,31 @@ jobs:
       run:
         shell: bash
     steps:
+      # Mint a short-lived GitHub App installation token for the release bot.
+      # This replaces the old GH_PAT: an App token never expires from under us
+      # (it's re-minted each run and auto-expires in ~1h) and, crucially, pushes
+      # made with it DO trigger workflows — unlike the default GITHUB_TOKEN, whose
+      # github-actions[bot] pushes GitHub blocks pull_request CI on (loop
+      # prevention). Requires repo secrets APP_ID + APP_PRIVATE_KEY from a GitHub
+      # App (Contents: R/W, Pull requests: R/W) installed on this repo.
+      - name: Mint release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          # Persist the PAT (not the default GITHUB_TOKEN) as the git credential so
-          # the "Version Packages" branch is PUSHED as a real user. changesets/action
-          # opens the PR via the API token in the step below (author = PAT owner), but
-          # it pushes the branch commits using checkout's persisted credentials. With
-          # the default token the push actor is github-actions[bot], and GitHub blocks
-          # pull_request CI on bot-pushed commits (loop prevention) — leaving the release
-          # PR permanently BLOCKED on the required test checks. Pushing with the PAT
-          # makes CI fire normally. (The PAT needs contents:write; no workflows scope —
-          # changesets only commits version/changelog files, never .github/workflows.)
-          token: ${{ secrets.GH_PAT }}
+          # Persist the App token (not the default GITHUB_TOKEN) as the git
+          # credential so the "Version Packages" branch is PUSHED as the App bot.
+          # changesets/action opens the PR via the API token in the step below, but
+          # it pushes the branch commits using checkout's persisted credentials —
+          # with the default token that push is github-actions[bot] and GitHub blocks
+          # pull_request CI on it, leaving the release PR permanently BLOCKED on the
+          # required test checks. Pushing with the App token makes CI fire normally.
+          token: ${{ steps.app-token.outputs.token }}
 
       # NOTE: no `registry-url` here on purpose. setup-node's registry-url
       # writes an ~/.npmrc with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`;
@@ -85,12 +97,12 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
-          # GH_PAT (fine-grained PAT, Contents+PRs read/write) is the API token
-          # changesets uses to open the "Version Packages" PR, so its author is the
-          # PAT owner rather than github-actions[bot]. This pairs with the PAT on the
-          # checkout step above: authoring the PR via the PAT is not enough on its own —
-          # the branch must also be PUSHED with the PAT (see that comment) for CI to fire.
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          # The App token is the API token changesets uses to open the "Version
+          # Packages" PR, so its author is the App bot rather than github-actions[bot].
+          # This pairs with the same token on the checkout step above: authoring the PR
+          # via the App is not enough on its own — the branch must also be PUSHED with it
+          # (see that comment) for the required pull_request CI to fire.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Build MCP Bundle

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -26,6 +26,21 @@ CI (the `CI` workflow) additionally enforces a **coverage gate** on the server's
 
 Settings → Actions → General → Workflow permissions → enable **"Allow GitHub Actions to create and approve pull requests"** (so Changesets can open the version PR).
 
+## Release-bot GitHub App (opens the version PR + triggers its CI)
+
+The default `GITHUB_TOKEN` can't be used to open the "Version Packages" PR: pushes made with it are attributed to `github-actions[bot]`, and GitHub blocks `pull_request` CI on bot-pushed commits (loop prevention), so the PR would sit permanently BLOCKED on the required `test (*)` checks. The workflow instead mints a short-lived **GitHub App installation token** (`actions/create-github-app-token`) — App-token pushes trigger workflows, and the token re-mints every run so nothing expires from under us (this replaced an earlier fine-grained PAT that had to be manually rotated).
+
+**One-time setup:**
+
+1. Create a GitHub App (Settings → Developer settings → GitHub Apps → New). Repository permissions: **Contents: Read & write** and **Pull requests: Read & write**. No webhook, no account permissions.
+2. **Install** the App on `shaqmughal/seekstone` (App settings → Install App).
+3. **Generate a private key** (App settings → bottom → Generate a private key → downloads a `.pem`).
+4. Add two repo secrets (Settings → Secrets and variables → Actions):
+   - `APP_ID` — the App's numeric ID (shown at the top of the App's settings page).
+   - `APP_PRIVATE_KEY` — the full contents of the downloaded `.pem`, including the `-----BEGIN/END-----` lines.
+
+Once both secrets exist, releases are hands-off. If the App is ever uninstalled or the secrets are removed, the `Mint release-bot token` step fails fast at the top of the job.
+
 ## Authentication — OIDC trusted publishing (no token)
 
 The workflow publishes via **OIDC trusted publishing**: no npm token is stored, and provenance is automatic. It needs `id-token: write` (set) and npm ≥ 11.5.1 (the workflow runs `npm install -g npm@latest`).


### PR DESCRIPTION
## Why

Follow-up to #151. That fix made the release pipeline push the version PR branch as a real user (via `GH_PAT`) so its required CI fires. But a fine-grained PAT **expires** and has to be rotated by hand — when it lapses, releases silently break again.

This swaps the PAT for a **GitHub App installation token** minted per run with `actions/create-github-app-token`:
- App-token pushes **trigger workflows** (the whole point — unlike the default `GITHUB_TOKEN`/`github-actions[bot]`, whose pushes GitHub blocks `pull_request` CI on).
- The token is **re-minted every run and auto-expires (~1h)** — nothing expires from under us between releases, no rotation.

## Changes

- New `Mint release-bot token` step (`actions/create-github-app-token`, pinned to v3.2.0 SHA) at the top of the release job.
- `checkout` `token` and the `changesets/action` `GITHUB_TOKEN` both now use `${{ steps.app-token.outputs.token }}` instead of `secrets.GH_PAT`.
- `docs/RELEASING.md`: documents the one-time GitHub App setup + the two required secrets.

## ⚠️ Required before merge

Create a GitHub App and add its secrets **first**, or the next push to `main` fails at the token step:

1. New GitHub App — repo permissions **Contents: R/W** + **Pull requests: R/W** (no webhook).
2. **Install** it on `shaqmughal/seekstone`.
3. Generate a private key (`.pem`).
4. Add repo secrets `APP_ID` (numeric) and `APP_PRIVATE_KEY` (full `.pem` contents).

Once the App publishes its first release PR, `GH_PAT` is unused and can be deleted.

## Testing

Workflow-only change; not exercisable by the unit suite. Real validation is the next release PR firing its `test (*)` checks unattended under the App identity. Normal CI (lint/test/typecheck) runs on this PR unchanged.