### PR TITLE
docs(release): drop stale GH_PAT reference from token comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
         shell: bash
     steps:
       # Mint a short-lived GitHub App installation token for the release bot.
-      # This replaces the old GH_PAT: an App token never expires from under us
-      # (it's re-minted each run and auto-expires in ~1h) and, crucially, pushes
-      # made with it DO trigger workflows — unlike the default GITHUB_TOKEN, whose
+      # The App token never expires from under us (it's re-minted each run and
+      # auto-expires in ~1h) and, crucially, pushes made with it DO trigger
+      # workflows — unlike the default GITHUB_TOKEN, whose
       # github-actions[bot] pushes GitHub blocks pull_request CI on (loop
       # prevention). Requires repo secrets APP_ID + APP_PRIVATE_KEY from a GitHub
       # App (Contents: R/W, Pull requests: R/W) installed on this repo.


### PR DESCRIPTION
## What

Rewords the release-bot token comment in `.github/workflows/release.yml` to describe the GitHub App token on its own terms, removing the now-stale "This replaces the old GH_PAT" framing.

## Why

The `GH_PAT` is fully retired:
- repo secret deleted (2026-06-27, during the App-token cutover in #152)
- underlying account-level fine-grained PAT revoked (2026-06-29) — last used by the pre-cutover #151 release run, nothing depended on it

The comment was the last lingering reference to it. No behavior change — comment-only.