### PR TITLE
Consolidate npm package name: seekstone is canonical, alias goes into migration mode

### DIFF
--- a/.changeset/consolidate-npm-name.md
+++ b/.changeset/consolidate-npm-name.md
@@ -1,0 +1,6 @@
+---
+"seekstone": patch
+"obsidian-mcp-seekstone": patch
+---
+
+Consolidate on the canonical npm name `seekstone`. The `obsidian-mcp-seekstone` discoverability alias is deprecated: its README is now a migration notice, and all install docs point at `npx -y seekstone`. Existing alias installs keep working. This is the alias's final release.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 <p align="center"><a href="https://seekstone.dev"><strong>seekstone.dev →</strong></a></p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/obsidian-mcp-seekstone"><img src="https://img.shields.io/npm/v/obsidian-mcp-seekstone?color=cb3837&logo=npm&label=obsidian-mcp-seekstone" alt="npm" /></a>
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/v/seekstone?color=cb3837&logo=npm&label=seekstone" alt="npm (seekstone)" /></a>
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/dt/seekstone?color=7c3aed&label=downloads" alt="npm total downloads" /></a>
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/dw/seekstone?color=7c3aed&label=downloads%2Fwk" alt="npm weekly downloads" /></a>
@@ -41,12 +40,7 @@ It reads your vault **directly from disk** rather than routing through the Obsid
 
 Claude can search and read your entire note library, in milliseconds, without burning most of its context window on a single tool call.
 
-**Two npm names, one server** — published under both for discoverability:
-
-| Package | Install command |
-|---|---|
-| [`obsidian-mcp-seekstone`](https://www.npmjs.com/package/obsidian-mcp-seekstone) | `npx -y obsidian-mcp-seekstone` |
-| [`seekstone`](https://www.npmjs.com/package/seekstone) | `npx -y seekstone` |
+Published on npm as [`seekstone`](https://www.npmjs.com/package/seekstone) — install with `npx -y seekstone`. (Previously also published as `obsidian-mcp-seekstone`; that alias is deprecated but existing installs keep working.)
 
 ---
 
@@ -107,7 +101,7 @@ You'll know it worked when seekstone appears in Claude's toolbar. No JSON editin
 Open **Terminal** (macOS: `Cmd+Space`, type "Terminal", press Enter) and run:
 
 ```bash
-npx -y obsidian-mcp-seekstone init
+npx -y seekstone init
 ```
 
 You'll know it worked when Seekstone appears in Claude's toolbar under the plug icon.
@@ -116,19 +110,19 @@ Seekstone reads Obsidian's own vault registry to detect your vault, validates it
 
 ```bash
 # Auto-detect vault, print config to paste
-npx -y obsidian-mcp-seekstone init
+npx -y seekstone init
 
 # Auto-detect vault, patch Claude Desktop in place (with backup)
-npx -y obsidian-mcp-seekstone init --write
+npx -y seekstone init --write
 
 # Specify vault explicitly if you have multiple
-npx -y obsidian-mcp-seekstone init --vault "/path/to/vault"
+npx -y seekstone init --vault "/path/to/vault"
 
 # Auto-configure Claude Code in one step (auto-detects vault, runs claude mcp add)
-npx -y obsidian-mcp-seekstone init --client code --write
+npx -y seekstone init --client code --write
 
 # Or just print the Claude Code command without running it
-npx -y obsidian-mcp-seekstone init --client code
+npx -y seekstone init --client code
 ```
 
 ### Option 3 — Manual config (Claude Desktop)
@@ -140,7 +134,7 @@ Add to `claude_desktop_config.json` (Settings → Developer → Edit Config):
   "mcpServers": {
     "seekstone": {
       "command": "npx",
-      "args": ["-y", "obsidian-mcp-seekstone"],
+      "args": ["-y", "seekstone"],
       "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
     }
   }
@@ -152,13 +146,13 @@ Add to `claude_desktop_config.json` (Settings → Developer → Edit Config):
 Auto-detects your vault and configures Claude Code in one command:
 
 ```bash
-npx -y obsidian-mcp-seekstone init --client code --write
+npx -y seekstone init --client code --write
 ```
 
 Or manually, if you prefer to specify the vault path explicitly:
 
 ```bash
-claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y obsidian-mcp-seekstone
+claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y seekstone
 ```
 
 ---

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -4,23 +4,18 @@ How Seekstone gets listed where people discover MCP servers. The repo contains
 the config files each registry reads (`server.json`, `glama.json`) and the
 `mcpName` field in `packages/server/package.json`.
 
-## Two npm packages, one server
+## One npm package
 
-| Package | npm | Purpose |
-|---|---|---|
-| `obsidian-mcp-seekstone` | [link](https://www.npmjs.com/package/obsidian-mcp-seekstone) | Discoverable via "obsidian mcp" search |
-| `seekstone` | [link](https://www.npmjs.com/package/seekstone) | Canonical short name |
-
-Both are published automatically by the release pipeline on every version bump.
+Seekstone is published as [`seekstone`](https://www.npmjs.com/package/seekstone) — the canonical and only maintained name. [`obsidian-mcp-seekstone`](https://www.npmjs.com/package/obsidian-mcp-seekstone) was a discoverability alias; it is **deprecated** (existing installs keep working, but it no longer receives updates). Discoverability for "obsidian mcp" searches now rests on the `keywords` field and description, not the package name.
 
 ## Canonical copy (reuse everywhere)
 
-- **Name:** Seekstone (also: obsidian-mcp-seekstone)
+- **Name:** Seekstone
 - **Tagline:** An Obsidian MCP server — filesystem-direct, low context-tax.
 - **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 16 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
-- **Install:** `npx -y obsidian-mcp-seekstone` (also: `npx -y seekstone`); env `SEEKSTONE_VAULT=/path/to/vault`
+- **Install:** `npx -y seekstone`; env `SEEKSTONE_VAULT=/path/to/vault`
 - **Repo:** https://github.com/shaqmughal/seekstone
-- **npm:** https://www.npmjs.com/package/obsidian-mcp-seekstone / https://www.npmjs.com/package/seekstone
+- **npm:** https://www.npmjs.com/package/seekstone
 - **Tools (16):** _Read_ — search, read_note, list_notes, list_tags, outline_note, get_backlinks, get_links, get_periodic_note · _Write_ — create_note, delete_note, move_note, append_note, patch_frontmatter, patch_note, replace_in_note, append_periodic_note
 - **Categories/tags:** obsidian, notes, knowledge-base, markdown, search, obsidian-mcp
 
@@ -63,7 +58,7 @@ Glama auto-indexes public repos. Direct listing: https://glama.ai/mcp/servers/@s
 
 PR open: https://github.com/punkpeye/awesome-mcp-servers/pull/7190
 
-Entry uses `obsidian-mcp-seekstone` for discoverability. Update the PR if the entry needs refreshing.
+The entry originally used `obsidian-mcp-seekstone`; that name is now deprecated — update the PR so the entry points at `seekstone`.
 
 ## Keeping listings current
 

--- a/llms.txt
+++ b/llms.txt
@@ -4,11 +4,7 @@
 
 Website: https://seekstone.dev
 
-Seekstone is published to npm under two names:
-- `obsidian-mcp-seekstone` — the discoverable name (search "obsidian mcp" on npm)
-- `seekstone` — the short canonical name
-
-Both names install the exact same server.
+Seekstone is published to npm as `seekstone`. (It was previously also published as `obsidian-mcp-seekstone`; that alias is deprecated — existing installs keep working but it no longer receives updates.)
 
 ## Why filesystem-direct?
 
@@ -23,7 +19,7 @@ Add to `claude_desktop_config.json`:
   "mcpServers": {
     "seekstone": {
       "command": "npx",
-      "args": ["-y", "obsidian-mcp-seekstone"],
+      "args": ["-y", "seekstone"],
       "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
     }
   }
@@ -33,19 +29,30 @@ Add to `claude_desktop_config.json`:
 ## How to install (Claude Code)
 
 ```bash
-claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y obsidian-mcp-seekstone
+claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y seekstone
 ```
 
-## Tools
+## Tools (16)
 
+Read:
 - `search` — full-text search returning ranked excerpts, ~120 chars by default and tunable (not full notes)
-- `read_note` — read the full content of a note by vault-relative path
+- `read_note` — read the full content of a note by vault-relative path; supports section, block, or line-range slices
 - `list_notes` — list notes filtered by folder prefix or tag
+- `list_tags` — list all tags sorted by usage count or alphabetically
+- `outline_note` — a note's heading and block structure without its full content
+- `get_backlinks` — all notes linking to a given note
+- `get_links` — all outgoing wikilinks and markdown links from a note
+- `get_periodic_note` — read a daily/weekly/monthly/quarterly/yearly note, path resolved from vault config
+
+Write:
 - `create_note` — create a note with optional frontmatter and body
 - `delete_note` — permanently delete a note
 - `move_note` — move or rename a note
 - `append_note` — append text to a note body without touching frontmatter
 - `patch_frontmatter` — set, update, or delete frontmatter keys while preserving key order and quote style
+- `patch_note` — insert text immediately after a heading
+- `replace_in_note` — replace the first occurrence of a word or phrase in the note body
+- `append_periodic_note` — append to today's periodic note, creating it from a template if needed
 
 ## Requirements
 
@@ -62,8 +69,7 @@ claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- n
 
 ## Links
 
-- npm (primary): https://www.npmjs.com/package/obsidian-mcp-seekstone
-- npm (short name): https://www.npmjs.com/package/seekstone
+- npm: https://www.npmjs.com/package/seekstone
 - GitHub: https://github.com/shaqmughal/seekstone
 - MCP registry: https://registry.modelcontextprotocol.io (search: io.github.shaqmughal/seekstone)
 - Glama: https://glama.ai/mcp/servers/@shaqmughal/seekstone

--- a/packages/obsidian-mcp-seekstone/README.md
+++ b/packages/obsidian-mcp-seekstone/README.md
@@ -1,52 +1,52 @@
 # obsidian-mcp-seekstone
 
-> **A discoverability alias for [seekstone](https://www.npmjs.com/package/seekstone)** — the filesystem-direct Obsidian MCP server.
+> **This package has been renamed to [`seekstone`](https://www.npmjs.com/package/seekstone).** Install that instead.
 
-`obsidian-mcp-seekstone` and `seekstone` are the same server. This package exists so users searching npm for "obsidian mcp" can find it. The underlying code, tools, and documentation all live in [shaqmughal/seekstone](https://github.com/shaqmughal/seekstone).
+`obsidian-mcp-seekstone` was a discoverability alias for `seekstone` — the filesystem-direct Obsidian MCP server. The two packages were always the same server. The project has consolidated on the canonical name **`seekstone`**, and this alias is deprecated.
 
-## Why seekstone?
+**Existing installs keep working** — this package still runs the same server — but it no longer receives updates. Migrate your MCP config when convenient.
 
-Seekstone reads your Obsidian vault **directly from disk** instead of routing through the Local REST API plugin. The practical difference: a search that returns ~1.75 MB / ~459,000 tokens via the REST plugin returns **~3 KB / ~800 tokens** via seekstone — a ~575× reduction. No Obsidian app, no plugin, no network calls.
+## How to migrate
 
-## Install
+Replace `obsidian-mcp-seekstone` with `seekstone` wherever it appears.
 
 **Claude Desktop** — `claude_desktop_config.json`:
 
-```json
-{
-  "mcpServers": {
-    "seekstone": {
-      "command": "npx",
-      "args": ["-y", "obsidian-mcp-seekstone"],
-      "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
-    }
-  }
-}
+```diff
+ {
+   "mcpServers": {
+     "seekstone": {
+       "command": "npx",
+-      "args": ["-y", "obsidian-mcp-seekstone"],
++      "args": ["-y", "seekstone"],
+       "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
+     }
+   }
+ }
 ```
 
 **Claude Code:**
 
 ```bash
-claude mcp add seekstone --env SEEKSTONE_VAULT=/path/to/vault -- npx -y obsidian-mcp-seekstone
+claude mcp remove seekstone
+claude mcp add seekstone --env SEEKSTONE_VAULT=/path/to/vault -- npx -y seekstone
 ```
 
-## Tools
+**Guided setup** (auto-detects your vault, patches your client config):
 
-8 tools over stdio: `search`, `read_note`, `list_notes`, `create_note`, `delete_note`, `move_note`, `append_note`, `patch_frontmatter`.
+```bash
+npx -y seekstone init
+```
 
-## Configuration
+## What is Seekstone?
 
-| Variable | Required | Description |
-|---|---|---|
-| `SEEKSTONE_VAULT` | Yes | Absolute path to your Obsidian vault. |
-| `SEEKSTONE_LOG_LEVEL` | No | `error` \| `warn` \| `info` (default) \| `debug`. |
-| `SEEKSTONE_WATCH_POLL` | No | Set to `1` for network drives / WSL. |
+The fastest Obsidian MCP server for Claude — it reads your vault **directly from disk**, no Obsidian app, no plugins, no network calls. 16 tools over stdio: search (ranked excerpts, not full notes), reads, writes, link navigation, and structural ops. macOS, Linux, and Windows (Node.js ≥ 22).
 
-Works on macOS, Linux, and Windows (Node.js ≥ 22).
+Everything lives at:
 
-## Source & docs
-
-Everything is in [shaqmughal/seekstone](https://github.com/shaqmughal/seekstone). Issues, PRs, and docs live there.
+- npm: [`seekstone`](https://www.npmjs.com/package/seekstone)
+- Website: [seekstone.dev](https://seekstone.dev)
+- GitHub: [shaqmughal/seekstone](https://github.com/shaqmughal/seekstone)
 
 ## License
 

--- a/packages/obsidian-mcp-seekstone/package.json
+++ b/packages/obsidian-mcp-seekstone/package.json
@@ -3,7 +3,7 @@
   "mcpName": "io.github.shaqmughal/seekstone",
   "type": "module",
   "version": "0.7.0",
-  "description": "Obsidian MCP server for Claude — filesystem-direct vault access, 575× smaller payloads than the REST plugin.",
+  "description": "Renamed to seekstone — install that instead. Obsidian MCP server for Claude, filesystem-direct vault access.",
   "keywords": [
     "obsidian",
     "obsidian-mcp",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,4 +1,4 @@
-# seekstone / obsidian-mcp-seekstone
+# seekstone
 
 **The Obsidian MCP server for Claude — search and edit your vault without burning context.**
 
@@ -6,12 +6,7 @@ Seekstone is an Obsidian MCP server that gives Claude (and any [Model Context Pr
 
 It reads your vault **directly from disk** instead of routing through the Obsidian Local REST API plugin. The practical difference: a search that returns ~1.75 MB and ~459,000 tokens via the REST plugin returns **~3 KB and ~800 tokens** via Seekstone — a **~575× reduction**. Claude can search and read your entire note library without burning most of its context window on a single tool call.
 
-**Two npm names, one server:**
-
-| Package | Best for |
-|---|---|
-| [`obsidian-mcp-seekstone`](https://www.npmjs.com/package/obsidian-mcp-seekstone) | Searching npm for "obsidian mcp" |
-| [`seekstone`](https://www.npmjs.com/package/seekstone) | Shorter name if you already know it |
+(Previously also published as `obsidian-mcp-seekstone` — that alias is deprecated; existing installs keep working, but install `seekstone` going forward.)
 
 ---
 
@@ -28,23 +23,23 @@ Download `seekstone.mcpb` from [GitHub Releases](https://github.com/shaqmughal/s
 Run the setup helper and let Seekstone find your vault automatically:
 
 ```bash
-npx -y obsidian-mcp-seekstone init
+npx -y seekstone init
 ```
 
 Seekstone reads Obsidian's own vault registry to detect your vault, validates it, and either prints the config to paste or patches Claude Desktop directly:
 
 ```bash
 # Auto-detect vault, print config to paste
-npx -y obsidian-mcp-seekstone init
+npx -y seekstone init
 
 # Auto-detect vault, patch Claude Desktop in place (with backup)
-npx -y obsidian-mcp-seekstone init --write
+npx -y seekstone init --write
 
 # Specify vault explicitly if you have multiple
-npx -y obsidian-mcp-seekstone init --vault "/path/to/vault"
+npx -y seekstone init --vault "/path/to/vault"
 
 # Generate the Claude Code command instead
-npx -y obsidian-mcp-seekstone init --client code
+npx -y seekstone init --client code
 ```
 
 ### Option 3 — Manual config (Claude Desktop)
@@ -56,7 +51,7 @@ Add to `claude_desktop_config.json` (Settings → Developer → Edit Config):
   "mcpServers": {
     "seekstone": {
       "command": "npx",
-      "args": ["-y", "obsidian-mcp-seekstone"],
+      "args": ["-y", "seekstone"],
       "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
     }
   }
@@ -66,23 +61,38 @@ Add to `claude_desktop_config.json` (Settings → Developer → Edit Config):
 ### Option 4 — Claude Code
 
 ```bash
-claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y obsidian-mcp-seekstone
+claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y seekstone
 ```
 
 ---
 
 ## Tools
 
+### Read
+
 | Tool | Description |
 |---|---|
 | `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy, prefix, and phrase queries. |
-| `read_note` | Read the full content of a note by vault-relative path. |
+| `read_note` | Read the full content of a note by vault-relative path. Supports returning a single section, block, or line range. |
 | `list_notes` | List notes, optionally filtered by folder prefix or tag. |
+| `list_tags` | List all tags in the vault sorted by usage count (or alphabetically). |
+| `outline_note` | Return a note's heading and block structure without its full content. |
+| `get_backlinks` | Find all notes that link to a given note. |
+| `get_links` | List all outgoing wikilinks and markdown links from a note. |
+| `get_periodic_note` | Read a daily/weekly/monthly/quarterly/yearly note — path resolved from your vault config, no Obsidian required. |
+
+### Write
+
+| Tool | Description |
+|---|---|
 | `create_note` | Create a note (optional frontmatter + body); parent dirs created automatically. |
 | `delete_note` | Permanently delete a note. |
 | `move_note` | Move/rename a note; destination dirs created automatically. |
 | `append_note` | Append to a note body without touching frontmatter. |
 | `patch_frontmatter` | Set/update/delete frontmatter keys without reordering existing keys or changing quote style. |
+| `patch_note` | Insert text immediately after a heading without touching frontmatter. |
+| `replace_in_note` | Replace the first occurrence of a word or phrase in the note body. |
+| `append_periodic_note` | Append to today's periodic note, creating it from a template if it doesn't yet exist. |
 
 ---
 


### PR DESCRIPTION
## Why

We publish the same server under two npm names, splitting the download signal ~50/50 (seekstone 3,576/mo + obsidian-mcp-seekstone 3,035/mo = 6,611 combined — a clear #4 among Obsidian MCP servers; split, each name ranks far lower). Our own docs feed the split: the repo README and the published seekstone npm README instruct users to install the alias.

This is step 1 of the consolidation (SHA-208): ship one final alias release whose README is a pure migration notice, and point every install doc at `npx -y seekstone`. A follow-up PR removes the alias from the monorepo and release train; after this release publishes, the alias gets `npm deprecate`d (non-breaking — existing installs keep working).

## Changes

- `packages/obsidian-mcp-seekstone/README.md` → migration notice with before/after config diffs (Claude Desktop + Claude Code)
- Alias `package.json` description → "Renamed to seekstone — install that instead…" (this is what npm search results show)
- `README.md` — drop alias badge, replace "two npm names" table, all install commands → `npx -y seekstone`
- `packages/server/README.md` (published npm README) — same, plus fixes the stale 8-tool table (server ships 16)
- `llms.txt` — canonical name + full 16-tool list (was 8)
- `docs/REGISTRIES.md` — "one npm package" framing, canonical copy updated
- Changeset: patch for both packages (linked), so the release train publishes the migration README as the alias's final version

## Verification

- `npm test` — 52 test files green across workspaces (incl. the alias version-lock shim tests)
- `npm run lint` — clean
- Grepped: every remaining `obsidian-mcp-seekstone` mention in docs is deliberate "deprecated alias" context