### PR TITLE
Add npm keywords for adjacent discovery clusters (SHA-214)

### DIFF
--- a/.changeset/add-discovery-keywords.md
+++ b/.changeset/add-discovery-keywords.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Add npm keywords for the adjacent discovery clusters Seekstone was absent from: `claude-code`, `second-brain`, `chatgpt`, `cursor`, `connect-claude-to-obsidian`, `mcp-server`.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,13 @@
     "pkm",
     "personal-knowledge-management",
     "note-taking",
-    "search"
+    "search",
+    "claude-code",
+    "second-brain",
+    "chatgpt",
+    "cursor",
+    "connect-claude-to-obsidian",
+    "mcp-server"
   ],
   "license": "MIT",
   "author": "Shaq Mughal",


### PR DESCRIPTION
Adds the six keywords from the SHA-214 keyword-gap research to `packages/server/package.json`: `claude-code`, `second-brain`, `chatgpt`, `cursor`, `connect-claude-to-obsidian`, `mcp-server`. Patch changeset included so they publish with the next release.

The matching six GitHub topics are already live on the repo (now at the 20-topic cap).