### PR TITLE
Add MCP protocol conformance gate + real-client E2E (SHA-231)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Gate: MCP protocol conformance — boots the built server over stdio with
+      # the SDK reference client and asserts handshake, exact tool surface
+      # (HANDLED_TOOLS), and a search + append_note round-trip. Protocol
+      # behavior is OS-independent; run once (Linux). Filesystem behavior is
+      # covered by the OS-matrix unit tests.
+      - name: MCP protocol conformance
+        if: matrix.os == 'ubuntu-latest'
+        run: npm run conformance
+
       # Guard: server.json (the MCP registry manifest) must match the package
       # versions. A manual `mcp-publisher publish` reads this file as-is, so a
       # stale version here would regress the registry. Runs once (Linux).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Smoke-test the published tarball
         run: npm run smoke
 
+      - name: MCP protocol conformance
+        run: npm run conformance
+
       # On a push that still has changesets pending → opens/updates a "Version
       # Packages" PR. On the push that merges that PR (no changesets left) →
       # publishes to npm with provenance. Re-publishing an existing version is

--- a/docs/CLIENT-TESTING.md
+++ b/docs/CLIENT-TESTING.md
@@ -1,0 +1,34 @@
+# Client testing
+
+How Seekstone backs the claim "works with any MCP client" (positioning decision SHA-217).
+
+## The layers
+
+| Layer | What | When it runs |
+|---|---|---|
+| Protocol conformance | `npm run conformance` — boots the built server over stdio with the MCP SDK reference client; asserts the initialize handshake, the exact `HANDLED_TOOLS` surface, and a `search` + `append_note` round-trip against a scratch vault | Every CI run (Linux leg) and as a release gate |
+| Config writers | Unit tests per `seekstone init --client <name>` target (`packages/server/src/init.test.ts`) — exact file format and path per client | Every `npm test` |
+| Real-client E2E | `scripts/claude-code-e2e.sh` — packs the current build, attaches it to headless Claude Code via `--mcp-config`, and asserts a model-driven `search` retrieves seeded vault content | Manual, before releases that change tool schemas |
+| GUI client checklist | The table below | Manual, when tool schemas or install docs change |
+
+If protocol conformance passes, any spec-compliant stdio client can talk to Seekstone — per-client work is config plumbing, which the other layers cover.
+
+## Manual GUI checklist
+
+For each client, three steps against a scratch vault (never a personal one):
+
+1. **Install** exactly as the README documents it for that client — no undocumented workarounds. If a workaround is needed, that's a docs bug; fix the docs.
+2. **Tools appear** — the client's MCP/server UI lists seekstone with 16 tools.
+3. **One search + one write** — ask for a term seeded in the scratch vault (search must return it), then ask to append a line to a note (file on disk must change, frontmatter untouched).
+
+Record each pass here (newest first):
+
+| Date | Client + version | Seekstone | Result | Notes |
+|---|---|---|---|---|
+| _(add rows as runs happen)_ | | | | |
+
+Clients to cover as their install docs ship (SHA-61 children): Claude Desktop, Claude Code (scripted — see above), Cursor (SHA-230), VS Code / Copilot (SHA-62), JetBrains AI Assistant (SHA-67), Windsurf.
+
+## Non-clients
+
+ChatGPT cannot run local stdio MCP servers (remote Streamable HTTP only) — deferred by SHA-217, gated on SHA-209. Don't add it to the checklist until that ships.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,9 +18,11 @@ Re-running a release for an already-published version is a no-op, so the workflo
 
 ## Gates (must pass before publish)
 
-The `Release` workflow runs typecheck → `npm test` → `npm run lint` → **`npm run smoke`** before the publish step. `smoke` packs the tarball, installs it into a throwaway project, and boots the `seekstone` bin to confirm `npx seekstone` works for a real user. A failure at any gate blocks the publish.
+The `Release` workflow runs typecheck → `npm test` → `npm run lint` → **`npm run smoke`** → **`npm run conformance`** before the publish step. `smoke` packs the tarball, installs it into a throwaway project, and boots the `seekstone` bin to confirm `npx seekstone` works for a real user. `conformance` drives the built server with the MCP SDK reference client — handshake, exact tool surface, and a search + append round-trip — so a protocol regression can't ship (see `docs/CLIENT-TESTING.md`). A failure at any gate blocks the publish.
 
 CI (the `CI` workflow) additionally enforces a **coverage gate** on the server's logic modules (thresholds in `packages/server/vitest.config.ts`).
+
+**Manual gate for tool-schema changes:** `scripts/claude-code-e2e.sh` runs a real headless Claude Code session against the packed tarball and asserts a model-driven `search` retrieves seeded vault content. Run it before releases that change tool names or input schemas (needs an authenticated `claude` CLI; spends a few tokens).
 
 ## One-time repo setting
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "harness": "npm run -w @seekstone/harness start --",
     "build:mcpb": "node scripts/build-mcpb.mjs",
     "smoke": "node scripts/smoke-install.mjs",
+    "conformance": "node scripts/mcp-conformance.mjs",
     "check:registries": "node scripts/check-registries-tools.mjs",
     "version-packages": "changeset version && node scripts/sync-server-json.mjs && biome format --write .",
     "release": "changeset publish"

--- a/scripts/claude-code-e2e.sh
+++ b/scripts/claude-code-e2e.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Real-client E2E: install the locally built seekstone into Claude Code and
+# confirm an actual model-driven `search` tool call round-trips.
+#
+# This is the one GUI-grade MCP client with a scriptable headless mode, so it
+# stands in for the whole client class. It is a MANUAL / release-gate script,
+# not CI: it needs the `claude` CLI installed and authenticated, and each run
+# spends a small number of tokens.
+#
+# Usage: scripts/claude-code-e2e.sh
+# Exits 0 iff the model reported the seeded search hit back.
+
+set -euo pipefail
+
+command -v claude >/dev/null || { echo "✗ claude CLI not found — install Claude Code first."; exit 1; }
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/seekstone-cc-e2e.XXXXXX")"
+vault="$workdir/vault"
+
+trap 'rm -rf "$workdir"' EXIT
+
+# 1. Pack the current build so we test exactly what would ship, and install it
+#    into a throwaway project (pre-installed → no npx cold-start racing the
+#    client's MCP startup timeout).
+echo "• building + packing seekstone…"
+(cd "$repo_root" && npm run build -w seekstone >/dev/null)
+tgz_name="$(cd "$repo_root" && npm pack -w seekstone --ignore-scripts --pack-destination "$workdir" 2>/dev/null | tail -1)"
+echo "• installing $tgz_name into a scratch project…"
+(cd "$workdir" && npm init -y >/dev/null 2>&1 && npm install --no-audit --no-fund "$workdir/$tgz_name" >/dev/null 2>&1)
+server_entry="$workdir/node_modules/seekstone/dist/index.js"
+[ -f "$server_entry" ] || { echo "✗ installed entry not found: $server_entry"; exit 1; }
+
+# 2. Seed a vault with a fact the model can only know via the search tool.
+mkdir -p "$vault/.obsidian" "$vault/Notes"
+cat > "$vault/Notes/Passphrase.md" <<'EOF'
+---
+title: Passphrase
+---
+# Passphrase
+
+The survey passphrase is cobalt-heron-42.
+EOF
+
+# 3. Explicit MCP config for the headless run — the documented way to attach
+#    servers to `claude -p`. --strict-mcp-config keeps the user's own servers
+#    out of the session; --allowedTools pre-approves the search tool so the
+#    non-interactive run can't stall on a permission prompt.
+cat > "$workdir/mcp-config.json" <<EOF
+{
+  "mcpServers": {
+    "seekstone-e2e": {
+      "command": "$(command -v node)",
+      "args": ["$server_entry"],
+      "env": { "SEEKSTONE_VAULT": "$vault" }
+    }
+  }
+}
+EOF
+
+echo "• running headless Claude Code query…"
+prompt="Using the seekstone-e2e MCP server's search tool, find the survey passphrase in my vault and reply with exactly the passphrase string."
+out="$(cd "$workdir" && printf '%s' "$prompt" | claude -p \
+  --mcp-config "$workdir/mcp-config.json" \
+  --strict-mcp-config \
+  --allowedTools "mcp__seekstone-e2e__search" 2>&1 || true)"
+
+if grep -q "cobalt-heron-42" <<<"$out"; then
+  echo "✓ Claude Code E2E passed — model retrieved the seeded passphrase via the search tool."
+else
+  echo "✗ Claude Code E2E failed — passphrase not found in output:"
+  printf '%s\n' "$out" | tail -20
+  exit 1
+fi

--- a/scripts/mcp-conformance.mjs
+++ b/scripts/mcp-conformance.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Protocol-conformance gate: boot the built server over stdio with a scratch
+// vault and drive it with the MCP SDK reference client — the same client code
+// every TypeScript MCP client embeds. If this passes, any spec-compliant
+// client (Claude Desktop/Code, Cursor, VS Code, Windsurf, …) can talk to us;
+// per-client differences are config-file plumbing, tested elsewhere.
+//
+// Asserts:
+//   1. initialize handshake succeeds and identifies as `seekstone`
+//   2. tools/list matches HANDLED_TOOLS exactly (no drops, no strays)
+//   3. tools/call round-trips: `search` finds seeded content, `append_note`
+//      writes it to disk with the frontmatter byte-identical
+//
+// Requires `npm run build -w seekstone` first (CI builds before this runs).
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const repoRoot = new URL('..', import.meta.url).pathname;
+const serverEntry = join(repoRoot, 'packages/server/dist/index.js');
+
+// Source of truth for the expected tool surface — same extraction as
+// scripts/check-registries-tools.mjs.
+const dispatch = readFileSync(join(repoRoot, 'packages/server/src/dispatch.ts'), 'utf8');
+const block = dispatch.match(/export const HANDLED_TOOLS = \[([\s\S]*?)\] as const;/);
+if (!block) {
+  console.error('conformance: could not find HANDLED_TOOLS in packages/server/src/dispatch.ts.');
+  process.exit(1);
+}
+const expectedTools = [...block[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+
+if (!existsSync(serverEntry)) {
+  console.error(
+    `conformance: ${serverEntry} not found — run \`npm run build -w seekstone\` first.`,
+  );
+  process.exit(1);
+}
+
+// Scratch vault with known content. The search term must be distinctive
+// enough that a ranked hit proves indexing, not luck.
+const vault = mkdtempSync(join(tmpdir(), 'seekstone-conformance-'));
+mkdirSync(join(vault, '.obsidian'), { recursive: true });
+mkdirSync(join(vault, 'Notes'), { recursive: true });
+const alphaFrontmatter = '---\ntitle: Alpha\ntags: [conformance]\n---\n';
+const alphaBody = '# Alpha\n\nThe quartzite outcrop anchors the northern survey line.\n';
+writeFileSync(join(vault, 'Notes', 'Alpha.md'), alphaFrontmatter + alphaBody);
+writeFileSync(join(vault, 'Notes', 'Beta.md'), '# Beta\n\nLinks to [[Alpha]].\n');
+
+const failures = [];
+const check = (ok, label, detail = '') => {
+  console.log(`${ok ? '✓' : '✗'} ${label}${ok || !detail ? '' : ` — ${detail}`}`);
+  if (!ok) failures.push(label);
+};
+
+const client = new Client({ name: 'seekstone-conformance', version: '0.0.0' });
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [serverEntry],
+  env: { ...process.env, SEEKSTONE_VAULT: vault },
+  stderr: 'ignore',
+});
+
+try {
+  // 1. Handshake. connect() performs the initialize round-trip.
+  await client.connect(transport);
+  const serverInfo = client.getServerVersion();
+  check(
+    serverInfo?.name === 'seekstone',
+    'initialize: server identifies as seekstone',
+    `got ${JSON.stringify(serverInfo)}`,
+  );
+
+  // 2. Tool surface matches HANDLED_TOOLS exactly.
+  const { tools } = await client.listTools();
+  const listed = tools.map((t) => t.name).sort();
+  const expected = [...expectedTools].sort();
+  check(
+    JSON.stringify(listed) === JSON.stringify(expected),
+    `tools/list: exactly the ${expected.length} registered tools`,
+    `missing=[${expected.filter((t) => !listed.includes(t))}] extra=[${listed.filter((t) => !expected.includes(t))}]`,
+  );
+  check(
+    tools.every((t) => t.description && t.inputSchema?.type === 'object'),
+    'tools/list: every tool has a description and an object input schema',
+  );
+
+  // 3a. Read round-trip. The index builds at startup; retry briefly in case
+  //     the first search lands before the walker finishes.
+  let hits = [];
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const res = await client.callTool({ name: 'search', arguments: { query: 'quartzite' } });
+    hits = JSON.parse(res.content[0].text);
+    if (hits.length > 0) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  check(
+    hits.length === 1 &&
+      hits[0].path === 'Notes/Alpha.md' &&
+      /quartzite/.test(hits[0].excerpt ?? ''),
+    'tools/call search: seeded note found with excerpt',
+    JSON.stringify(hits).slice(0, 200),
+  );
+
+  // 3b. Write round-trip: content lands on disk, frontmatter byte-identical.
+  const marker = 'Conformance gate wrote this line.';
+  const res = await client.callTool({
+    name: 'append_note',
+    arguments: { path: 'Notes/Alpha.md', content: marker },
+  });
+  check(!res.isError, 'tools/call append_note: no error', res.content?.[0]?.text);
+  const after = readFileSync(join(vault, 'Notes', 'Alpha.md'), 'utf8');
+  check(after.includes(marker), 'append_note: marker present on disk');
+  check(after.startsWith(alphaFrontmatter), 'append_note: frontmatter byte-identical');
+} catch (err) {
+  check(false, 'conformance run completed', err.message);
+} finally {
+  await client.close().catch(() => {});
+  rmSync(vault, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error(`\n✗ conformance failed: ${failures.length} check(s): ${failures.join('; ')}`);
+  process.exit(1);
+}
+console.log('\n✓ MCP protocol conformance passed.');


### PR DESCRIPTION
The testing backbone for the multi-client positioning (SHA-217): prove protocol conformance in CI so per-client work reduces to config plumbing.

## What's in here

- **`scripts/mcp-conformance.mjs`** — boots `dist/index.js` over stdio with the **MCP SDK reference client** and asserts: initialize handshake (identifies as `seekstone`), `tools/list` matches `HANDLED_TOOLS` exactly (same regex extraction as `check-registries-tools.mjs`, so no duplicated tool list), every tool has a description + object schema, and `tools/call` round-trips — `search` finds seeded content, `append_note` lands on disk with frontmatter byte-identical. Runs in ~2s against a scratch vault.
  - *Deviation from the ticket:* uses the SDK client directly instead of `@modelcontextprotocol/inspector` CLI — same conformance guarantee (the SDK client is the reference implementation TS clients embed), no new heavyweight devDep, richer assertions.
- **CI wiring** — `npm run conformance` on the ubuntu leg of `ci.yml` and as a release gate in `release.yml` (after smoke).
- **`scripts/claude-code-e2e.sh`** — manual real-client layer: packs the current build, pre-installs the tarball into a scratch project, attaches via `claude -p --mcp-config --strict-mcp-config --allowedTools`, and asserts a model-driven `search` returns a seeded passphrase. Documented in RELEASING.md as the manual gate for tool-schema changes.
- **`docs/CLIENT-TESTING.md`** — the four testing layers + the manual 3-step GUI-client checklist (install per docs → tools appear → one search + one write).

## Verification

- `npm run conformance` — all 7 checks pass locally
- Negative test: injecting a bogus expected tool makes it exit 1 with `missing=[bogus_tool]`
- `scripts/claude-code-e2e.sh` — passed against a live headless Claude Code session (model retrieved the seeded passphrase via the search tool)
- `npm test` (52 files) and `npm run lint` green