### PR TITLE
Add Cursor as a first-class init client (SHA-230)

### DIFF
--- a/.changeset/init-client-cursor.md
+++ b/.changeset/init-client-cursor.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+`seekstone init --client cursor` — auto-detect your vault and print or (with `--write`) patch `~/.cursor/mcp.json`, with the same additive merge + backup behavior as the Claude Desktop writer. Cursor joins Claude Desktop and Claude Code as a first-class documented client.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,32 @@ Or manually, if you prefer to specify the vault path explicitly:
 claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y seekstone
 ```
 
+### Option 5 — Cursor
+
+Auto-detects your vault and patches `~/.cursor/mcp.json` (with a backup):
+
+```bash
+npx -y seekstone init --client cursor --write
+```
+
+Or add the block manually to `~/.cursor/mcp.json` (global) or `<project>/.cursor/mcp.json` (per-project):
+
+```json
+{
+  "mcpServers": {
+    "seekstone": {
+      "command": "npx",
+      "args": ["-y", "seekstone"],
+      "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
+    }
+  }
+}
+```
+
+### Other MCP clients (VS Code, Windsurf, Cline, …)
+
+Seekstone is a standard MCP stdio server — any MCP client can run it. Use the same JSON block as above in your client's MCP config (`command: npx`, `args: ["-y", "seekstone"]`, env `SEEKSTONE_VAULT`).
+
 ---
 
 After installing, restart the client. On startup Seekstone walks the vault, builds an in-memory full-text index (a few seconds for thousands of notes), and keeps it live as you edit. The 16 tools below are then available to Claude.

--- a/llms.txt
+++ b/llms.txt
@@ -32,6 +32,14 @@ Add to `claude_desktop_config.json`:
 claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y seekstone
 ```
 
+## How to install (Cursor)
+
+```bash
+npx -y seekstone init --client cursor --write
+```
+
+Or add the same `mcpServers` JSON block as Claude Desktop to `~/.cursor/mcp.json`. Any other MCP-over-stdio client (VS Code/Copilot, Windsurf, Cline, Continue, JetBrains, Zed) takes the identical block in its own MCP config file.
+
 ## Tools (16)
 
 Read:

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -64,6 +64,14 @@ Add to `claude_desktop_config.json` (Settings → Developer → Edit Config):
 claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- npx -y seekstone
 ```
 
+### Option 5 — Cursor
+
+```bash
+npx -y seekstone init --client cursor --write
+```
+
+Or add the Option 3 JSON block to `~/.cursor/mcp.json`. Other MCP clients (VS Code, Windsurf, Cline, …) take the same block in their own MCP config file.
+
 ---
 
 ## Tools

--- a/packages/server/src/cli-args.ts
+++ b/packages/server/src/cli-args.ts
@@ -21,18 +21,18 @@ export function helpText(version: string): string {
   return `seekstone ${version} — an Obsidian MCP server (filesystem-direct, low context-tax)
 
 Seekstone runs as a Model Context Protocol stdio server. It is normally
-launched by an MCP client (Claude Desktop, Claude Code), not run by hand.
+launched by an MCP client (Claude Desktop, Claude Code, Cursor, …), not run by hand.
 
 Usage:
   seekstone            Start the MCP server (reads from stdin/stdout)
-  seekstone init       Validate a vault and print/patch the Claude config
+  seekstone init       Validate a vault and print/patch the client MCP config
   seekstone --version  Print the version and exit
   seekstone --help     Print this help and exit
 
 "seekstone init" options:
   --vault <path>       Vault to use (auto-detected from Obsidian if omitted; fallback: $SEEKSTONE_VAULT)
-  --client <name>      desktop (default) | code
-  --write              Patch the Claude Desktop config in place (backs it up first)
+  --client <name>      desktop (default) | code | cursor
+  --write              Patch the client config in place (backs it up first)
 
 Required environment:
   SEEKSTONE_VAULT      Absolute path to your Obsidian vault

--- a/packages/server/src/init.test.ts
+++ b/packages/server/src/init.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   claudeDesktopConfigPath,
+  cursorConfigPath,
   mcpAddCommand,
   mergeSeekstoneConfig,
   obsidianRegistryPath,
@@ -25,6 +26,9 @@ describe('parseInitArgs', () => {
       client: 'code',
     });
   });
+  it('parses --client cursor', () => {
+    expect(parseInitArgs(['--client', 'cursor']).client).toBe('cursor');
+  });
   it('ignores an invalid --client value (keeps default)', () => {
     expect(parseInitArgs(['--client', 'nonsense']).client).toBe('desktop');
   });
@@ -45,6 +49,18 @@ describe('claudeDesktopConfigPath', () => {
     expect(
       claudeDesktopConfigPath('win32', { appData: 'C:\\Users\\x\\AppData\\Roaming' }),
     ).toContain('Claude');
+  });
+});
+
+describe('cursorConfigPath', () => {
+  it('macOS / linux are home-relative', () => {
+    expect(cursorConfigPath('darwin', { home: '/Users/x' })).toBe('/Users/x/.cursor/mcp.json');
+    expect(cursorConfigPath('linux', { home: '/home/x' })).toBe('/home/x/.cursor/mcp.json');
+  });
+  it('windows is home-relative too (no APPDATA)', () => {
+    expect(cursorConfigPath('win32', { home: 'C:\\Users\\x' })).toBe(
+      'C:\\Users\\x\\.cursor\\mcp.json',
+    );
   });
 });
 
@@ -230,6 +246,40 @@ describe('runInit', () => {
   it('prints the claude mcp add command for code client', async () => {
     const res = await runInit({ vault, write: false, client: 'code' }, deps());
     expect(res.output.join('\n')).toContain('claude mcp add seekstone');
+  });
+
+  it('prints the config block (no write) for cursor, pointing at ~/.cursor/mcp.json', async () => {
+    const res = await runInit({ vault, write: false, client: 'cursor' }, deps());
+    expect(res.exitCode).toBe(0);
+    expect(res.wrotePath).toBeUndefined();
+    const text = res.output.join('\n');
+    expect(text).toContain('Cursor config');
+    expect(text).toContain(join(home, '.cursor', 'mcp.json'));
+    expect(text).toContain('mcpServers');
+    expect(text).toContain(vault);
+  });
+
+  it('--write --client cursor creates ~/.cursor/mcp.json', async () => {
+    const res = await runInit({ vault, write: true, client: 'cursor' }, deps());
+    expect(res.exitCode).toBe(0);
+    expect(res.wrotePath).toBe(join(home, '.cursor', 'mcp.json'));
+    expect(res.backupPath).toBeUndefined();
+    const written = JSON.parse(await readFile(res.wrotePath as string, 'utf8'));
+    expect(written.mcpServers.seekstone).toEqual(seekstoneServerConfig(vault));
+    expect(res.output.join('\n')).toContain('Restart Cursor');
+  });
+
+  it('--write --client cursor merges into an existing mcp.json and backs it up', async () => {
+    const cfgPath = cursorConfigPath('darwin', { home });
+    await mkdir(join(home, '.cursor'), { recursive: true });
+    await writeFile(cfgPath, JSON.stringify({ mcpServers: { other: { command: 'x' } } }, null, 2));
+
+    const res = await runInit({ vault, write: true, client: 'cursor' }, deps());
+    expect(res.exitCode).toBe(0);
+    expect(res.backupPath).toBeDefined();
+    const written = JSON.parse(await readFile(cfgPath, 'utf8'));
+    expect(written.mcpServers.other).toEqual({ command: 'x' });
+    expect(written.mcpServers.seekstone).toBeDefined();
   });
 
   it('--write --client code calls spawnClaudeMcp with correct args', async () => {

--- a/packages/server/src/init.test.ts
+++ b/packages/server/src/init.test.ts
@@ -254,7 +254,9 @@ describe('runInit', () => {
     expect(res.wrotePath).toBeUndefined();
     const text = res.output.join('\n');
     expect(text).toContain('Cursor config');
-    expect(text).toContain(join(home, '.cursor', 'mcp.json'));
+    // Same helper runInit uses: deps() injects darwin, so host-native join
+    // would mismatch on Windows CI.
+    expect(text).toContain(cursorConfigPath('darwin', { home }));
     expect(text).toContain('mcpServers');
     expect(text).toContain(vault);
   });
@@ -262,7 +264,7 @@ describe('runInit', () => {
   it('--write --client cursor creates ~/.cursor/mcp.json', async () => {
     const res = await runInit({ vault, write: true, client: 'cursor' }, deps());
     expect(res.exitCode).toBe(0);
-    expect(res.wrotePath).toBe(join(home, '.cursor', 'mcp.json'));
+    expect(res.wrotePath).toBe(cursorConfigPath('darwin', { home }));
     expect(res.backupPath).toBeUndefined();
     const written = JSON.parse(await readFile(res.wrotePath as string, 'utf8'));
     expect(written.mcpServers.seekstone).toEqual(seekstoneServerConfig(vault));

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -9,8 +9,9 @@ import path, { dirname, join } from 'node:path';
 
 /**
  * `seekstone init` — a guided setup helper. Validates an Obsidian vault and
- * prints (or, with --write, patches) the Claude MCP config so a user doesn't
- * have to hand-edit JSON or guess paths.
+ * prints (or, with --write, patches) the MCP config for the chosen client
+ * (Claude Desktop, Claude Code, Cursor) so a user doesn't have to hand-edit
+ * JSON or guess paths.
  *
  * The pure helpers (arg parsing, config-path resolution, additive merge,
  * command string) are exported and unit-tested. `runInit` wires them to the
@@ -20,7 +21,7 @@ import path, { dirname, join } from 'node:path';
 export interface InitOptions {
   vault?: string;
   write: boolean;
-  client: 'desktop' | 'code';
+  client: 'desktop' | 'code' | 'cursor';
 }
 
 export function parseInitArgs(argv: readonly string[]): InitOptions {
@@ -32,7 +33,7 @@ export function parseInitArgs(argv: readonly string[]): InitOptions {
     else if (a === '--vault') opts.vault = argv[++i];
     else if (a === '--client') {
       const v = argv[++i];
-      if (v === 'desktop' || v === 'code') opts.client = v;
+      if (v === 'desktop' || v === 'code' || v === 'cursor') opts.client = v;
     }
   }
   return opts;
@@ -79,6 +80,16 @@ export function claudeDesktopConfigPath(
   }
   // Linux / other
   return j(home, '.config', 'Claude', 'claude_desktop_config.json');
+}
+
+/**
+ * Resolve Cursor's global MCP config path for a platform. Cursor reads
+ * `~/.cursor/mcp.json` on every OS (home-relative, no APPDATA) and uses the
+ * same `mcpServers` shape as Claude Desktop. Pure, like claudeDesktopConfigPath.
+ */
+export function cursorConfigPath(platform: NodeJS.Platform, env: { home?: string }): string {
+  const j = platform === 'win32' ? path.win32.join : path.posix.join;
+  return j(env.home ?? '', '.cursor', 'mcp.json');
 }
 
 /**
@@ -339,11 +350,16 @@ export async function runInit(
     return { ok: true, exitCode: 0, output: out };
   }
 
-  // Claude Desktop
-  const configPath = claudeDesktopConfigPath(deps.platform, {
-    home: deps.env.HOME,
-    appData: deps.env.APPDATA,
-  });
+  // File-config clients: Claude Desktop and Cursor share the same
+  // `mcpServers` JSON shape; only the config path and the restart hint differ.
+  const clientLabel = opts.client === 'cursor' ? 'Cursor' : 'Claude Desktop';
+  const configPath =
+    opts.client === 'cursor'
+      ? cursorConfigPath(deps.platform, { home: deps.env.HOME })
+      : claudeDesktopConfigPath(deps.platform, {
+          home: deps.env.HOME,
+          appData: deps.env.APPDATA,
+        });
   const block = JSON.stringify(
     { mcpServers: { seekstone: seekstoneServerConfig(vaultPath) } },
     null,
@@ -352,12 +368,12 @@ export async function runInit(
 
   if (!opts.write) {
     out.push(
-      'Add this to your Claude Desktop config:',
+      `Add this to your ${clientLabel} config:`,
       `  ${configPath}`,
       '',
       block,
       '',
-      'Then restart Claude Desktop. Or re-run with --write to patch it automatically.',
+      `Then restart ${clientLabel}. Or re-run with --write to patch it automatically.`,
     );
     return { ok: true, exitCode: 0, output: out };
   }
@@ -396,7 +412,7 @@ export async function runInit(
     `✓ Patched ${configPath}`,
     backupPath ? `  Backup saved to ${backupPath}` : '  (created a new config file)',
     '',
-    'Restart Claude Desktop to load seekstone.',
+    `Restart ${clientLabel} to load seekstone.`,
   );
   return { ok: true, exitCode: 0, output: out, wrotePath: configPath, backupPath };
 }


### PR DESCRIPTION
First engineering follow-through on the SHA-217 multi-client positioning: Cursor — arguably the largest MCP client by installed base — becomes a documented, `init`-supported client.

## Changes

- `seekstone init --client cursor` — prints the config block, or with `--write` patches `~/.cursor/mcp.json` (additive merge, timestamped backup, refuses malformed JSON — all shared with the Desktop writer since Cursor uses the identical `mcpServers` shape; only the path and restart hint differ)
- `cursorConfigPath()` — home-relative on every OS (verified against Cursor's MCP docs; no APPDATA on Windows)
- Docs: README gets Option 5 (Cursor) plus a generic "Other MCP clients" block; published npm README and llms.txt updated to match
- Minor changeset (new user-facing capability)

## Verification

- Unit: parse accepts `cursor`; path helper per-OS; runInit print/create/merge+backup tests (55 tests green in init/cli-args suites)
- E2E against a scratch $HOME: print mode shows the right path + block; `--write` creates `~/.cursor/mcp.json` with the correct content
- Full `npm test`, lint, and the REGISTRIES guard green

Deeplink one-click button intentionally left to SHA-204 (Cursor's docs don't currently specify a stable deeplink format).