### PR TITLE
ci: trigger seekstone.dev rebuild after npm publish (SHA-165)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,21 @@ jobs:
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish
 
+      # Rebuild seekstone.dev so its build-time npm version lookup picks up the
+      # release we just published (site repo: src/version.ts). Deploy hooks are
+      # fire-and-forget and unauthenticated-by-URL, so the step is best-effort:
+      # a missing secret or a Vercel hiccup must never fail a release.
+      - name: Trigger seekstone.dev rebuild
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$DEPLOY_HOOK_URL" ]; then
+            echo "::warning::VERCEL_DEPLOY_HOOK_URL not set; seekstone.dev will show the new version on its next rebuild"
+            exit 0
+          fi
+          curl -fsS -X POST "$DEPLOY_HOOK_URL" || echo "::warning::deploy hook failed; seekstone.dev will show the new version on its next rebuild"
+
       # NOTE: a manual Glama release step is still required after every publish.
       # Glama has no public API for programmatic release creation (investigated SHA-85).
       # See docs/RELEASING.md for the manual steps and the placeholder curl command


### PR DESCRIPTION
## What

Adds a best-effort step to the release workflow that POSTs to a Vercel deploy hook after a successful npm publish, so seekstone.dev rebuilds and its build-time npm version lookup (seekstone.dev#21) picks up the new release.

## Notes

- Guarded on `steps.changesets.outputs.published == 'true'` — only fires on real publishes.
- Best-effort by design: a missing `VERCEL_DEPLOY_HOOK_URL` secret or a Vercel hiccup emits a workflow warning but never fails the release. Without the hook the site simply shows the new version on its next rebuild.

## Setup required after merge

1. Vercel dashboard → seekstone.dev project → Settings → Git → Deploy Hooks → create a hook for `main`.
2. `gh secret set VERCEL_DEPLOY_HOOK_URL --repo shaqmughal/seekstone` with the hook URL.

Pairs with seekstone.dev#21. Closes SHA-165 together with it.