### PR TITLE
docs: add Cursor + VS Code one-click install buttons (SHA-204)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 <p align="center"><a href="https://seekstone.dev"><strong>seekstone.dev →</strong></a></p>
 
 <p align="center">
+  <a href="https://github.com/shaqmughal/seekstone/releases/latest/download/seekstone.mcpb"><img src="https://img.shields.io/badge/Install_in-Claude_Desktop-D97757?style=for-the-badge&amp;logo=anthropic&amp;logoColor=white" alt="Install in Claude Desktop" /></a>
+  <a href="https://cursor.com/install-mcp?name=seekstone&amp;config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInNlZWtzdG9uZSJdLCJlbnYiOnsiU0VFS1NUT05FX1ZBVUxUIjoiL2Fic29sdXRlL3BhdGgvdG8veW91ci92YXVsdCJ9fQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install in Cursor" /></a>
+  <a href="https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22seekstone%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22seekstone%22%5D%2C%22env%22%3A%7B%22SEEKSTONE_VAULT%22%3A%22%2Fabsolute%2Fpath%2Fto%2Fyour%2Fvault%22%7D%7D"><img src="https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=for-the-badge&amp;logo=visualstudiocode&amp;logoColor=white" alt="Install in VS Code" /></a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/v/seekstone?color=cb3837&logo=npm&label=seekstone" alt="npm (seekstone)" /></a>
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/dt/seekstone?color=7c3aed&label=downloads" alt="npm total downloads" /></a>
   <a href="https://www.npmjs.com/package/seekstone"><img src="https://img.shields.io/npm/dw/seekstone?color=7c3aed&label=downloads%2Fwk" alt="npm weekly downloads" /></a>
@@ -157,7 +163,9 @@ claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- n
 
 ### Option 5 — Cursor
 
-Auto-detects your vault and patches `~/.cursor/mcp.json` (with a backup):
+One-click: <a href="https://cursor.com/install-mcp?name=seekstone&amp;config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInNlZWtzdG9uZSJdLCJlbnYiOnsiU0VFS1NUT05FX1ZBVUxUIjoiL2Fic29sdXRlL3BhdGgvdG8veW91ci92YXVsdCJ9fQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install in Cursor" align="top" /></a> — then set `SEEKSTONE_VAULT` to your vault's absolute path in Cursor's MCP settings (the link installs a placeholder).
+
+Or let the CLI auto-detect your vault and patch `~/.cursor/mcp.json` (with a backup):
 
 ```bash
 npx -y seekstone init --client cursor --write
@@ -177,7 +185,17 @@ Or add the block manually to `~/.cursor/mcp.json` (global) or `<project>/.cursor
 }
 ```
 
-### Other MCP clients (VS Code, Windsurf, Cline, …)
+### Option 6 — VS Code
+
+One-click: <a href="https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22seekstone%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22seekstone%22%5D%2C%22env%22%3A%7B%22SEEKSTONE_VAULT%22%3A%22%2Fabsolute%2Fpath%2Fto%2Fyour%2Fvault%22%7D%7D"><img src="https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=for-the-badge&amp;logo=visualstudiocode&amp;logoColor=white" alt="Install in VS Code" align="top" /></a> — then set `SEEKSTONE_VAULT` to your vault's absolute path when VS Code opens the server config (the link installs a placeholder).
+
+Or add it from the terminal:
+
+```bash
+code --add-mcp '{"name":"seekstone","command":"npx","args":["-y","seekstone"],"env":{"SEEKSTONE_VAULT":"/absolute/path/to/your/vault"}}'
+```
+
+### Other MCP clients (Windsurf, Cline, …)
 
 Seekstone is a standard MCP stdio server — any MCP client can run it. Use the same JSON block as above in your client's MCP config (`command: npx`, `args: ["-y", "seekstone"]`, env `SEEKSTONE_VAULT`).
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -8,6 +8,8 @@ It reads your vault **directly from disk** instead of routing through the Obsidi
 
 (Previously also published as `obsidian-mcp-seekstone` — that alias is deprecated; existing installs keep working, but install `seekstone` going forward.)
 
+[![Install in Claude Desktop](https://img.shields.io/badge/Install_in-Claude_Desktop-D97757?style=for-the-badge&logo=anthropic&logoColor=white)](https://github.com/shaqmughal/seekstone/releases/latest/download/seekstone.mcpb) [![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=seekstone&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInNlZWtzdG9uZSJdLCJlbnYiOnsiU0VFS1NUT05FX1ZBVUxUIjoiL2Fic29sdXRlL3BhdGgvdG8veW91ci92YXVsdCJ9fQ%3D%3D) [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=for-the-badge&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22seekstone%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22seekstone%22%5D%2C%22env%22%3A%7B%22SEEKSTONE_VAULT%22%3A%22%2Fabsolute%2Fpath%2Fto%2Fyour%2Fvault%22%7D%7D)
+
 ---
 
 ## Install
@@ -66,11 +68,23 @@ claude mcp add seekstone --env SEEKSTONE_VAULT=/absolute/path/to/your/vault -- n
 
 ### Option 5 — Cursor
 
+One-click via the [Install in Cursor](https://cursor.com/install-mcp?name=seekstone&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInNlZWtzdG9uZSJdLCJlbnYiOnsiU0VFS1NUT05FX1ZBVUxUIjoiL2Fic29sdXRlL3BhdGgvdG8veW91ci92YXVsdCJ9fQ%3D%3D) link above (then set `SEEKSTONE_VAULT` to your vault path), or let the CLI auto-detect your vault:
+
 ```bash
 npx -y seekstone init --client cursor --write
 ```
 
-Or add the Option 3 JSON block to `~/.cursor/mcp.json`. Other MCP clients (VS Code, Windsurf, Cline, …) take the same block in their own MCP config file.
+Or add the Option 3 JSON block to `~/.cursor/mcp.json`.
+
+### Option 6 — VS Code
+
+One-click via the [Install in VS Code](https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22seekstone%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22seekstone%22%5D%2C%22env%22%3A%7B%22SEEKSTONE_VAULT%22%3A%22%2Fabsolute%2Fpath%2Fto%2Fyour%2Fvault%22%7D%7D) link above (then set `SEEKSTONE_VAULT` to your vault path), or from the terminal:
+
+```bash
+code --add-mcp '{"name":"seekstone","command":"npx","args":["-y","seekstone"],"env":{"SEEKSTONE_VAULT":"/absolute/path/to/your/vault"}}'
+```
+
+Other MCP clients (Windsurf, Cline, …) take the Option 3 JSON block in their own MCP config file.
 
 ---
 


### PR DESCRIPTION
## What

One-click install buttons for the two highest-traffic non-Claude clients, modeled on the obsidian-mcp-server markup:

- **Hero button row** (repo README + npm-facing `packages/server/README.md`): Claude Desktop (latest `.mcpb` release asset), Cursor (`cursor.com/install-mcp` deeplink with base64 config), VS Code (`vscode.dev/redirect` → `vscode:mcp/install`).
- **Option 5 (Cursor)**: one-click link added above the existing `init --client cursor` flow.
- **New Option 6 (VS Code)**: one-click link + `code --add-mcp` terminal one-liner; "Other MCP clients" section now covers Windsurf/Cline only.

Deep links necessarily install with a placeholder vault path (they can't auto-detect), so both sections tell the user to set `SEEKSTONE_VAULT` afterwards — the `init` flows remain the recommended path since they auto-detect the vault.

## Verified

- Cursor URL resolves 200 at canonical `cursor.com/install-mcp` (no `/en/`) and renders the seekstone install page; base64 config round-trips to `{"command":"npx","args":["-y","seekstone"],"env":{"SEEKSTONE_VAULT":...}}`.
- `vscode.dev/redirect` returns its expected 302; `.mcpb` latest-release asset URL returns 200.
- README-only change — no changeset required per the CI gate.

Part of SHA-203 Tier 1. Closes SHA-204 (Docker/ghcr evaluation recorded on the ticket).