### PR TITLE
docs: wedge-first README hero + above-the-fold head-to-head table (SHA-207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
   </picture>
 </p>
 
-<p align="center"><strong>The fastest Obsidian MCP server for Claude — search and edit your vault in milliseconds, without burning context.</strong></p>
-<p align="center"><em>Filesystem-direct · 16 tools · No plugins · No Obsidian app required · macOS · Linux · Windows</em></p>
+<p align="center"><strong>The Obsidian MCP server that needs no plugin, no running Obsidian app — and doesn't blow your context window.</strong></p>
+<p align="center"><em>Filesystem-direct · single-digit-ms search · ~2 KB payloads · 16 tools · macOS · Linux · Windows</em></p>
 
 <p align="center"><a href="https://seekstone.dev"><strong>seekstone.dev →</strong></a></p>
 
@@ -32,6 +32,17 @@
   <a href="https://glama.ai/mcp/servers/shaqmughal/seekstone"><img src="https://glama.ai/mcp/servers/shaqmughal/seekstone/badges/score.svg" alt="shaqmughal/seekstone MCP server" /></a>
   <a href="https://buymeacoffee.com/shaqmughal"><img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-%E2%98%95-FFDD00?logo=buymeacoffee&logoColor=black" alt="Buy me a coffee" /></a>
 </p>
+
+---
+
+|  | **Seekstone** | [obsidian-mcp-server](https://github.com/cyanheads/obsidian-mcp-server) (#1 by downloads) | REST-proxy servers |
+|---|---|---|---|
+| Local REST API plugin | **Not needed** | Required | Required |
+| Obsidian app running | **Not needed — works with Obsidian closed** | Required | Required |
+| Search payload @ 10k notes | **2.0 KB** | 47 KB | up to **95 MB** |
+| Warm search latency @ 10k notes | **6.2 ms** | 732 ms (~118× slower) | up to 1,550 ms |
+
+<sup>Same queries, same committed vaults, 20 runs each — [full results across six servers and three vault sizes below](#why-seekstone-the-numbers), fully reproducible from the [harness](packages/harness).</sup>
 
 ---
 


### PR DESCRIPTION
Closes SHA-207 (parent: SHA-203 competitive strategy, Tier 3 — amplify the moat).

Repositions the README around the sentence competitors structurally cannot say, per the SHA-203 decision record.

## Changes

- **Hero tagline** now leads with the wedge — "The Obsidian MCP server that needs no plugin, no running Obsidian app — and doesn't blow your context window." Speed moves to the subtitle line (single-digit-ms search, ~2 KB payloads).
- **New compact head-to-head table above the fold** (right after the badges): requirements contrast (Local REST API plugin / Obsidian running) + payload and latency @ 10k notes, Seekstone vs obsidian-mcp-server vs REST-proxy servers. All figures are the same harness-sourced numbers already published in the "Why Seekstone? The numbers." tables; the caption links there for full methodology.

## Notes

- The site side of the ticket is covered: SHA-215 shipped the intent-phrase positioning to seekstone.dev today, and the site's benchmark section already carries the head-to-head story (deeper site benchmark work is tracked in SHA-191).
- No other file carries the old tagline verbatim (checked docs/llms/manifest surfaces).