### PR TITLE
Add query_notes: structured frontmatter/metadata query tool (SHA-210)

### DIFF
--- a/.changeset/query-notes-tool.md
+++ b/.changeset/query-notes-tool.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+New `query_notes` tool — a second search mode alongside full-text `search`. Filter notes by frontmatter key/value predicates (`eq`, `ne`, `contains`, `exists`, `missing`, `gt`/`gte`/`lt`/`lte`), tag, folder, modified time, and size, with sort, field selection, and limit. Returns compact rows (path + title by default; opt into frontmatter keys or `mtime`/`size`/`tags` via `select`) — never note content — so a full 10k-note vault scan costs ~350 bytes of context.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center"><strong>The Obsidian MCP server that needs no plugin, no running Obsidian app — and doesn't blow your context window.</strong></p>
-<p align="center"><em>Filesystem-direct · single-digit-ms search · ~2 KB payloads · 16 tools · macOS · Linux · Windows</em></p>
+<p align="center"><em>Filesystem-direct · single-digit-ms search · ~2 KB payloads · 17 tools · macOS · Linux · Windows</em></p>
 
 <p align="center"><a href="https://seekstone.dev"><strong>seekstone.dev →</strong></a></p>
 
@@ -212,7 +212,7 @@ Seekstone is a standard MCP stdio server — any MCP client can run it. Use the 
 
 ---
 
-After installing, restart the client. On startup Seekstone walks the vault, builds an in-memory full-text index (a few seconds for thousands of notes), and keeps it live as you edit. The 16 tools below are then available to Claude.
+After installing, restart the client. On startup Seekstone walks the vault, builds an in-memory full-text index (a few seconds for thousands of notes), and keeps it live as you edit. The 17 tools below are then available to Claude.
 
 Requires [Node.js](https://nodejs.org) ≥ 22 for the CLI options. The one-click `.mcpb` bundle has no external requirements.
 
@@ -244,6 +244,7 @@ Claude never sees your full vault at once — it searches and reads selectively,
 | Tool | Description |
 |---|---|
 | `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy, prefix, and phrase queries. |
+| `query_notes` | Structured metadata query. Filter by frontmatter key/value predicates (`eq`, `ne`, `contains`, `exists`, `missing`, `gt`/`gte`/`lt`/`lte`), tag, folder, modified time, and size; sort and select the fields you need. Returns compact rows (path + title by default), not note content. |
 | `read_note` | Read the full content of a note by vault-relative path. Supports returning a single section, block, or line range. |
 | `list_notes` | List notes, optionally filtered by folder prefix or tag. |
 | `list_tags` | List all tags in the vault sorted by usage count (or alphabetically). |
@@ -350,7 +351,7 @@ npx tsc -p packages/server/tsconfig.json --noEmit        # typecheck
 
 | Package | Purpose |
 |---|---|
-| `packages/server` | The published `seekstone` MCP server (16 tools, stdio, MiniSearch index, chokidar watcher). |
+| `packages/server` | The published `seekstone` MCP server (17 tools, stdio, MiniSearch index, chokidar watcher). |
 | `packages/core` | Shared vault primitives — walk, frontmatter parser, link/tag extractor, percentiles. Bundled into the server build. |
 | `packages/harness` | Profiler + benchmark + write-safety harness (REST vs filesystem) that produced the payload numbers above. Dev-only; not published. |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,7 +167,7 @@ sequenceDiagram
 ```
 
 `ListToolsRequest` is answered directly from the bootstrap's static schema list
-(the 16 tools). On error, `dispatch()` catches and returns
+(the 17 tools). On error, `dispatch()` catches and returns
 `{ isError: true, content: [...] }` rather than throwing — the session stays
 alive.
 
@@ -294,11 +294,12 @@ are the receipts.
 
 ---
 
-## The 16 tools
+## The 17 tools
 
 | Tool | Kind | Purpose |
 | --- | --- | --- |
 | `search` | read | Ranked full-text search; returns ~200-char excerpts, not full notes |
+| `query_notes` | read | Structured metadata query: frontmatter predicates + mtime/size/tag/folder filters; compact rows, no note content |
 | `read_note` | read | Read a note (with optional outline/frontmatter metadata) |
 | `list_notes` | read | Enumerate notes, optionally by folder |
 | `list_tags` | read | All tags with usage counts |

--- a/docs/CLIENT-TESTING.md
+++ b/docs/CLIENT-TESTING.md
@@ -18,7 +18,7 @@ If protocol conformance passes, any spec-compliant stdio client can talk to Seek
 For each client, three steps against a scratch vault (never a personal one):
 
 1. **Install** exactly as the README documents it for that client — no undocumented workarounds. If a workaround is needed, that's a docs bug; fix the docs.
-2. **Tools appear** — the client's MCP/server UI lists seekstone with 16 tools.
+2. **Tools appear** — the client's MCP/server UI lists seekstone with 17 tools.
 3. **One search + one write** — ask for a term seeded in the scratch vault (search must return it), then ask to append a line to a note (file on disk must change, frontmatter untouched).
 
 Record each pass here (newest first):

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -12,11 +12,11 @@ Seekstone is published as [`seekstone`](https://www.npmjs.com/package/seekstone)
 
 - **Name:** Seekstone
 - **Tagline:** An Obsidian MCP server — filesystem-direct, low context-tax.
-- **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 16 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
+- **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 17 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
 - **Install:** `npx -y seekstone`; env `SEEKSTONE_VAULT=/path/to/vault`
 - **Repo:** https://github.com/shaqmughal/seekstone
 - **npm:** https://www.npmjs.com/package/seekstone
-- **Tools (16):** _Read_ — search, read_note, list_notes, list_tags, outline_note, get_backlinks, get_links, get_periodic_note · _Write_ — create_note, delete_note, move_note, append_note, patch_frontmatter, patch_note, replace_in_note, append_periodic_note
+- **Tools (17):** _Read_ — search, query_notes, read_note, list_notes, list_tags, outline_note, get_backlinks, get_links, get_periodic_note · _Write_ — create_note, delete_note, move_note, append_note, patch_frontmatter, patch_note, replace_in_note, append_periodic_note
 - **Categories/tags:** obsidian, notes, knowledge-base, markdown, search, obsidian-mcp
 
 <!-- Note: the official registry caps server.json `description` at 100 characters. -->

--- a/packages/server/src/dispatch.test.ts
+++ b/packages/server/src/dispatch.test.ts
@@ -103,6 +103,23 @@ describe('dispatch', () => {
     expect(JSON.stringify(ok?.fields ?? {})).not.toContain('confidential-term');
   });
 
+  it('routes query_notes, returns minified JSON, and logs predicate count not values', async () => {
+    const { logger, records } = recordingLogger();
+    const res = await dispatch(
+      ctx,
+      'query_notes',
+      { where: [{ key: 'title', op: 'ne', value: 'secret-value' }] },
+      logger,
+    );
+    expect(res.isError).toBeUndefined();
+    const text = res.content[0]?.text ?? '';
+    expect(JSON.parse(text)).toEqual([{ path: 'note.md', title: 'A' }]);
+    expect(text).not.toContain('\n'); // minified, same context-tax discipline as search
+    const ok = records.find((r) => r.msg === 'tool ok');
+    expect(ok?.fields?.whereCount).toBe(1);
+    expect(JSON.stringify(ok?.fields ?? {})).not.toContain('secret-value');
+  });
+
   it('never writes to stdout while dispatching (protects the stdio transport)', async () => {
     const outSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
     vi.spyOn(process.stderr, 'write').mockReturnValue(true);

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -17,6 +17,7 @@ import {
   GetPeriodicNoteInput,
   getPeriodicNote,
 } from './tools/periodic_note.js';
+import { QueryNotesInput, queryNotes } from './tools/query_notes.js';
 import { ReadNoteInput, readNote } from './tools/read_note.js';
 import { ReplaceInNoteInput, replaceInNote } from './tools/replace_in_note.js';
 import { SearchInput, search } from './tools/search.js';
@@ -29,6 +30,7 @@ export type ToolResult = {
 /** Tool names this dispatcher handles — kept in sync with the server's tool list. */
 export const HANDLED_TOOLS = [
   'search',
+  'query_notes',
   'read_note',
   'list_notes',
   'list_tags',
@@ -60,6 +62,12 @@ const META_KEYS = [
   'pattern',
   'minCount',
   'sort',
+  'order',
+  'select',
+  'modifiedAfter',
+  'modifiedBefore',
+  'minSizeBytes',
+  'maxSizeBytes',
   'period',
   'date',
 ] as const;
@@ -72,6 +80,7 @@ function safeMeta(args: unknown): Record<string, unknown> {
     if (a[k] !== undefined) out[k] = a[k];
   }
   if (typeof a.query === 'string') out.queryLen = a.query.length; // not the query itself
+  if (Array.isArray(a.where)) out.whereCount = a.where.length; // predicate values may be personal
   return out;
 }
 
@@ -120,6 +129,12 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
       const input = SearchInput.parse(args);
       const hits = search(ctx, input);
       // Minified: search is the headline context-tax metric — indentation is pure tax.
+      return { content: [{ type: 'text', text: JSON.stringify(hits) }] };
+    }
+    case 'query_notes': {
+      const input = QueryNotesInput.parse(args);
+      const hits = queryNotes(ctx, input);
+      // Minified like search — a second search mode, same context-tax discipline.
       return { content: [{ type: 'text', text: JSON.stringify(hits) }] };
     }
     case 'read_note': {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -81,6 +81,66 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: 'query_notes',
+      description:
+        'Structured metadata query — filter notes by frontmatter key/value predicates, tag, folder, modified time, and size. Returns compact rows (path + title by default; opt into more via select), not note content. Use this instead of search when filtering by properties rather than text.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          where: {
+            type: 'array',
+            description: 'Frontmatter predicates — all must match (AND).',
+            items: {
+              type: 'object',
+              properties: {
+                key: { type: 'string', description: 'Frontmatter key to test.' },
+                op: {
+                  type: 'string',
+                  enum: ['eq', 'ne', 'contains', 'exists', 'missing', 'gt', 'gte', 'lt', 'lte'],
+                  description:
+                    'eq/ne compare scalars; contains matches array membership or substring; exists/missing test key presence; gt/gte/lt/lte compare numbers or strings (ISO dates sort correctly).',
+                },
+                value: {
+                  description: 'Comparison value. Required for every op except exists/missing.',
+                },
+              },
+              required: ['key', 'op'],
+            },
+          },
+          folder: { type: 'string', description: 'Restrict to a vault-relative folder prefix.' },
+          tag: { type: 'string', description: 'Restrict to notes with this tag (# optional).' },
+          modifiedAfter: {
+            type: 'string',
+            description: 'Only notes modified at or after this ISO 8601 date/time.',
+          },
+          modifiedBefore: {
+            type: 'string',
+            description: 'Only notes modified before this ISO 8601 date/time.',
+          },
+          minSizeBytes: { type: 'number', description: 'Only notes at least this many bytes.' },
+          maxSizeBytes: { type: 'number', description: 'Only notes at most this many bytes.' },
+          select: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Extra fields per hit: frontmatter keys, or "mtime", "size", "tags". Default returns only path + title.',
+          },
+          sort: {
+            type: 'string',
+            enum: ['path', 'title', 'mtime', 'size'],
+            description: 'Sort field (default path).',
+          },
+          order: {
+            type: 'string',
+            enum: ['asc', 'desc'],
+            description: 'Sort order (default asc).',
+          },
+          limit: { type: 'number', description: 'Max results (1–500, default 100).' },
+        },
+        required: [],
+      },
+    },
+    {
       name: 'read_note',
       description:
         'Read a note or a span of it — by heading section, block reference, or line range. Returns structured JSON with the content, bytes returned, and total note size so payload savings are measurable. Use search or outline_note first to find the right path and section names.',
@@ -425,7 +485,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req): Promise<CallToolRes
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
-log.info('ready', { tools: 16, transport: 'stdio' });
+log.info('ready', { tools: 17, transport: 'stdio' });
 
 process.stderr.write(
   `seekstone: add to Claude Desktop:\n${JSON.stringify(

--- a/packages/server/src/index/build.test.ts
+++ b/packages/server/src/index/build.test.ts
@@ -59,6 +59,21 @@ describe('buildIndex', () => {
     expect(note?.fmKeys).toContain('author');
   });
 
+  it('note with frontmatter: parsed values stored on fm', async () => {
+    const { notes } = await buildIndex(vaultRoot);
+    const note = notes.get('with-fm.md');
+    expect(note?.fm).toEqual({
+      title: 'Frontmatter Note',
+      tags: ['alpha', 'beta'],
+      author: 'Bob',
+    });
+  });
+
+  it('note without frontmatter: fm is null', async () => {
+    const { notes } = await buildIndex(vaultRoot);
+    expect(notes.get('plain.md')?.fm).toBeNull();
+  });
+
   it('note without frontmatter: title falls back to filename without .md', async () => {
     const { notes } = await buildIndex(vaultRoot);
     const note = notes.get('plain.md');

--- a/packages/server/src/index/build.ts
+++ b/packages/server/src/index/build.ts
@@ -57,6 +57,7 @@ export async function buildIndex(vaultRoot: string): Promise<BuildResult> {
           body: fm.body,
           tags: allTags.join(' '),
           fmKeys: fm.keys.join(' '),
+          fm: fm.data,
           raw,
           sizeBytes: entry.sizeBytes,
           mtimeMs: entry.mtimeMs,

--- a/packages/server/src/index/doc.ts
+++ b/packages/server/src/index/doc.ts
@@ -17,6 +17,7 @@ export function buildDoc(relPath: string, raw: string): IndexedNote {
     body: fm.body,
     tags: allTags.join(' '),
     fmKeys: fm.keys.join(' '),
+    fm: fm.data,
     raw,
     sizeBytes: Buffer.byteLength(raw, 'utf8'),
     mtimeMs: Date.now(),

--- a/packages/server/src/index/types.ts
+++ b/packages/server/src/index/types.ts
@@ -9,6 +9,8 @@ export interface IndexedNote {
   tags: string;
   /** Frontmatter keys joined with space — makes keys searchable. */
   fmKeys: string;
+  /** Parsed frontmatter values for structured queries. Null when absent or malformed. */
+  fm: Record<string, unknown> | null;
   /** Raw full text (FM + body) for excerpt extraction after a hit. */
   raw: string;
   sizeBytes: number;

--- a/packages/server/src/tools/append_note.test.ts
+++ b/packages/server/src/tools/append_note.test.ts
@@ -15,6 +15,7 @@ function buildCtx(
     body: string;
     tags?: string;
     fmKeys?: string;
+    fm?: Record<string, unknown> | null;
     raw?: string;
   }>,
 ): ServerContext {
@@ -31,6 +32,7 @@ function buildCtx(
     body: n.body,
     tags: n.tags ?? '',
     fmKeys: n.fmKeys ?? '',
+    fm: n.fm ?? null,
     raw: n.raw ?? n.body,
     sizeBytes: Buffer.byteLength(n.raw ?? n.body, 'utf8'),
     mtimeMs: Date.now(),

--- a/packages/server/src/tools/create_note.test.ts
+++ b/packages/server/src/tools/create_note.test.ts
@@ -105,6 +105,7 @@ describe('createNote', () => {
       body: 'old content',
       tags: '',
       fmKeys: '',
+      fm: null,
       raw: 'old content',
       sizeBytes: 11,
       mtimeMs: Date.now(),

--- a/packages/server/src/tools/delete_note.test.ts
+++ b/packages/server/src/tools/delete_note.test.ts
@@ -27,6 +27,7 @@ function seedNote(relPath: string, raw: string): IndexedNote {
     body: raw,
     tags: '',
     fmKeys: '',
+    fm: null,
     raw,
     sizeBytes: Buffer.byteLength(raw, 'utf8'),
     mtimeMs: Date.now(),

--- a/packages/server/src/tools/list_notes.test.ts
+++ b/packages/server/src/tools/list_notes.test.ts
@@ -12,6 +12,7 @@ function buildCtx(
     body: string;
     tags?: string;
     fmKeys?: string;
+    fm?: Record<string, unknown> | null;
     raw?: string;
   }>,
 ): ServerContext {
@@ -28,6 +29,7 @@ function buildCtx(
     body: n.body,
     tags: n.tags ?? '',
     fmKeys: n.fmKeys ?? '',
+    fm: n.fm ?? null,
     raw: n.raw ?? n.body,
     sizeBytes: Buffer.byteLength(n.raw ?? n.body, 'utf8'),
     mtimeMs: Date.now(),

--- a/packages/server/src/tools/list_tags.test.ts
+++ b/packages/server/src/tools/list_tags.test.ts
@@ -12,6 +12,7 @@ function buildCtx(
     body: string;
     tags?: string;
     fmKeys?: string;
+    fm?: Record<string, unknown> | null;
     raw?: string;
   }>,
 ): ServerContext {
@@ -28,6 +29,7 @@ function buildCtx(
     body: n.body,
     tags: n.tags ?? '',
     fmKeys: n.fmKeys ?? '',
+    fm: n.fm ?? null,
     raw: n.raw ?? n.body,
     sizeBytes: Buffer.byteLength(n.raw ?? n.body, 'utf8'),
     mtimeMs: Date.now(),

--- a/packages/server/src/tools/move_note.test.ts
+++ b/packages/server/src/tools/move_note.test.ts
@@ -27,6 +27,7 @@ function seedNote(relPath: string, raw: string): IndexedNote {
     body: raw,
     tags: '',
     fmKeys: '',
+    fm: null,
     raw,
     sizeBytes: Buffer.byteLength(raw, 'utf8'),
     mtimeMs: Date.now(),

--- a/packages/server/src/tools/patch_frontmatter.test.ts
+++ b/packages/server/src/tools/patch_frontmatter.test.ts
@@ -16,6 +16,7 @@ function buildCtx(
     body: string;
     tags?: string;
     fmKeys?: string;
+    fm?: Record<string, unknown> | null;
     raw?: string;
   }>,
 ): ServerContext {
@@ -32,6 +33,7 @@ function buildCtx(
     body: n.body,
     tags: n.tags ?? '',
     fmKeys: n.fmKeys ?? '',
+    fm: n.fm ?? null,
     raw: n.raw ?? n.body,
     sizeBytes: Buffer.byteLength(n.raw ?? n.body, 'utf8'),
     mtimeMs: Date.now(),

--- a/packages/server/src/tools/patch_note.test.ts
+++ b/packages/server/src/tools/patch_note.test.ts
@@ -314,6 +314,7 @@ describe('patchNote — cache + safety', () => {
       body: '',
       tags: '',
       fmKeys: 'title tags',
+      fm: null,
       raw: NOTE,
       sizeBytes: Buffer.byteLength(NOTE, 'utf8'),
       mtimeMs: Date.now(),

--- a/packages/server/src/tools/query_notes.test.ts
+++ b/packages/server/src/tools/query_notes.test.ts
@@ -1,0 +1,255 @@
+import MiniSearch from 'minisearch';
+import { describe, expect, it } from 'vitest';
+import type { ServerContext } from '../context.js';
+import type { IndexedNote } from '../index/types.js';
+import { QueryNotesInput, queryNotes } from './query_notes.js';
+
+function buildCtx(
+  notes: {
+    id: string;
+    title?: string;
+    tags?: string;
+    fm?: Record<string, unknown> | null;
+    sizeBytes?: number;
+    mtimeMs?: number;
+  }[],
+): ServerContext {
+  const index = new MiniSearch<IndexedNote>({
+    idField: 'id',
+    fields: ['title', 'body', 'tags', 'fmKeys'],
+  });
+  const notesMap = new Map<string, IndexedNote>();
+  for (const n of notes) {
+    const title = n.title ?? n.id.slice(n.id.lastIndexOf('/') + 1).replace(/\.md$/, '');
+    notesMap.set(n.id, {
+      id: n.id,
+      title,
+      body: '',
+      tags: n.tags ?? '',
+      fmKeys: n.fm ? Object.keys(n.fm).join(' ') : '',
+      fm: n.fm ?? null,
+      raw: '',
+      sizeBytes: n.sizeBytes ?? 100,
+      mtimeMs: n.mtimeMs ?? Date.UTC(2026, 0, 15),
+    });
+  }
+  return { vaultRoot: '/vault', index, notes: notesMap, backlinks: new Map() };
+}
+
+function parse(input: unknown) {
+  return QueryNotesInput.parse(input);
+}
+
+describe('queryNotes: frontmatter predicates', () => {
+  const ctx = buildCtx([
+    { id: 'a.md', fm: { status: 'draft', priority: 5, published: false, tags: ['x', 'y'] } },
+    { id: 'b.md', fm: { status: 'final', priority: 2, due: '2026-03-01' } },
+    { id: 'c.md', fm: null },
+  ]);
+
+  it('eq matches scalar values', () => {
+    const hits = queryNotes(ctx, parse({ where: [{ key: 'status', op: 'eq', value: 'draft' }] }));
+    expect(hits.map((h) => h.path)).toEqual(['a.md']);
+  });
+
+  it('eq is loose across string/number forms', () => {
+    const hits = queryNotes(ctx, parse({ where: [{ key: 'priority', op: 'eq', value: '5' }] }));
+    expect(hits.map((h) => h.path)).toEqual(['a.md']);
+  });
+
+  it('eq matches booleans', () => {
+    const hits = queryNotes(ctx, parse({ where: [{ key: 'published', op: 'eq', value: false }] }));
+    expect(hits.map((h) => h.path)).toEqual(['a.md']);
+  });
+
+  it('ne excludes notes missing the key', () => {
+    const hits = queryNotes(ctx, parse({ where: [{ key: 'status', op: 'ne', value: 'draft' }] }));
+    expect(hits.map((h) => h.path)).toEqual(['b.md']);
+  });
+
+  it('exists and missing test key presence', () => {
+    expect(
+      queryNotes(ctx, parse({ where: [{ key: 'due', op: 'exists' }] })).map((h) => h.path),
+    ).toEqual(['b.md']);
+    expect(
+      queryNotes(ctx, parse({ where: [{ key: 'due', op: 'missing' }] })).map((h) => h.path),
+    ).toEqual(['a.md', 'c.md']);
+  });
+
+  it('contains matches array membership', () => {
+    const hits = queryNotes(ctx, parse({ where: [{ key: 'tags', op: 'contains', value: 'y' }] }));
+    expect(hits.map((h) => h.path)).toEqual(['a.md']);
+  });
+
+  it('contains matches case-insensitive substring on strings', () => {
+    const hits = queryNotes(
+      ctx,
+      parse({ where: [{ key: 'status', op: 'contains', value: 'FIN' }] }),
+    );
+    expect(hits.map((h) => h.path)).toEqual(['b.md']);
+  });
+
+  it('gt/lte compare numbers', () => {
+    expect(
+      queryNotes(ctx, parse({ where: [{ key: 'priority', op: 'gt', value: 2 }] })).map(
+        (h) => h.path,
+      ),
+    ).toEqual(['a.md']);
+    expect(
+      queryNotes(ctx, parse({ where: [{ key: 'priority', op: 'lte', value: 2 }] })).map(
+        (h) => h.path,
+      ),
+    ).toEqual(['b.md']);
+  });
+
+  it('gte/lt compare ISO date strings lexicographically', () => {
+    expect(
+      queryNotes(ctx, parse({ where: [{ key: 'due', op: 'gte', value: '2026-01-01' }] })).map(
+        (h) => h.path,
+      ),
+    ).toEqual(['b.md']);
+    expect(
+      queryNotes(ctx, parse({ where: [{ key: 'due', op: 'lt', value: '2026-01-01' }] })),
+    ).toEqual([]);
+  });
+
+  it('multiple predicates AND together', () => {
+    const hits = queryNotes(
+      ctx,
+      parse({
+        where: [
+          { key: 'status', op: 'exists' },
+          { key: 'priority', op: 'lt', value: 3 },
+        ],
+      }),
+    );
+    expect(hits.map((h) => h.path)).toEqual(['b.md']);
+  });
+
+  it('comparison ops never match objects or missing values', () => {
+    expect(queryNotes(ctx, parse({ where: [{ key: 'nope', op: 'gt', value: 0 }] }))).toEqual([]);
+    expect(queryNotes(ctx, parse({ where: [{ key: 'tags', op: 'gt', value: 0 }] }))).toEqual([]);
+  });
+});
+
+describe('queryNotes: file filters', () => {
+  const ctx = buildCtx([
+    { id: 'projects/a.md', tags: 'work', sizeBytes: 50, mtimeMs: Date.UTC(2026, 5, 1) },
+    { id: 'projects/b.md', tags: 'home', sizeBytes: 500, mtimeMs: Date.UTC(2026, 5, 20) },
+    { id: 'daily/c.md', tags: 'work log', sizeBytes: 5000, mtimeMs: Date.UTC(2026, 6, 2) },
+  ]);
+
+  it('folder restricts to a path prefix', () => {
+    const hits = queryNotes(ctx, parse({ folder: 'projects/' }));
+    expect(hits.map((h) => h.path)).toEqual(['projects/a.md', 'projects/b.md']);
+  });
+
+  it('tag filter accepts an optional # prefix', () => {
+    const hits = queryNotes(ctx, parse({ tag: '#work' }));
+    expect(hits.map((h) => h.path)).toEqual(['daily/c.md', 'projects/a.md']);
+  });
+
+  it('modifiedAfter/modifiedBefore bound mtime', () => {
+    const hits = queryNotes(
+      ctx,
+      parse({ modifiedAfter: '2026-06-10', modifiedBefore: '2026-07-01' }),
+    );
+    expect(hits.map((h) => h.path)).toEqual(['projects/b.md']);
+  });
+
+  it('minSizeBytes/maxSizeBytes bound size', () => {
+    const hits = queryNotes(ctx, parse({ minSizeBytes: 100, maxSizeBytes: 1000 }));
+    expect(hits.map((h) => h.path)).toEqual(['projects/b.md']);
+  });
+});
+
+describe('queryNotes: output shape', () => {
+  const ctx = buildCtx([
+    {
+      id: 'a.md',
+      title: 'Custom Title',
+      tags: 'x y',
+      fm: { status: 'draft', priority: 5 },
+      sizeBytes: 42,
+      mtimeMs: Date.UTC(2026, 6, 1, 12),
+    },
+    { id: 'b.md', fm: { status: 'final' } },
+  ]);
+
+  it('default output is just path (+ title when it differs from basename)', () => {
+    const hits = queryNotes(ctx, parse({}));
+    expect(hits).toEqual([{ path: 'a.md', title: 'Custom Title' }, { path: 'b.md' }]);
+  });
+
+  it('select returns requested fm keys, skipping absent ones', () => {
+    const hits = queryNotes(ctx, parse({ select: ['status', 'priority'] }));
+    expect(hits[0]?.fm).toEqual({ status: 'draft', priority: 5 });
+    expect(hits[1]?.fm).toEqual({ status: 'final' });
+  });
+
+  it('select supports the mtime/size/tags specials', () => {
+    const hits = queryNotes(ctx, parse({ select: ['mtime', 'size', 'tags'] }));
+    expect(hits[0]).toEqual({
+      path: 'a.md',
+      title: 'Custom Title',
+      mtime: '2026-07-01T12:00:00.000Z',
+      sizeBytes: 42,
+      tags: ['x', 'y'],
+    });
+    // b.md has no tags — the field is omitted, not empty.
+    expect(hits[1]?.tags).toBeUndefined();
+  });
+});
+
+describe('queryNotes: sort and limit', () => {
+  const ctx = buildCtx([
+    { id: 'b.md', title: 'Beta', sizeBytes: 300, mtimeMs: 3000 },
+    { id: 'a.md', title: 'Zulu', sizeBytes: 100, mtimeMs: 2000 },
+    { id: 'c.md', title: 'Alpha', sizeBytes: 200, mtimeMs: 1000 },
+  ]);
+
+  it('sorts by path ascending by default', () => {
+    expect(queryNotes(ctx, parse({})).map((h) => h.path)).toEqual(['a.md', 'b.md', 'c.md']);
+  });
+
+  it('sorts by mtime descending', () => {
+    expect(queryNotes(ctx, parse({ sort: 'mtime', order: 'desc' })).map((h) => h.path)).toEqual([
+      'b.md',
+      'a.md',
+      'c.md',
+    ]);
+  });
+
+  it('sorts by size and by title', () => {
+    expect(queryNotes(ctx, parse({ sort: 'size' })).map((h) => h.path)).toEqual([
+      'a.md',
+      'c.md',
+      'b.md',
+    ]);
+    expect(queryNotes(ctx, parse({ sort: 'title' })).map((h) => h.path)).toEqual([
+      'c.md',
+      'b.md',
+      'a.md',
+    ]);
+  });
+
+  it('limit truncates after sorting', () => {
+    expect(
+      queryNotes(ctx, parse({ sort: 'mtime', order: 'desc', limit: 1 })).map((h) => h.path),
+    ).toEqual(['b.md']);
+  });
+});
+
+describe('QueryNotesInput validation', () => {
+  it('rejects value-requiring ops without a value', () => {
+    expect(() => parse({ where: [{ key: 'status', op: 'eq' }] })).toThrow();
+  });
+
+  it('allows exists/missing without a value', () => {
+    expect(() => parse({ where: [{ key: 'status', op: 'exists' }] })).not.toThrow();
+  });
+
+  it('rejects unparseable dates', () => {
+    expect(() => parse({ modifiedAfter: 'not-a-date' })).toThrow();
+  });
+});

--- a/packages/server/src/tools/query_notes.ts
+++ b/packages/server/src/tools/query_notes.ts
@@ -1,0 +1,182 @@
+import { z } from 'zod';
+import type { ServerContext } from '../context.js';
+import { basenameNoExt } from './search.js';
+
+const OPS_WITHOUT_VALUE = new Set(['exists', 'missing']);
+
+const Predicate = z
+  .object({
+    key: z.string().min(1).describe('Frontmatter key to test (top-level).'),
+    op: z
+      .enum(['eq', 'ne', 'contains', 'exists', 'missing', 'gt', 'gte', 'lt', 'lte'])
+      .describe(
+        'eq/ne compare scalars; contains matches array membership or substring; ' +
+          'exists/missing test key presence; gt/gte/lt/lte compare numbers or strings (ISO dates sort correctly).',
+      ),
+    value: z
+      .union([z.string(), z.number(), z.boolean()])
+      .optional()
+      .describe('Comparison value. Required for every op except exists/missing.'),
+  })
+  .refine((p) => OPS_WITHOUT_VALUE.has(p.op) || p.value !== undefined, {
+    message: 'value is required for this op',
+  });
+
+const ISO_DATE = z
+  .string()
+  .refine((s) => !Number.isNaN(Date.parse(s)), { message: 'not a parseable date' });
+
+export const QueryNotesInput = z.object({
+  where: z
+    .array(Predicate)
+    .max(20)
+    .default([])
+    .describe('Frontmatter predicates. All must match (AND).'),
+  folder: z
+    .string()
+    .optional()
+    .describe('Restrict to notes under this vault-relative folder prefix.'),
+  tag: z.string().optional().describe('Restrict to notes with this tag (# prefix optional).'),
+  modifiedAfter: ISO_DATE.optional().describe(
+    'Only notes modified at or after this ISO 8601 date/time.',
+  ),
+  modifiedBefore: ISO_DATE.optional().describe(
+    'Only notes modified before this ISO 8601 date/time.',
+  ),
+  minSizeBytes: z.number().int().min(0).optional().describe('Only notes at least this many bytes.'),
+  maxSizeBytes: z.number().int().min(0).optional().describe('Only notes at most this many bytes.'),
+  select: z
+    .array(z.string())
+    .max(20)
+    .default([])
+    .describe(
+      'Extra fields to return per hit: frontmatter keys, or the specials "mtime", "size", "tags". ' +
+        'Default returns only path + title, keeping the payload minimal.',
+    ),
+  sort: z.enum(['path', 'title', 'mtime', 'size']).default('path').describe('Sort field.'),
+  order: z.enum(['asc', 'desc']).default('asc').describe('Sort order.'),
+  limit: z.number().int().min(1).max(500).default(100).describe('Maximum number of results.'),
+});
+export type QueryNotesInput = z.infer<typeof QueryNotesInput>;
+
+export interface QueryHit {
+  path: string;
+  /** Omitted when it equals the path's basename (recoverable from `path`). */
+  title?: string;
+  /** ISO 8601 mtime — present only when "mtime" is selected. */
+  mtime?: string;
+  /** Present only when "size" is selected. */
+  sizeBytes?: number;
+  /** Present only when "tags" is selected and the note has tags. */
+  tags?: string[];
+  /** Selected frontmatter keys — present only when the note has at least one of them. */
+  fm?: Record<string, unknown>;
+}
+
+type Scalar = string | number | boolean;
+
+/** Loose scalar equality: strict first, then string-form — so `5` matches "5" and dates match. */
+function scalarEq(a: unknown, b: Scalar): boolean {
+  if (a === b) return true;
+  if (a === null || a === undefined || typeof a === 'object') return false;
+  return String(a) === String(b);
+}
+
+/** Numeric when both sides coerce to finite numbers, else lexicographic (ISO dates sort correctly). */
+function compare(a: unknown, b: Scalar): number | undefined {
+  if (a === null || a === undefined || typeof a === 'object' || typeof a === 'boolean') {
+    return undefined;
+  }
+  const an = Number(a);
+  const bn = Number(b);
+  if (Number.isFinite(an) && Number.isFinite(bn)) return an - bn;
+  const as = String(a);
+  const bs = String(b);
+  return as < bs ? -1 : as > bs ? 1 : 0;
+}
+
+function matches(fm: Record<string, unknown> | null, p: z.infer<typeof Predicate>): boolean {
+  const val = fm?.[p.key];
+  switch (p.op) {
+    case 'exists':
+      return val !== undefined;
+    case 'missing':
+      return val === undefined;
+    case 'eq':
+      return scalarEq(val, p.value as Scalar);
+    // `ne` requires the key to exist — notes without the key don't match.
+    case 'ne':
+      return val !== undefined && !scalarEq(val, p.value as Scalar);
+    case 'contains': {
+      if (Array.isArray(val)) return val.some((v) => scalarEq(v, p.value as Scalar));
+      if (typeof val === 'string') {
+        return val.toLowerCase().includes(String(p.value).toLowerCase());
+      }
+      return false;
+    }
+    case 'gt':
+    case 'gte':
+    case 'lt':
+    case 'lte': {
+      const c = compare(val, p.value as Scalar);
+      if (c === undefined) return false;
+      if (p.op === 'gt') return c > 0;
+      if (p.op === 'gte') return c >= 0;
+      if (p.op === 'lt') return c < 0;
+      return c <= 0;
+    }
+  }
+}
+
+export function queryNotes(ctx: ServerContext, input: QueryNotesInput): QueryHit[] {
+  const tag = input.tag?.replace(/^#/, '');
+  const after = input.modifiedAfter ? Date.parse(input.modifiedAfter) : undefined;
+  const before = input.modifiedBefore ? Date.parse(input.modifiedBefore) : undefined;
+  const fmKeys = input.select.filter((s) => s !== 'mtime' && s !== 'size' && s !== 'tags');
+
+  const hits: { hit: QueryHit; note: { title: string; mtimeMs: number; sizeBytes: number } }[] = [];
+
+  for (const [path, note] of ctx.notes) {
+    if (input.folder && !path.startsWith(input.folder)) continue;
+    if (tag && !note.tags.split(' ').filter(Boolean).includes(tag)) continue;
+    if (after !== undefined && note.mtimeMs < after) continue;
+    if (before !== undefined && note.mtimeMs >= before) continue;
+    if (input.minSizeBytes !== undefined && note.sizeBytes < input.minSizeBytes) continue;
+    if (input.maxSizeBytes !== undefined && note.sizeBytes > input.maxSizeBytes) continue;
+    if (!input.where.every((p) => matches(note.fm, p))) continue;
+
+    const hit: QueryHit = { path };
+    // Omit redundant/empty metadata to keep the payload lean (recoverable from `path`).
+    if (note.title && note.title !== basenameNoExt(path)) hit.title = note.title;
+    if (input.select.includes('mtime')) hit.mtime = new Date(note.mtimeMs).toISOString();
+    if (input.select.includes('size')) hit.sizeBytes = note.sizeBytes;
+    if (input.select.includes('tags')) {
+      const noteTags = note.tags.split(' ').filter(Boolean);
+      if (noteTags.length > 0) hit.tags = noteTags;
+    }
+    if (fmKeys.length > 0 && note.fm) {
+      const fm: Record<string, unknown> = {};
+      for (const k of fmKeys) {
+        if (note.fm[k] !== undefined) fm[k] = note.fm[k];
+      }
+      if (Object.keys(fm).length > 0) hit.fm = fm;
+    }
+    hits.push({ hit, note });
+  }
+
+  const dir = input.order === 'desc' ? -1 : 1;
+  hits.sort((a, b) => {
+    switch (input.sort) {
+      case 'mtime':
+        return (a.note.mtimeMs - b.note.mtimeMs) * dir;
+      case 'size':
+        return (a.note.sizeBytes - b.note.sizeBytes) * dir;
+      case 'title':
+        return a.note.title.localeCompare(b.note.title) * dir;
+      default:
+        return a.hit.path.localeCompare(b.hit.path) * dir;
+    }
+  });
+
+  return hits.slice(0, input.limit).map((h) => h.hit);
+}

--- a/packages/server/src/tools/replace_in_note.test.ts
+++ b/packages/server/src/tools/replace_in_note.test.ts
@@ -303,6 +303,7 @@ describe('replaceInNote — cache + safety', () => {
       body: '',
       tags: '',
       fmKeys: 'title tags',
+      fm: null,
       raw: NOTE,
       sizeBytes: Buffer.byteLength(NOTE, 'utf8'),
       mtimeMs: Date.now(),

--- a/packages/server/src/tools/search.test.ts
+++ b/packages/server/src/tools/search.test.ts
@@ -12,6 +12,7 @@ function buildCtx(
     body: string;
     tags?: string;
     fmKeys?: string;
+    fm?: Record<string, unknown> | null;
     raw?: string;
   }>,
 ): ServerContext {
@@ -28,6 +29,7 @@ function buildCtx(
     body: n.body,
     tags: n.tags ?? '',
     fmKeys: n.fmKeys ?? '',
+    fm: n.fm ?? null,
     raw: n.raw ?? n.body,
     sizeBytes: Buffer.byteLength(n.raw ?? n.body, 'utf8'),
     mtimeMs: Date.now(),

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -30,7 +30,7 @@ export const SearchInput = z.object({
 export type SearchInput = z.infer<typeof SearchInput>;
 
 /** Basename without extension — the title is omitted from a hit when it matches this. */
-function basenameNoExt(path: string): string {
+export function basenameNoExt(path: string): string {
   const base = path.slice(path.lastIndexOf('/') + 1);
   const dot = base.lastIndexOf('.');
   return dot > 0 ? base.slice(0, dot) : base;

--- a/packages/server/src/watcher.test.ts
+++ b/packages/server/src/watcher.test.ts
@@ -82,6 +82,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       body: 'will be deleted',
       tags: '',
       fmKeys: '',
+      fm: null,
       raw: 'will be deleted',
       sizeBytes: 15,
       mtimeMs: Date.now(),


### PR DESCRIPTION
## Summary

Adds a second search mode per [SHA-210](https://linear.app/shaqster/issue/SHA-210): a **structured metadata query tool** (`query_notes`) alongside the existing full-text `search`. Of the two options in the issue, this is the differentiated one — MiniSearch's ranking is already BM25-derived, while predicate queries over frontmatter are a genuinely new capability for agent workflows (also effectively covers SHA-20).

## What it does

- **Frontmatter predicates** (`where`, ANDed): `eq` / `ne` / `contains` (array membership or substring) / `exists` / `missing` / `gt` / `gte` / `lt` / `lte` (numeric, or lexicographic so ISO dates compare correctly)
- **File filters**: `folder` prefix, `tag`, `modifiedAfter`/`modifiedBefore`, `minSizeBytes`/`maxSizeBytes`
- **Lean output**: path + title only by default; opt into frontmatter keys or `mtime`/`size`/`tags` via `select`; `sort` + `order` + `limit`
- Minified JSON like `search` — same context-tax discipline, never note content

## Implementation

- `IndexedNote` now keeps the parsed frontmatter values (`fm`) that were already parsed at index time but previously discarded. **Not** a MiniSearch-indexed field — index size and search behaviour are unchanged; the watcher's incremental upsert path carries it too.
- Predicate values are excluded from info-level logs (only `whereCount` is logged), matching the existing raw-query policy.
- Tool count 16 → 17 everywhere guarded: dispatch `HANDLED_TOOLS`, advertised schema, README, ARCHITECTURE, CLIENT-TESTING, REGISTRIES (`check-registries-tools.mjs` passes).

## Verification

- 305 server tests pass (36 new: predicates, filters, output shape, sort/limit, input validation, dispatch routing + log-safety)
- `scripts/mcp-conformance.mjs` passes against the built bundle (17 tools)
- E2E against the committed 10k-note fixture vault over real stdio: predicate + date-range queries return correct rows; **full-vault scan ≈ 5ms round-trip at ~350 bytes payload**; validation errors surface as `isError` without killing the transport; `search` regression-checked

Closes SHA-210.