### PR TITLE
Add VS Code (GitHub Copilot) as an init client (SHA-62)

### DIFF
--- a/.changeset/init-client-vscode.md
+++ b/.changeset/init-client-vscode.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+`seekstone init --client vscode` — auto-detect your vault and print or (with `--write`) create/merge the workspace `.vscode/mcp.json` for GitHub Copilot in VS Code, handling VS Code's config quirks (`servers` key instead of `mcpServers`, explicit `"type": "stdio"`). Same additive merge + backup behavior as the other client writers. `init` now also resolves relative `--vault` paths to absolute before writing any client config, so the spawned server always finds the vault regardless of the client's working directory.

--- a/README.md
+++ b/README.md
@@ -203,11 +203,34 @@ Or add the block manually to `~/.cursor/mcp.json` (global) or `<project>/.cursor
 
 One-click: <a href="https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22seekstone%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22seekstone%22%5D%2C%22env%22%3A%7B%22SEEKSTONE_VAULT%22%3A%22%2Fabsolute%2Fpath%2Fto%2Fyour%2Fvault%22%7D%7D"><img src="https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=for-the-badge&amp;logo=visualstudiocode&amp;logoColor=white" alt="Install in VS Code" align="top" /></a> — then set `SEEKSTONE_VAULT` to your vault's absolute path when VS Code opens the server config (the link installs a placeholder).
 
+Or let the CLI auto-detect your vault and write the workspace config (`.vscode/mcp.json` in the current directory):
+
+```bash
+npx -y seekstone init --client vscode --write
+```
+
 Or add it from the terminal:
 
 ```bash
 code --add-mcp '{"name":"seekstone","command":"npx","args":["-y","seekstone"],"env":{"SEEKSTONE_VAULT":"/absolute/path/to/your/vault"}}'
 ```
+
+Or add the block manually to `.vscode/mcp.json` (workspace) or via Command Palette → *MCP: Open User Configuration* (user-global). Note VS Code's two quirks: the top-level key is `servers` (not `mcpServers`), and `"type": "stdio"` is required:
+
+```json
+{
+  "servers": {
+    "seekstone": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "seekstone"],
+      "env": { "SEEKSTONE_VAULT": "/absolute/path/to/your/vault" }
+    }
+  }
+}
+```
+
+Requires VS Code 1.102+; seekstone appears in Copilot Chat's **Agent mode** tools picker.
 
 ### Other MCP clients (Windsurf, Cline, …)
 

--- a/packages/server/src/cli-args.ts
+++ b/packages/server/src/cli-args.ts
@@ -31,7 +31,7 @@ Usage:
 
 "seekstone init" options:
   --vault <path>       Vault to use (auto-detected from Obsidian if omitted; fallback: $SEEKSTONE_VAULT)
-  --client <name>      desktop (default) | code | cursor
+  --client <name>      desktop (default) | code | cursor | vscode
   --write              Patch the client config in place (backs it up first)
 
 Required environment:

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -35,6 +35,7 @@ if (intent === 'init') {
     env: process.env,
     platform: process.platform,
     timestamp: new Date().toISOString().replace(/[:.]/g, '-'),
+    cwd: process.cwd(),
   });
   process.stdout.write(`${result.output.join('\n')}\n`);
   process.exit(result.exitCode);

--- a/packages/server/src/init.test.ts
+++ b/packages/server/src/init.test.ts
@@ -7,12 +7,15 @@ import {
   cursorConfigPath,
   mcpAddCommand,
   mergeSeekstoneConfig,
+  mergeSeekstoneConfigVsCode,
   obsidianRegistryPath,
   parseInitArgs,
   parseObsidianVaults,
   runInit,
   seekstoneServerConfig,
   validateVault,
+  vscodeMcpConfigPath,
+  vscodeServerConfig,
 } from './init.js';
 
 describe('parseInitArgs', () => {
@@ -28,6 +31,9 @@ describe('parseInitArgs', () => {
   });
   it('parses --client cursor', () => {
     expect(parseInitArgs(['--client', 'cursor']).client).toBe('cursor');
+  });
+  it('parses --client vscode', () => {
+    expect(parseInitArgs(['--client', 'vscode']).client).toBe('vscode');
   });
   it('ignores an invalid --client value (keeps default)', () => {
     expect(parseInitArgs(['--client', 'nonsense']).client).toBe('desktop');
@@ -102,6 +108,44 @@ describe('mergeSeekstoneConfig', () => {
   it('is idempotent', () => {
     const once = mergeSeekstoneConfig(null, '/v');
     const twice = mergeSeekstoneConfig(once, '/v');
+    expect(twice).toEqual(once);
+  });
+});
+
+describe('vscodeMcpConfigPath', () => {
+  it('resolves .vscode/mcp.json under the given cwd', () => {
+    expect(vscodeMcpConfigPath('/repo')).toBe(join('/repo', '.vscode', 'mcp.json'));
+  });
+});
+
+describe('mergeSeekstoneConfigVsCode', () => {
+  it('creates the servers block with an explicit stdio type on a fresh config', () => {
+    const merged = mergeSeekstoneConfigVsCode(null, '/v');
+    expect(merged.servers?.seekstone).toEqual({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'seekstone'],
+      env: { SEEKSTONE_VAULT: '/v' },
+    });
+  });
+  it('preserves other servers and unrelated top-level keys', () => {
+    const existing = {
+      servers: { other: { type: 'stdio', command: 'x' } },
+      inputs: [{ id: 'token' }],
+    };
+    const merged = mergeSeekstoneConfigVsCode(existing, '/v');
+    expect(merged.servers?.other).toEqual({ type: 'stdio', command: 'x' });
+    expect(merged.inputs).toEqual([{ id: 'token' }]);
+    expect(merged.servers?.seekstone).toEqual(vscodeServerConfig('/v'));
+  });
+  it('does not mutate the input', () => {
+    const existing = { servers: { other: { command: 'x' } } };
+    mergeSeekstoneConfigVsCode(existing, '/v');
+    expect(existing.servers).toEqual({ other: { command: 'x' } });
+  });
+  it('is idempotent', () => {
+    const once = mergeSeekstoneConfigVsCode(null, '/v');
+    const twice = mergeSeekstoneConfigVsCode(once, '/v');
     expect(twice).toEqual(once);
   });
 });
@@ -282,6 +326,67 @@ describe('runInit', () => {
     const written = JSON.parse(await readFile(cfgPath, 'utf8'));
     expect(written.mcpServers.other).toEqual({ command: 'x' });
     expect(written.mcpServers.seekstone).toBeDefined();
+  });
+
+  it('prints the config block (no write) for vscode with the servers key and stdio type', async () => {
+    const res = await runInit({ vault, write: false, client: 'vscode' }, { ...deps(), cwd: dir });
+    expect(res.exitCode).toBe(0);
+    expect(res.wrotePath).toBeUndefined();
+    const text = res.output.join('\n');
+    expect(text).toContain('VS Code (GitHub Copilot) config');
+    expect(text).toContain(vscodeMcpConfigPath(dir));
+    expect(text).toContain('"servers"');
+    expect(text).toContain('"type": "stdio"');
+    expect(text).not.toContain('mcpServers');
+  });
+
+  it('--write --client vscode creates .vscode/mcp.json under cwd', async () => {
+    const res = await runInit({ vault, write: true, client: 'vscode' }, { ...deps(), cwd: dir });
+    expect(res.exitCode).toBe(0);
+    expect(res.wrotePath).toBe(vscodeMcpConfigPath(dir));
+    expect(res.backupPath).toBeUndefined();
+    const written = JSON.parse(await readFile(res.wrotePath as string, 'utf8'));
+    expect(written.servers.seekstone).toEqual(vscodeServerConfig(vault));
+    expect(written.mcpServers).toBeUndefined();
+    expect(res.output.join('\n')).toContain('Agent mode');
+  });
+
+  it('--write --client vscode merges into an existing mcp.json and backs it up', async () => {
+    const cfgPath = vscodeMcpConfigPath(dir);
+    await mkdir(join(dir, '.vscode'), { recursive: true });
+    await writeFile(
+      cfgPath,
+      JSON.stringify({ servers: { other: { type: 'stdio', command: 'x' } } }, null, 2),
+    );
+
+    const res = await runInit({ vault, write: true, client: 'vscode' }, { ...deps(), cwd: dir });
+    expect(res.exitCode).toBe(0);
+    expect(res.backupPath).toBeDefined();
+    const written = JSON.parse(await readFile(cfgPath, 'utf8'));
+    expect(written.servers.other).toEqual({ type: 'stdio', command: 'x' });
+    expect(written.servers.seekstone).toEqual(vscodeServerConfig(vault));
+  });
+
+  it('--write --client vscode refuses to modify a malformed mcp.json', async () => {
+    const cfgPath = vscodeMcpConfigPath(dir);
+    await mkdir(join(dir, '.vscode'), { recursive: true });
+    await writeFile(cfgPath, '{ not json');
+
+    const res = await runInit({ vault, write: true, client: 'vscode' }, { ...deps(), cwd: dir });
+    expect(res.exitCode).toBe(1);
+    expect(res.output.join('\n')).toContain('not valid JSON');
+    expect(await readFile(cfgPath, 'utf8')).toBe('{ not json');
+  });
+
+  it('resolves a relative --vault against cwd before writing config', async () => {
+    const res = await runInit(
+      { vault: 'vault', write: true, client: 'vscode' },
+      { ...deps(), cwd: dir },
+    );
+    expect(res.exitCode).toBe(0);
+    const written = JSON.parse(await readFile(res.wrotePath as string, 'utf8'));
+    // The absolute vault path, not the relative one the user typed.
+    expect(written.servers.seekstone.env.SEEKSTONE_VAULT).toBe(vault);
   });
 
   it('--write --client code calls spawnClaudeMcp with correct args', async () => {

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -21,7 +21,7 @@ import path, { dirname, join } from 'node:path';
 export interface InitOptions {
   vault?: string;
   write: boolean;
-  client: 'desktop' | 'code' | 'cursor';
+  client: 'desktop' | 'code' | 'cursor' | 'vscode';
 }
 
 export function parseInitArgs(argv: readonly string[]): InitOptions {
@@ -33,7 +33,7 @@ export function parseInitArgs(argv: readonly string[]): InitOptions {
     else if (a === '--vault') opts.vault = argv[++i];
     else if (a === '--client') {
       const v = argv[++i];
-      if (v === 'desktop' || v === 'code' || v === 'cursor') opts.client = v;
+      if (v === 'desktop' || v === 'code' || v === 'cursor' || v === 'vscode') opts.client = v;
     }
   }
   return opts;
@@ -90,6 +90,18 @@ export function claudeDesktopConfigPath(
 export function cursorConfigPath(platform: NodeJS.Platform, env: { home?: string }): string {
   const j = platform === 'win32' ? path.win32.join : path.posix.join;
   return j(env.home ?? '', '.cursor', 'mcp.json');
+}
+
+/**
+ * VS Code (GitHub Copilot) workspace MCP config: `.vscode/mcp.json` under the
+ * given working directory. Workspace-level on purpose — the user-global config
+ * has no stable documented path (VS Code's "MCP: Open User Configuration"
+ * command owns it), and workspace config takes precedence anyway. Host path
+ * semantics (unlike the other path helpers) because it resolves the *real*
+ * cwd of the running process, not a target-platform location.
+ */
+export function vscodeMcpConfigPath(cwd: string): string {
+  return join(cwd, '.vscode', 'mcp.json');
 }
 
 /**
@@ -158,6 +170,33 @@ export function mergeSeekstoneConfig(existing: McpConfig | null, vaultPath: stri
   const servers = { ...(base.mcpServers ?? {}) };
   servers.seekstone = seekstoneServerConfig(vaultPath);
   return { ...base, mcpServers: servers };
+}
+
+type VsCodeMcpConfig = { servers?: Record<string, unknown> } & Record<string, unknown>;
+
+/** The server entry for VS Code, which requires an explicit `"type": "stdio"`. */
+export function vscodeServerConfig(vaultPath: string): {
+  type: 'stdio';
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+} {
+  return { type: 'stdio', ...seekstoneServerConfig(vaultPath) };
+}
+
+/**
+ * VS Code variant of mergeSeekstoneConfig. Same additive/idempotent contract,
+ * but VS Code's mcp.json is the one client config keyed `"servers"` (not
+ * `"mcpServers"`) and requires `"type": "stdio"` on each entry.
+ */
+export function mergeSeekstoneConfigVsCode(
+  existing: VsCodeMcpConfig | null,
+  vaultPath: string,
+): VsCodeMcpConfig {
+  const base: VsCodeMcpConfig = existing ? structuredClone(existing) : {};
+  const servers = { ...(base.servers ?? {}) };
+  servers.seekstone = vscodeServerConfig(vaultPath);
+  return { ...base, servers };
 }
 
 export interface VaultCheck {
@@ -230,6 +269,8 @@ export async function runInit(
     platform: NodeJS.Platform;
     /** ISO timestamp for the backup filename (injected for determinism in tests). */
     timestamp: string;
+    /** Working directory for workspace-level configs (vscode); defaults to process.cwd(). */
+    cwd?: string;
     /** Injectable for testing; defaults to fs/promises readFile. */
     readFile?: (p: string, enc: 'utf8') => Promise<string>;
     /**
@@ -286,6 +327,11 @@ export async function runInit(
       };
     }
   }
+
+  // Resolve to absolute before validating or writing config: clients spawn the
+  // server from their own working directory, so a relative SEEKSTONE_VAULT in
+  // the written config would silently point at the wrong place.
+  vaultPath = path.resolve(deps.cwd ?? process.cwd(), vaultPath);
 
   const check = await validateVault(vaultPath);
   if (!check.ok) {
@@ -351,29 +397,45 @@ export async function runInit(
   }
 
   // File-config clients: Claude Desktop and Cursor share the same
-  // `mcpServers` JSON shape; only the config path and the restart hint differ.
-  const clientLabel = opts.client === 'cursor' ? 'Cursor' : 'Claude Desktop';
-  const configPath =
+  // `mcpServers` JSON shape; VS Code uses `servers` + explicit `type: stdio`.
+  // Only the config path, JSON shape, and restart hint differ.
+  const clientLabel =
     opts.client === 'cursor'
-      ? cursorConfigPath(deps.platform, { home: deps.env.HOME })
-      : claudeDesktopConfigPath(deps.platform, {
-          home: deps.env.HOME,
-          appData: deps.env.APPDATA,
-        });
-  const block = JSON.stringify(
-    { mcpServers: { seekstone: seekstoneServerConfig(vaultPath) } },
-    null,
-    2,
-  );
+      ? 'Cursor'
+      : opts.client === 'vscode'
+        ? 'VS Code (GitHub Copilot)'
+        : 'Claude Desktop';
+  const configPath =
+    opts.client === 'vscode'
+      ? vscodeMcpConfigPath(deps.cwd ?? process.cwd())
+      : opts.client === 'cursor'
+        ? cursorConfigPath(deps.platform, { home: deps.env.HOME })
+        : claudeDesktopConfigPath(deps.platform, {
+            home: deps.env.HOME,
+            appData: deps.env.APPDATA,
+          });
+  const block =
+    opts.client === 'vscode'
+      ? JSON.stringify({ servers: { seekstone: vscodeServerConfig(vaultPath) } }, null, 2)
+      : JSON.stringify({ mcpServers: { seekstone: seekstoneServerConfig(vaultPath) } }, null, 2);
+  const restartHint =
+    opts.client === 'vscode'
+      ? 'Reload VS Code, then open Copilot Chat in Agent mode — seekstone appears in the tools picker.'
+      : `Restart ${clientLabel} to load seekstone.`;
 
   if (!opts.write) {
     out.push(
       `Add this to your ${clientLabel} config:`,
       `  ${configPath}`,
+      ...(opts.client === 'vscode'
+        ? [
+            '  (workspace config — run from your project root, or use the Command Palette\'s "MCP: Open User Configuration" for user-global)',
+          ]
+        : []),
       '',
       block,
       '',
-      `Then restart ${clientLabel}. Or re-run with --write to patch it automatically.`,
+      `${restartHint} Or re-run with --write to patch it automatically.`,
     );
     return { ok: true, exitCode: 0, output: out };
   }
@@ -399,7 +461,10 @@ export async function runInit(
     existing = null; // file simply doesn't exist yet
   }
 
-  const merged = mergeSeekstoneConfig(existing, vaultPath);
+  const merged =
+    opts.client === 'vscode'
+      ? mergeSeekstoneConfigVsCode(existing, vaultPath)
+      : mergeSeekstoneConfig(existing, vaultPath);
   let backupPath: string | undefined;
   await mkdir(dirname(configPath), { recursive: true });
   if (existingRaw !== null) {
@@ -412,7 +477,7 @@ export async function runInit(
     `✓ Patched ${configPath}`,
     backupPath ? `  Backup saved to ${backupPath}` : '  (created a new config file)',
     '',
-    `Restart ${clientLabel} to load seekstone.`,
+    restartHint,
   );
   return { ok: true, exitCode: 0, output: out, wrotePath: configPath, backupPath };
 }


### PR DESCRIPTION
Implements [SHA-62](https://linear.app/shaqster/issue/SHA-62): `seekstone init --client vscode` + install docs, completing the high-priority clients under the install-UX epic (SHA-61).

## What it does

- **Print mode**: outputs the correct `.vscode/mcp.json` block with the auto-detected (or `--vault`) path
- **`--write` mode**: creates or additively merges the **workspace** `.vscode/mcp.json` under the current directory — same contract as the desktop/cursor writers (timestamped backup, refuses malformed JSON, idempotent, never touches other servers or top-level keys like `inputs`)
- Handles VS Code's two config quirks from the PRD: top-level key is **`servers`** (not `mcpServers`) and **`"type": "stdio"`** is required on the entry
- Workspace-level on purpose: the user-global config has no stable documented path (VS Code's *MCP: Open User Configuration* command owns it), and workspace config takes precedence anyway — the print output says how to go user-global

## Bonus fix caught during E2E

`init` now resolves relative `--vault` paths to absolute before validating or writing **any** client config. Previously `--vault ../vault` was written verbatim into the config; since clients spawn the server from their own cwd, that silently pointed at the wrong place. Applies to all clients, with a regression test.

## Docs

README **Option 6 — VS Code** gains the `init` CLI path and a manual `servers`-key snippet with the quirks called out (the PRD's `docs/CLIENTS.md` predates the README's per-client Options structure, so this follows the existing convention instead).

## Verification

- 316 tests pass (10 new: parse, path helper, merge contract ×4, print/write/merge/refuse-malformed runInit flows, relative-vault resolution)
- E2E against the built bundle in a scratch workspace: print mode, `--write` create, idempotent re-run with backup — all verified by hand
- Changeset included (minor)

Note for the PRD's last acceptance box (manual smoke test in real VS Code Agent mode): needs a human with VS Code 1.102+ — config shape matches the documented format exactly.