### PR TITLE
Disable Codecov PR comments (SHA-238)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Adds a root `codecov.yml` with `comment: false` so Codecov stops posting the per-PR comment from the `codecov-commenter` bot (which carries an "install the app" warning and emails a notification on every PR).

Coverage regressions remain enforced by the `codecov/project` and `codecov/patch` status checks, and coverage uploads via `CODECOV_TOKEN` in CI are unaffected.

Closes SHA-238