### PR TITLE
chore(deps): bump github/codeql-action from 4.36.2 to 4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: javascript-typescript
 
-      - uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
Bumps `github/codeql-action` init/autobuild/analyze to 4.36.3 **in one PR**, replacing dependabot PRs #174, #177, #178.

Those three cannot merge individually: all three actions run in the same `codeql.yml` workflow, and CodeQL rejects mixed versions in a single run (`Loaded a configuration file for version '4.36.3', but running version '4.36.2'`).

Closes #174, closes #177, closes #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)