### PR TITLE
chore: group dependabot updates (github-actions, vitest)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"


### PR DESCRIPTION
Adds `groups:` to dependabot config:

- **github-actions**: all action bumps in one weekly PR. The codeql-action init/autobuild/analyze steps share one workflow and reject mixed versions, so separate per-action PRs (like #174/#177/#178) can never pass CI individually.
- **vitest**: `vitest` + `@vitest/*` are a matched-version pair (see #179/#180) and should bump together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)