### PR TITLE
fix: deflake macOS copyVault collision + Windows watcher create-miss (SHA-242)

### DIFF
--- a/.changeset/tidy-donkeys-brush.md
+++ b/.changeset/tidy-donkeys-brush.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Watcher teardown is now awaitable: `stop()` returns chokidar's close promise instead of fire-and-forgetting it, so embedders and tests can wait for the watcher (and its polling timers) to fully shut down. Also deflakes CI: the harness's `copyVault` scratch destinations are created atomically with `mkdtemp` (the old millisecond-timestamp naming could collide under parallel test workers), and the watcher tests self-heal missed single-create polling ticks on Windows.

--- a/packages/harness/src/safety/copy.test.ts
+++ b/packages/harness/src/safety/copy.test.ts
@@ -98,6 +98,28 @@ describe('copyVault', () => {
     }
   });
 
+  it('concurrent default-label copies get distinct destinations (SHA-242 regression)', async () => {
+    // The old default label was `seekstone-safety-${Date.now()}` — millisecond
+    // resolution, so two copies starting in the same ms shared a destination
+    // and one caller's cleanup deleted the other's copy mid-cp (the macOS CI
+    // flake). mkdtemp destinations must never collide, even when started
+    // back-to-back in the same tick.
+    const results = await Promise.all([copyVault(srcDir), copyVault(srcDir), copyVault(srcDir)]);
+    try {
+      const roots = results.map((r) => r.copyRoot);
+      expect(new Set(roots).size).toBe(roots.length);
+      // Each copy is complete and independent: deleting one must not affect
+      // the others' contents.
+      const { readFile } = await import('node:fs/promises');
+      await rm(roots[0] as string, { recursive: true, force: true });
+      for (const root of roots.slice(1)) {
+        expect(await readFile(join(root, 'note.md'), 'utf8')).toContain('Hello world.');
+      }
+    } finally {
+      await Promise.all(results.map((r) => rm(r.copyRoot, { recursive: true, force: true })));
+    }
+  });
+
   it('throws when dest path equals src path', async () => {
     // copyVault compares resolve(tmpdir(), label) to realpath(srcRoot).
     // On macOS, tmpdir() is a symlink (/var → /private/var) so the guard

--- a/packages/harness/src/safety/copy.ts
+++ b/packages/harness/src/safety/copy.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, realpath } from 'node:fs/promises';
+import { cp, mkdir, mkdtemp, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
 
@@ -40,20 +40,32 @@ export async function copyVault(
   opts: { label?: string } = {},
 ): Promise<CopyResult> {
   const srcAbs = await realpath(resolve(srcRoot));
-  const label = opts.label ?? `seekstone-safety-${Date.now()}`;
   // realpath the tmpdir base so destAbs is the same (long) form as srcAbs.
   // On Windows, os.tmpdir() can return an 8.3 short path (e.g. RUNNER~1);
   // leaving it unresolved makes the dest==src / inside-source guards compare
   // mismatched path forms (so they never fire) and feeds fs.cp a short path it
   // intermittently mis-resolves into a spurious ENOENT. Same root cause as the
   // watcher fix in SHA-144; see SHA-152.
-  const destAbs = resolve(await realpath(tmpdir()), label);
+  const tmpBase = await realpath(tmpdir());
+  // Without an explicit label the destination MUST be created atomically via
+  // mkdtemp, never derived from a timestamp: Date.now() has millisecond
+  // resolution, so two copyVault calls in the same ms (e.g. parallel vitest
+  // workers) would share a destination — mkdir{recursive} merges them silently
+  // and whichever caller cleans up first deletes the other's copy mid-cp,
+  // surfacing as a spurious ENOENT from copyfile (SHA-242).
+  const destAbs = opts.label
+    ? resolve(tmpBase, opts.label)
+    : await mkdtemp(join(tmpBase, 'seekstone-safety-'));
 
-  if (destAbs === srcAbs) {
-    throw new Error(`Refusing to copy: destination equals source (${srcAbs}).`);
-  }
-  if (destAbs.startsWith(`${srcAbs}${sep}`)) {
-    throw new Error(`Refusing to copy: destination is inside source.`);
+  if (destAbs === srcAbs || destAbs.startsWith(`${srcAbs}${sep}`)) {
+    // Remove the scratch dir mkdtemp just created before refusing (labelled
+    // destinations haven't been created yet, so there's nothing to clean).
+    if (!opts.label) await rm(destAbs, { recursive: true, force: true });
+    throw new Error(
+      destAbs === srcAbs
+        ? `Refusing to copy: destination equals source (${srcAbs}).`
+        : `Refusing to copy: destination is inside source.`,
+    );
   }
 
   await mkdir(destAbs, { recursive: true });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -60,7 +60,8 @@ log.info('index ready', { notes: notes.size, buildMs });
 const ctx: ServerContext = { vaultRoot, index, notes, backlinks };
 
 const watcher = startWatcher(ctx, log);
-process.on('exit', watcher.stop);
+// Exit handlers must stay synchronous — kick off the close; nothing awaits it.
+process.on('exit', () => void watcher.stop());
 
 const server = new Server({ name: 'seekstone', version: VERSION }, { capabilities: { tools: {} } });
 

--- a/packages/server/src/watcher.test.ts
+++ b/packages/server/src/watcher.test.ts
@@ -21,12 +21,42 @@ function freshCtx(vaultRoot: string): ServerContext {
   return { vaultRoot, index, notes: new Map(), backlinks: new Map() };
 }
 
-async function waitFor(condition: () => boolean, timeoutMs = 60_000): Promise<void> {
+interface WaitForOpts {
+  timeoutMs?: number;
+  /**
+   * Invoked every ~2s while still waiting. Used by the file-creation tests to
+   * write a new uniquely-named sibling file: under usePolling, chokidar only
+   * rescans a directory when its mtime changes, and NTFS directory mtime
+   * updates on entry create/delete/rename — not on content writes. On slow
+   * Windows runners a single create can slip through a poll tick and stay
+   * invisible forever (the SHA-242 flake, rawEvents=(none) after 60s). Each
+   * nudge adds a fresh directory transition, so the rescan discovers the
+   * missed target. A genuine event-silencing bug (e.g. the SHA-144 8.3-path
+   * regression) still fails: nudges change the directory, but silenced
+   * watchers deliver nothing regardless.
+   */
+  nudge?: () => Promise<void>;
+}
+
+async function waitFor(condition: () => boolean, opts: WaitForOpts = {}): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 60_000;
   const deadline = Date.now() + timeoutMs;
+  let ticks = 0;
   while (!condition()) {
     if (Date.now() > deadline) throw new Error('waitFor timeout');
+    ticks += 1;
+    if (opts.nudge && ticks % 100 === 0) await opts.nudge();
     await new Promise((r) => setTimeout(r, 20));
   }
+}
+
+/** Nudge helper: create a new (non-.md, so never indexed) sibling per call. */
+function dirNudger(dir: string): () => Promise<void> {
+  let n = 0;
+  return async () => {
+    n += 1;
+    await writeFile(join(dir, `nudge-${n}.tmp`), String(n), 'utf8');
+  };
 }
 
 beforeEach(async () => {
@@ -53,7 +83,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
         true,
       );
     } finally {
-      stop();
+      await stop();
     }
   });
 
@@ -69,7 +99,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       );
       expect(ctx.notes.get('watch-mod.md')?.body).toContain('new_unique_modified_xyz');
     } finally {
-      stop();
+      await stop();
     }
   });
 
@@ -97,7 +127,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       await waitFor(() => !ctx.notes.has('watch-del.md'));
       expect(ctx.notes.has('watch-del.md')).toBe(false);
     } finally {
-      stop();
+      await stop();
     }
   });
 
@@ -117,7 +147,9 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       await new Promise((r) => setImmediate(r));
       await writeFile(join(tmpDir, 'a', 'b', 'c', 'deep.md'), 'nested_unique_def', 'utf8');
       try {
-        await waitFor(() => ctx.notes.has('a/b/c/deep.md'));
+        await waitFor(() => ctx.notes.has('a/b/c/deep.md'), {
+          nudge: dirNudger(join(tmpDir, 'a', 'b', 'c')),
+        });
       } catch {
         throw new Error(
           `waitFor timeout — diagnostics:\n  platform=${process.platform} sep=${JSON.stringify(sep)}\n  vaultRoot=${tmpDir}\n  ctx.notes keys=[${[...ctx.notes.keys()].join(', ')}]\n  rawEvents(${rawEvents.length}):\n    ${rawEvents.join('\n    ') || '(none)'}`,
@@ -125,7 +157,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       }
       expect(ctx.notes.get('a/b/c/deep.md')?.body).toContain('nested_unique_def');
     } finally {
-      stop();
+      await stop();
     }
   });
 
@@ -143,7 +175,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       await new Promise((r) => setImmediate(r));
       await writeFile(join(spaced, 'spaced note.md'), 'spaced_unique_ghi', 'utf8');
       try {
-        await waitFor(() => ctx.notes.has('spaced note.md'));
+        await waitFor(() => ctx.notes.has('spaced note.md'), { nudge: dirNudger(spaced) });
       } catch {
         throw new Error(
           `waitFor timeout — diagnostics:\n  platform=${process.platform} sep=${JSON.stringify(sep)}\n  vaultRoot=${spaced}\n  ctx.notes keys=[${[...ctx.notes.keys()].join(', ')}]\n  rawEvents(${rawEvents.length}):\n    ${rawEvents.join('\n    ') || '(none)'}`,
@@ -151,7 +183,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       }
       expect(ctx.notes.get('spaced note.md')?.body).toContain('spaced_unique_ghi');
     } finally {
-      stop();
+      await stop();
     }
   });
 
@@ -178,7 +210,7 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
         events.some((e) => e.msg === 'index updated' && e.fields?.path === 'watch-log.md'),
       ).toBe(true);
     } finally {
-      stop();
+      await stop();
     }
   });
 
@@ -191,15 +223,13 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       await new Promise((r) => setTimeout(r, 150));
       expect(ctx.notes.size).toBe(0);
     } finally {
-      stop();
+      await stop();
     }
   });
 
-  it('returns a stop function that closes the watcher', () => {
+  it('returns a stop function whose promise resolves once the watcher closes', async () => {
     const ctx = freshCtx(tmpDir);
     const { stop } = startWatcher(ctx, undefined, { usePolling: true });
-    expect(() => {
-      stop();
-    }).not.toThrow();
+    await expect(stop()).resolves.toBeUndefined();
   });
 });

--- a/packages/server/src/watcher.ts
+++ b/packages/server/src/watcher.ts
@@ -19,7 +19,13 @@ import type { Logger } from './log.js';
  * resolves once chokidar has finished its initial scan and is live.
  */
 export interface WatcherHandle {
-  stop: () => void;
+  /**
+   * Close the watcher. Returns chokidar's close promise so callers that need
+   * deterministic teardown (tests, especially under usePolling where every
+   * watched path holds a live stat-poll timer) can await full shutdown;
+   * fire-and-forget callers may ignore the result.
+   */
+  stop: () => Promise<void>;
   ready: Promise<void>;
 }
 
@@ -161,7 +167,7 @@ export function startWatcher(
   });
 
   return {
-    stop: () => void watcher.close(),
+    stop: () => watcher.close(),
     ready,
   };
 }


### PR DESCRIPTION
Closes SHA-242 — both flakes root-caused, no blanket retries.

## Flake 1 — macOS `prepareSafetyVault` ENOENT

**Root cause:** `copyVault`'s default destination was `seekstone-safety-${Date.now()}` — millisecond resolution. `copy.test.ts` and `runner.test.ts` run in parallel vitest workers and both call `copyVault` with the default label; same-ms starts shared one destination (`mkdir {recursive}` merges silently), and whichever test finished first `rm -rf`'d the shared dir out from under the other's in-flight `fs.cp` → the spurious `ENOENT: copyfile`.

**Fix:** default destinations now come from `mkdtemp` — atomic and collision-free. Explicit `label` behavior unchanged (CLI path). If the paranoia guards fire on an mkdtemp destination, the just-created scratch dir is removed before throwing.

**Regression test:** three concurrent default-label copies → distinct roots, and deleting one leaves the others intact.

## Flake 2 — Windows watcher 'vault path containing spaces' timeout

**Diagnosis from the failing run (28822063594):** `rawEvents(0): (none)` — chokidar emitted nothing for 60s. This is *post*-SHA-144 (realpath fix landed 06-11, failure on 07-06), so it's a second failure mode: under `usePolling`, chokidar rescans a directory only when its mtime changes; a single file-create can slip past a poll tick on a slow runner and stay invisible forever (NTFS dir mtime changes on create/delete/rename only — later content writes to the missed file never wake the dir poller).

**Fix (test-side hardening, per the issue's framing):** the two create-detection tests nudge every ~2s by writing a new uniquely-named **non-.md sibling** — each nudge is a fresh directory transition that forces a rescan, which then discovers the missed target. Crucially this does **not** mask real bugs: an event-silencing regression (like the pre-SHA-144 8.3-path bug) delivers nothing regardless of nudges and still times out with full diagnostics.

**Plus a real product-code fix:** `WatcherHandle.stop()` fire-and-forgot `watcher.close()`; under polling every watched path holds a live stat-poll timer, so each test leaked pollers into the next. `stop()` now returns chokidar's close promise; tests await it; the server's `process.on('exit')` handler stays synchronous.

## Verification

- Full suite green across all workspaces (206 + 316 + 6 tests)
- Safety + watcher suites stress-run **10× locally on macOS: 10/10 green**
- Typecheck (server + harness) and biome clean
- Windows proof = this PR's matrix; acceptance calls for surviving a 5× rerun — I'll rerun the matrix from the PR to demonstrate