### PR TITLE
chore: align package description with README wedge (SHA-244)

### DIFF
--- a/.changeset/wise-pandas-cheer.md
+++ b/.changeset/wise-pandas-cheer.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+npm description now matches the README wedge: no plugin, no running Obsidian app, filesystem-direct with single-digit-ms search and ~2 KB payloads across 17 tools. Replaces the stale pre-benchmark-refresh "575×" phrasing.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.0",
   "mcpName": "io.github.shaqmughal/seekstone",
   "type": "module",
-  "description": "Obsidian MCP server for Claude — filesystem-direct vault access, 575× smaller payloads than the REST plugin.",
+  "description": "The Obsidian MCP server that needs no plugin, no running Obsidian app — and doesn't blow your context window. Filesystem-direct: single-digit-ms search, ~2 KB payloads, 17 tools.",
   "keywords": [
     "obsidian",
     "obsidian-mcp",


### PR DESCRIPTION
Closes SHA-244.

The npm `description` still carried the pre-benchmark-refresh "575× smaller payloads" phrasing. It now matches the README hero and the GitHub repo description (updated 07-11) verbatim — npm search snippets lead with the wedge: no plugin, no running Obsidian app, filesystem-direct, single-digit-ms search, ~2 KB payloads, 17 tools.

`@seekstone/core` is private and its description is accurate — unchanged.

Patch changeset included; intended to ride the open Version Packages PR (#189) so the refreshed description is live on npm before Tuesday's coordinated launch (SHA-223).