### PR TITLE
docs: add star CTA to README (SHA-59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ After installing, restart the client. On startup Seekstone walks the vault, buil
 
 Requires [Node.js](https://nodejs.org) ≥ 22 for the CLI options. The one-click `.mcpb` bundle has no external requirements.
 
+If Seekstone saves you context, consider [⭐ starring the repo](https://github.com/shaqmughal/seekstone) — it helps others find it.
+
 ---
 
 ## What can Claude do with your vault?


### PR DESCRIPTION
Adds the one-line star CTA from SHA-59 at the end of the install section — subtle, value-first phrasing per the ticket ("keep it subtle — one line, not a banner").

Linear: SHA-59

🤖 Generated with [Claude Code](https://claude.com/claude-code)