### PR TITLE
fix(cli): init --help prints help instead of running vault detection (SHA-263)

### DIFF
--- a/.changeset/witty-mails-help.md
+++ b/.changeset/witty-mails-help.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+`seekstone init --help` (and `-h`) now prints the init subcommand's usage — its `--vault`, `--client`, and `--write` flags — instead of ignoring the flag and running the init flow (vault auto-detection). Help flags after `init` were previously swallowed by init's own argument parsing.

--- a/packages/server/src/cli-args.test.ts
+++ b/packages/server/src/cli-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { helpText, parseCliIntent } from './cli-args.js';
+import { helpText, initHelpText, parseCliIntent } from './cli-args.js';
 
 describe('parseCliIntent', () => {
   it('returns "run" with no args', () => {
@@ -29,6 +29,12 @@ describe('parseCliIntent', () => {
     expect(parseCliIntent(['init'])).toBe('init');
     expect(parseCliIntent(['init', '--vault', '/x', '--write'])).toBe('init');
   });
+
+  it('init --help / init -h ask for init help, not the init run path', () => {
+    expect(parseCliIntent(['init', '--help'])).toBe('init-help');
+    expect(parseCliIntent(['init', '-h'])).toBe('init-help');
+    expect(parseCliIntent(['init', '--vault', '/x', '--help'])).toBe('init-help');
+  });
 });
 
 describe('helpText', () => {
@@ -41,5 +47,16 @@ describe('helpText', () => {
 
   it('documents the init subcommand', () => {
     expect(helpText('1.2.3')).toContain('seekstone init');
+  });
+});
+
+describe('initHelpText', () => {
+  it('includes the version and every init flag', () => {
+    const text = initHelpText('1.2.3');
+    expect(text).toContain('seekstone 1.2.3');
+    expect(text).toContain('seekstone init');
+    expect(text).toContain('--vault');
+    expect(text).toContain('--client');
+    expect(text).toContain('--write');
   });
 });

--- a/packages/server/src/cli-args.ts
+++ b/packages/server/src/cli-args.ts
@@ -5,17 +5,30 @@
  * CLI installed via `npx`.
  */
 
-export type CliIntent = 'version' | 'help' | 'init' | 'run';
+export type CliIntent = 'version' | 'help' | 'init' | 'init-help' | 'run';
 
 export function parseCliIntent(argv: readonly string[]): CliIntent {
-  // A subcommand, if present, is the first non-flag token.
-  if (argv[0] === 'init') return 'init';
+  // A subcommand, if present, is the first non-flag token. A help flag after
+  // the subcommand asks for the subcommand's help, so it must be recognised
+  // here — before the init run path — not swallowed by init's own arg parsing.
+  if (argv[0] === 'init') {
+    for (const arg of argv.slice(1)) {
+      if (arg === '--help' || arg === '-h') return 'init-help';
+    }
+    return 'init';
+  }
   for (const arg of argv) {
     if (arg === '--version' || arg === '-v') return 'version';
     if (arg === '--help' || arg === '-h') return 'help';
   }
   return 'run';
 }
+
+// Shared between the top-level help and `seekstone init --help` so the two
+// can't drift apart.
+const initOptionLines = `  --vault <path>       Vault to use (auto-detected from Obsidian if omitted; fallback: $SEEKSTONE_VAULT)
+  --client <name>      desktop (default) | code | cursor | vscode
+  --write              Patch the client config in place (backs it up first)`;
 
 export function helpText(version: string): string {
   return `seekstone ${version} — an Obsidian MCP server (filesystem-direct, low context-tax)
@@ -30,9 +43,7 @@ Usage:
   seekstone --help     Print this help and exit
 
 "seekstone init" options:
-  --vault <path>       Vault to use (auto-detected from Obsidian if omitted; fallback: $SEEKSTONE_VAULT)
-  --client <name>      desktop (default) | code | cursor | vscode
-  --write              Patch the client config in place (backs it up first)
+${initOptionLines}
 
 Required environment:
   SEEKSTONE_VAULT      Absolute path to your Obsidian vault
@@ -44,6 +55,26 @@ Optional environment:
 
 Add to Claude Code:
   claude mcp add seekstone --env SEEKSTONE_VAULT=/path/to/vault -- npx -y seekstone
+
+Docs: https://github.com/shaqmughal/seekstone`;
+}
+
+export function initHelpText(version: string): string {
+  return `seekstone ${version} — seekstone init
+
+Validate an Obsidian vault and print (or, with --write, patch) the MCP config
+for the chosen client (Claude Desktop, Claude Code, Cursor, VS Code).
+
+Usage:
+  seekstone init [options]
+
+Options:
+${initOptionLines}
+  --help, -h           Print this help and exit
+
+Examples:
+  seekstone init
+  seekstone init --vault "/Users/you/Obsidian/My Vault" --client code --write
 
 Docs: https://github.com/shaqmughal/seekstone`;
 }

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,0 +1,79 @@
+// execFileSync bypasses the shell entirely (see the note in init.ts) — these
+// tests spawn the real CLI entry, not a shell line.
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * Black-box tests for the bin entry's help handling (SHA-263): `seekstone init
+ * --help` must print init's usage and exit 0 — it must NOT enter the init run
+ * path (vault auto-detection) or touch the filesystem.
+ *
+ * Each run gets an empty scratch HOME with no Obsidian registry and no
+ * SEEKSTONE_VAULT, so if the init flow *did* run it would fail with
+ * "No vault specified" and exit 1 — the assertions below would catch it.
+ */
+
+const serverDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+let scratchHome: string;
+
+beforeEach(() => {
+  scratchHome = mkdtempSync(join(tmpdir(), 'seekstone-cli-help-'));
+});
+
+afterEach(() => {
+  rmSync(scratchHome, { recursive: true, force: true });
+});
+
+function runCli(args: string[]): string {
+  // Throws on non-zero exit, which fails the test — exit 0 is asserted for free.
+  return execFileSync(process.execPath, ['--import', 'tsx', 'src/index.ts', ...args], {
+    cwd: serverDir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: scratchHome,
+      APPDATA: join(scratchHome, 'AppData', 'Roaming'),
+      SEEKSTONE_VAULT: undefined,
+    },
+  });
+}
+
+describe('seekstone init --help (subprocess)', () => {
+  for (const flag of ['--help', '-h']) {
+    it(`"init ${flag}" prints init usage and exits 0 without running vault detection`, () => {
+      const out = runCli(['init', flag]);
+
+      // Init's own usage, with all three flags documented.
+      expect(out).toContain('seekstone init');
+      expect(out).toContain('--vault');
+      expect(out).toContain('--client');
+      expect(out).toContain('--write');
+
+      // No trace of the init run path (vault auto-detection / validation).
+      expect(out).not.toContain('No vault specified');
+      expect(out).not.toContain('Multiple Obsidian vaults');
+      expect(out).not.toContain('Vault looks good');
+
+      // Nothing was written under the scratch HOME.
+      expect(readdirSync(scratchHome)).toEqual([]);
+    });
+  }
+
+  it('help flags placed after other init options still win', () => {
+    const out = runCli(['init', '--vault', join(scratchHome, 'nope'), '--help']);
+    expect(out).toContain('--client');
+    expect(out).not.toContain('does not exist');
+    expect(readdirSync(scratchHome)).toEqual([]);
+  });
+
+  it('top-level --help still prints the general help', () => {
+    const out = runCli(['--help']);
+    expect(out).toContain('Start the MCP server');
+    expect(out).toContain('seekstone init');
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,7 +6,7 @@ import {
   type CallToolResult,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { helpText, parseCliIntent } from './cli-args.js';
+import { helpText, initHelpText, parseCliIntent } from './cli-args.js';
 import type { ServerContext } from './context.js';
 import { dispatch } from './dispatch.js';
 import { buildIndex } from './index/build.js';
@@ -28,6 +28,10 @@ if (intent === 'version') {
 }
 if (intent === 'help') {
   process.stdout.write(`${helpText(VERSION)}\n`);
+  process.exit(0);
+}
+if (intent === 'init-help') {
+  process.stdout.write(`${initHelpText(VERSION)}\n`);
   process.exit(0);
 }
 if (intent === 'init') {


### PR DESCRIPTION
## Problem

`npx -y seekstone init --help` (and `-h`) ignored the help flag and ran the init flow — vault auto-detection from Obsidian's registry — instead of printing usage for the `init` subcommand. Root cause: `parseCliIntent` returned `'init'` as soon as `argv[0] === 'init'`, before the `--help`/`-h` scan ran, and `parseInitArgs` silently ignored unknown flags. `init` is the only subcommand, so no other subcommands share the gap.

## Fix

- `parseCliIntent` now recognises `--help`/`-h` anywhere after `init` and returns a new `'init-help'` intent, handled in `index.ts` before the init run path (exit 0).
- New `initHelpText()` prints init-specific usage (`--vault`, `--client`, `--write`); the option lines are shared with the top-level help so the two can't drift.

## Tests

- Unit tests for the new intent and `initHelpText` in `cli-args.test.ts`.
- New black-box subprocess tests (`index.test.ts`): `init --help` / `init -h` print init usage mentioning all three flags, exit 0, show no trace of vault detection, and write nothing under a scratch $HOME; also covers help flags after other init options and top-level `--help`.

All workspace tests, `tsc --noEmit` (server), and biome lint pass locally. Changeset included (patch).

Fixes SHA-263