### PR TITLE
feat(cli): one-prompt agent install + error on unknown --client (SHA-260)

### DIFF
--- a/.changeset/great-crabs-greet.md
+++ b/.changeset/great-crabs-greet.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+`seekstone init` now errors on an unknown `--client` value instead of silently configuring Claude Desktop — agents running the one-prompt install get a clear failure they can relay. Docs gain a copy-pasteable agent install prompt (README + llms.txt), and llms.txt catches up to the 17-tool surface (adds `query_notes`).

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ Every competitor spawns a subprocess or makes HTTP round-trips per query, and mo
 
 Choose the method that suits you best.
 
+### Using an AI agent? Paste this prompt
+
+If you use Claude Code, Cursor, or another coding agent, you don't need to follow any instructions yourself — paste this prompt and the agent does the install:
+
+> Install the **seekstone** MCP server for this editor. Run `npx -y seekstone init --client code --write` (use `desktop`, `cursor`, or `vscode` for other clients). It auto-detects my Obsidian vault; if it lists several, ask me which one and re-run with `--vault "<path>"`. Relay any errors to me, then tell me to restart this session so the seekstone tools load.
+
+`seekstone init` is fully non-interactive — with `--write` it validates the vault and patches the client config in one shot (Claude Code via `claude mcp add`, other clients via an additive JSON patch with a timestamped backup).
+
 ### Option 1 — One-click (Claude Desktop, no terminal needed)
 
 1. Download `seekstone.mcpb` from [GitHub Releases](https://github.com/shaqmughal/seekstone/releases/latest)

--- a/llms.txt
+++ b/llms.txt
@@ -6,6 +6,14 @@ Website: https://seekstone.dev
 
 Seekstone is published to npm as `seekstone`. (It was previously also published as `obsidian-mcp-seekstone`; that alias is deprecated — existing installs keep working but it no longer receives updates.)
 
+## One-prompt install for agents
+
+A user can paste this prompt into any coding agent (Claude Code, Cursor, Windsurf) and the agent can install seekstone unattended:
+
+> Install the **seekstone** MCP server for this editor. Run `npx -y seekstone init --client code --write` (use `desktop`, `cursor`, or `vscode` for other clients). It auto-detects my Obsidian vault; if it lists several, ask me which one and re-run with `--vault "<path>"`. Relay any errors to me, then tell me to restart this session so the seekstone tools load.
+
+`seekstone init` is fully non-interactive: `--write` applies the config (Claude Code via `claude mcp add`, other clients via an additive JSON patch with a timestamped backup); without `--write` it only prints the config. Exit code 0 on success, 1 with a `✗`-prefixed reason on failure. An unknown `--client` value is an error, not a silent fallback.
+
 ## Why filesystem-direct?
 
 Routing through the Obsidian Local REST API plugin returns ~1.75 MB (~459,000 tokens) for a typical search. Seekstone returns ~2 KB (~580 tokens) for the same query — a ~800× reduction. Claude can search an entire vault without burning its context window on a single tool call.
@@ -40,10 +48,11 @@ npx -y seekstone init --client cursor --write
 
 Or add the same `mcpServers` JSON block as Claude Desktop to `~/.cursor/mcp.json`. Any other MCP-over-stdio client (VS Code/Copilot, Windsurf, Cline, Continue, JetBrains, Zed) takes the identical block in its own MCP config file.
 
-## Tools (16)
+## Tools (17)
 
 Read:
 - `search` — full-text search returning ranked excerpts, ~120 chars by default and tunable (not full notes)
+- `query_notes` — structured metadata query: filter notes by frontmatter key/value predicates, tag, folder, modified time, and size; returns compact rows (path + title by default), not note content
 - `read_note` — read the full content of a note by vault-relative path; supports section, block, or line-range slices
 - `list_notes` — list notes filtered by folder prefix or tag
 - `list_tags` — list all tags sorted by usage count or alphabetically

--- a/packages/server/src/init.test.ts
+++ b/packages/server/src/init.test.ts
@@ -35,8 +35,13 @@ describe('parseInitArgs', () => {
   it('parses --client vscode', () => {
     expect(parseInitArgs(['--client', 'vscode']).client).toBe('vscode');
   });
-  it('ignores an invalid --client value (keeps default)', () => {
-    expect(parseInitArgs(['--client', 'nonsense']).client).toBe('desktop');
+  it('records an invalid --client value for runInit to reject', () => {
+    const opts = parseInitArgs(['--client', 'nonsense']);
+    expect(opts.client).toBe('desktop');
+    expect(opts.invalidClient).toBe('nonsense');
+  });
+  it('records a missing --client value', () => {
+    expect(parseInitArgs(['--client']).invalidClient).toBe('(missing)');
   });
 });
 
@@ -270,6 +275,17 @@ describe('runInit', () => {
     const res = await runInit({ write: false, client: 'desktop' }, deps());
     expect(res.exitCode).toBe(1);
     expect(res.output.join('\n')).toContain('No vault specified');
+  });
+
+  it('errors with exit 1 on an unknown --client instead of configuring desktop', async () => {
+    const res = await runInit(
+      { vault, write: false, client: 'desktop', invalidClient: 'windsurf' },
+      deps(),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.exitCode).toBe(1);
+    expect(res.output.join('\n')).toContain('Unknown --client: windsurf');
+    expect(res.output.join('\n')).toContain('desktop, code, cursor, vscode');
   });
 
   it('errors with exit 1 for a non-vault directory', async () => {

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -22,6 +22,8 @@ export interface InitOptions {
   vault?: string;
   write: boolean;
   client: 'desktop' | 'code' | 'cursor' | 'vscode';
+  /** Set when --client was given an unrecognized value; runInit errors on it. */
+  invalidClient?: string;
 }
 
 export function parseInitArgs(argv: readonly string[]): InitOptions {
@@ -34,6 +36,10 @@ export function parseInitArgs(argv: readonly string[]): InitOptions {
     else if (a === '--client') {
       const v = argv[++i];
       if (v === 'desktop' || v === 'code' || v === 'cursor' || v === 'vscode') opts.client = v;
+      // Record the bad value instead of silently falling back to desktop —
+      // agents run init non-interactively and would otherwise configure the
+      // wrong client without anyone noticing.
+      else opts.invalidClient = v ?? '(missing)';
     }
   }
   return opts;
@@ -280,6 +286,16 @@ export async function runInit(
     spawnClaudeMcp?: (args: string[]) => { ok: boolean; error?: string };
   },
 ): Promise<InitResult> {
+  if (opts.invalidClient !== undefined) {
+    return {
+      ok: false,
+      exitCode: 1,
+      output: [
+        `✗ Unknown --client: ${opts.invalidClient}. Known clients: desktop, code, cursor, vscode.`,
+      ],
+    };
+  }
+
   const rf = deps.readFile ?? readFile;
   let vaultPath = opts.vault ?? deps.env.SEEKSTONE_VAULT;
 


### PR DESCRIPTION
Closes [SHA-260](https://linear.app/shaqster/issue/SHA-260).

MCP servers are increasingly installed by agents, not humans — obsidian-mcp-rs leads its README with exactly this pattern. This PR adds our canonical paste-to-your-agent prompt and hardens `seekstone init` for unattended runs.

## Changes

- **README**: new "Using an AI agent? Paste this prompt" block at the top of the Install section, ahead of the human options. The prompt uses `npx -y seekstone init --client code --write` and leans on the shipped vault auto-detection (SHA-44), with a fallback instruction for the multiple-vault case.
- **llms.txt**: same prompt block in a "One-prompt install for agents" section — when a user asks their model how to install seekstone, the model can reproduce the working prompt verbatim (GEO). Also fixed drift: the tool list said 16 and was missing `query_notes`; it now matches the 17-tool surface.
- **init hardening**: an unknown `--client` value now exits 1 with `✗ Unknown --client: <v>. Known clients: desktop, code, cursor, vscode.` instead of silently configuring Claude Desktop — the exact failure mode an agent-driven install would hit without noticing (e.g. `--client windsurf`).

## Verification

- Unit tests for the new parse behavior (invalid + missing `--client` value) and the runInit rejection; full server suite green (324 tests).
- Real-CLI smoke: `init --client windsurf` → exit 1 with the error; `init --client cursor --vault <tmp>` → normal output.
- Scripted init E2E deliberately deferred: the injectable-spawn unit tests + `claude-code-e2e.sh` + `smoke-install.mjs` already cover adjacent live paths; a live init E2E adds CI flake for little marginal proof.

Changeset: patch.

Follow-up (separate marketing PR, different repo): mirror the prompt block on seekstone.dev 1:1.