### PR TITLE
feat(server): link-aware moves — move_note rewrites references (SHA-249)

### DIFF
--- a/.changeset/proud-poets-brake.md
+++ b/.changeset/proud-poets-brake.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+Link-aware moves: `move_note` now rewrites wikilinks, embeds, and relative/vault-absolute markdown links in other notes that pointed at the moved note, so a move or rename no longer orphans it in the graph. Links that still resolve after the move (unchanged, unambiguous basename) are left byte-identical; aliases, `#fragments`, embed prefixes, and `%20`/`<...>` encodings are preserved; fenced code blocks are skipped. The tool reports how many links in how many notes were updated, `rewriteLinks: false` restores the old move-only behavior, and referencing notes outside `SEEKSTONE_WRITE_PATHS` are skipped and reported rather than blocking the move. Also fixes a pre-existing gap where the moved note's own outgoing links stayed registered in the backlink index under its old path.

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Claude never sees your full vault at once — it searches and reads selectively,
 |---|---|
 | `create_note` | Create a note (optional frontmatter + body); parent directories are created automatically. |
 | `delete_note` | Permanently delete a note. **Irreversible.** |
-| `move_note` | Move or rename a note; destination directories are created automatically. |
+| `move_note` | Move or rename a note — wikilinks and markdown links in other notes that point at it are rewritten so nothing breaks (`rewriteLinks: false` to opt out); destination directories are created automatically. |
 | `append_note` | Append text to a note body without touching frontmatter. |
 | `patch_frontmatter` | Set, update, or delete frontmatter keys without reordering existing keys or changing quote style. |
 | `patch_note` | Insert text immediately after a heading without touching frontmatter. |

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ Read:
 Write:
 - `create_note` — create a note with optional frontmatter and body
 - `delete_note` — permanently delete a note
-- `move_note` — move or rename a note
+- `move_note` — move or rename a note, rewriting wikilinks and markdown links in other notes that point at it (link-aware; `rewriteLinks: false` to opt out)
 - `append_note` — append text to a note body without touching frontmatter
 - `patch_frontmatter` — set, update, or delete frontmatter keys while preserving key order and quote style
 - `patch_note` — insert text immediately after a heading

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -202,7 +202,13 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
     case 'move_note': {
       const input = MoveNoteInput.parse(args);
       const result = await moveNote(ctx, input);
-      return { content: [{ type: 'text', text: `Moved ${result.from} → ${result.to}.` }] };
+      let text = `Moved ${result.from} → ${result.to}. Rewrote ${result.linksRewritten} link${
+        result.linksRewritten === 1 ? '' : 's'
+      } in ${result.notesRewritten} note${result.notesRewritten === 1 ? '' : 's'}.`;
+      if (result.skipped?.length) {
+        text += ` Skipped (outside SEEKSTONE_WRITE_PATHS): ${result.skipped.join(', ')}.`;
+      }
+      return { content: [{ type: 'text', text }] };
     }
     case 'append_note': {
       const input = AppendNoteInput.parse(args);

--- a/packages/server/src/index/backlinks.ts
+++ b/packages/server/src/index/backlinks.ts
@@ -1,0 +1,41 @@
+import { extractLinksWithLines } from '@seekstone/core/extract';
+import type { BacklinkRef, ServerContext } from '../context.js';
+import { resolveLink } from './resolve.js';
+
+/**
+ * Incremental backlink-index maintenance, shared by the watcher and the
+ * link-aware move path. Remove BEFORE mutating the note's entry in ctx.notes
+ * (it reads the old raw); add AFTER the entry is current.
+ */
+
+export function removeNoteBacklinks(ctx: ServerContext, relPath: string): void {
+  const oldDoc = ctx.notes.get(relPath);
+  if (oldDoc === undefined) return;
+  for (const link of extractLinksWithLines(oldDoc.raw)) {
+    const resolved = resolveLink(link.target, ctx.notes);
+    if (resolved === undefined) continue;
+    const arr = ctx.backlinks.get(resolved);
+    if (arr === undefined) continue;
+    const filtered = arr.filter((r) => r.path !== relPath);
+    ctx.backlinks.set(resolved, filtered);
+  }
+}
+
+export function addNoteBacklinks(ctx: ServerContext, relPath: string, raw: string): void {
+  const seen = new Set<string>();
+  for (const link of extractLinksWithLines(raw)) {
+    const resolved = resolveLink(link.target, ctx.notes);
+    if (resolved === undefined) continue;
+    const dedupeKey = `${relPath}\0${resolved}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    let arr = ctx.backlinks.get(resolved);
+    if (arr === undefined) {
+      arr = [];
+      ctx.backlinks.set(resolved, arr);
+    }
+    const ref: BacklinkRef = { path: relPath, line: link.line, linkType: link.linkType };
+    arr.push(ref);
+    arr.sort((a, b) => a.path.localeCompare(b.path));
+  }
+}

--- a/packages/server/src/tool-list.ts
+++ b/packages/server/src/tool-list.ts
@@ -200,7 +200,7 @@ export const ALL_TOOLS = [
   {
     name: 'move_note',
     description:
-      'Move or rename a note to a new vault-relative path. Parent directories at the destination are created automatically. Fails if the destination already exists unless overwrite is true.',
+      'Move or rename a note to a new vault-relative path, rewriting wikilinks and markdown links in other notes that point at it so nothing breaks (links inside fenced code blocks are left alone). Parent directories at the destination are created automatically. Fails if the destination already exists unless overwrite is true.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -209,6 +209,11 @@ export const ALL_TOOLS = [
         overwrite: {
           type: 'boolean',
           description: 'Overwrite destination if it exists. Defaults to false.',
+        },
+        rewriteLinks: {
+          type: 'boolean',
+          description:
+            'Rewrite references in other notes to follow the move. Defaults to true; pass false to move the file only.',
         },
       },
       required: ['from', 'to'],

--- a/packages/server/src/tools/move_note.test.ts
+++ b/packages/server/src/tools/move_note.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import MiniSearch from 'minisearch';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ServerContext } from '../context.js';
+import { addNoteBacklinks } from '../index/backlinks.js';
 import type { IndexedNote } from '../index/types.js';
 import { PERMISSIVE_POLICY } from '../policy.js';
 import { moveNote } from './move_note.js';
@@ -25,6 +26,23 @@ function freshCtx(): ServerContext {
     backlinks: new Map(),
     policy: PERMISSIVE_POLICY,
   };
+}
+
+function seedInto(target: ServerContext, relPath: string, raw: string): IndexedNote {
+  const doc: IndexedNote = {
+    id: relPath,
+    title: relPath,
+    body: raw,
+    tags: '',
+    fmKeys: '',
+    fm: null,
+    raw,
+    sizeBytes: Buffer.byteLength(raw, 'utf8'),
+    mtimeMs: Date.now(),
+  };
+  target.notes.set(relPath, doc);
+  target.index.add(doc);
+  return doc;
 }
 
 function seedNote(relPath: string, raw: string): IndexedNote {
@@ -123,6 +141,130 @@ describe('moveNote', () => {
     await expect(moveNote(ctx, { from: 'legit.md', to: '../escape.md' })).rejects.toThrow(
       'Path outside vault',
     );
+  });
+
+  it('rewrites a referencing wikilink when the basename changes', async () => {
+    const localCtx = freshCtx();
+    await mkdir(join(tmpDir, 'lw'), { recursive: true });
+    await writeFile(join(tmpDir, 'lw/target.md'), '# Target', 'utf8');
+    await writeFile(
+      join(tmpDir, 'lw/ref.md'),
+      'See [[target|the note]] and ![[target#Sec]].',
+      'utf8',
+    );
+    seedInto(localCtx, 'lw/target.md', '# Target');
+    seedInto(localCtx, 'lw/ref.md', 'See [[target|the note]] and ![[target#Sec]].');
+    addNoteBacklinks(localCtx, 'lw/ref.md', localCtx.notes.get('lw/ref.md')?.raw ?? '');
+
+    const result = await moveNote(localCtx, { from: 'lw/target.md', to: 'lw/renamed.md' });
+
+    expect(result.notesRewritten).toBe(1);
+    expect(result.linksRewritten).toBe(2);
+    const disk = await readFile(join(tmpDir, 'lw/ref.md'), 'utf8');
+    expect(disk).toBe('See [[renamed|the note]] and ![[renamed#Sec]].');
+    // Backlink index re-keyed: refs now live under the new path.
+    expect(localCtx.backlinks.get('lw/target.md')).toBeUndefined();
+    expect(localCtx.backlinks.get('lw/renamed.md')?.map((r) => r.path)).toEqual(['lw/ref.md']);
+    expect(localCtx.notes.get('lw/ref.md')?.raw).toContain('[[renamed|the note]]');
+  });
+
+  it('rewrites nothing on a folder move with unchanged, unambiguous basename', async () => {
+    const localCtx = freshCtx();
+    await mkdir(join(tmpDir, 'fm/sub'), { recursive: true });
+    await writeFile(join(tmpDir, 'fm/stable.md'), '# S', 'utf8');
+    await writeFile(join(tmpDir, 'fm/ref2.md'), 'Link: [[stable]].', 'utf8');
+    seedInto(localCtx, 'fm/stable.md', '# S');
+    seedInto(localCtx, 'fm/ref2.md', 'Link: [[stable]].');
+    addNoteBacklinks(localCtx, 'fm/ref2.md', 'Link: [[stable]].');
+
+    const result = await moveNote(localCtx, { from: 'fm/stable.md', to: 'fm/sub/stable.md' });
+
+    expect(result.notesRewritten).toBe(0);
+    expect(result.linksRewritten).toBe(0);
+    expect(await readFile(join(tmpDir, 'fm/ref2.md'), 'utf8')).toBe('Link: [[stable]].');
+    // Refs still re-keyed to the new path even though nothing was rewritten.
+    expect(localCtx.backlinks.get('fm/stable.md')).toBeUndefined();
+    expect(localCtx.backlinks.get('fm/sub/stable.md')?.map((r) => r.path)).toEqual(['fm/ref2.md']);
+  });
+
+  it('discovers and rewrites markdown-link references the backlink index cannot see', async () => {
+    const localCtx = freshCtx();
+    await mkdir(join(tmpDir, 'md'), { recursive: true });
+    await writeFile(join(tmpDir, 'md/doc.md'), '# D', 'utf8');
+    await writeFile(join(tmpDir, 'md/refmd.md'), 'Read [the doc](doc.md).', 'utf8');
+    seedInto(localCtx, 'md/doc.md', '# D');
+    seedInto(localCtx, 'md/refmd.md', 'Read [the doc](doc.md).');
+    // No backlink seeding on purpose — markdown links are not in the index.
+
+    const result = await moveNote(localCtx, { from: 'md/doc.md', to: 'md/archive/doc2.md' });
+
+    expect(result.notesRewritten).toBe(1);
+    expect(await readFile(join(tmpDir, 'md/refmd.md'), 'utf8')).toBe(
+      'Read [the doc](archive/doc2.md).',
+    );
+  });
+
+  it('leaves links in fenced code blocks untouched', async () => {
+    const localCtx = freshCtx();
+    await mkdir(join(tmpDir, 'fence'), { recursive: true });
+    const refRaw = '[[fenced-t]]\n```\n[[fenced-t]]\n```\n';
+    await writeFile(join(tmpDir, 'fence/fenced-t.md'), '#T', 'utf8');
+    await writeFile(join(tmpDir, 'fence/fref.md'), refRaw, 'utf8');
+    seedInto(localCtx, 'fence/fenced-t.md', '#T');
+    seedInto(localCtx, 'fence/fref.md', refRaw);
+    addNoteBacklinks(localCtx, 'fence/fref.md', refRaw);
+
+    const result = await moveNote(localCtx, { from: 'fence/fenced-t.md', to: 'fence/f2.md' });
+
+    expect(result.linksRewritten).toBe(1);
+    expect(await readFile(join(tmpDir, 'fence/fref.md'), 'utf8')).toBe(
+      '[[f2]]\n```\n[[fenced-t]]\n```\n',
+    );
+  });
+
+  it('rewriteLinks: false moves the file only', async () => {
+    const localCtx = freshCtx();
+    await mkdir(join(tmpDir, 'off'), { recursive: true });
+    await writeFile(join(tmpDir, 'off/t.md'), '#T', 'utf8');
+    await writeFile(join(tmpDir, 'off/r.md'), '[[t]]', 'utf8');
+    seedInto(localCtx, 'off/t.md', '#T');
+    seedInto(localCtx, 'off/r.md', '[[t]]');
+    addNoteBacklinks(localCtx, 'off/r.md', '[[t]]');
+
+    const result = await moveNote(localCtx, {
+      from: 'off/t.md',
+      to: 'off/renamed-t.md',
+      rewriteLinks: false,
+    });
+
+    expect(result.notesRewritten).toBe(0);
+    expect(await readFile(join(tmpDir, 'off/r.md'), 'utf8')).toBe('[[t]]');
+  });
+
+  it('skips and reports referencing notes outside the write-path allowlist', async () => {
+    const localCtx = freshCtx();
+    localCtx.policy = { readOnly: false, writeGlobs: ['scope/**'] };
+    await mkdir(join(tmpDir, 'scope'), { recursive: true });
+    await mkdir(join(tmpDir, 'outside'), { recursive: true });
+    await writeFile(join(tmpDir, 'scope/starget.md'), '#T', 'utf8');
+    await writeFile(join(tmpDir, 'scope/sref.md'), '[[starget]]', 'utf8');
+    await writeFile(join(tmpDir, 'outside/oref.md'), '[[starget]]', 'utf8');
+    seedInto(localCtx, 'scope/starget.md', '#T');
+    seedInto(localCtx, 'scope/sref.md', '[[starget]]');
+    seedInto(localCtx, 'outside/oref.md', '[[starget]]');
+    addNoteBacklinks(localCtx, 'scope/sref.md', '[[starget]]');
+    addNoteBacklinks(localCtx, 'outside/oref.md', '[[starget]]');
+
+    const result = await moveNote(localCtx, {
+      from: 'scope/starget.md',
+      to: 'scope/srenamed.md',
+    });
+
+    expect(result.notesRewritten).toBe(1);
+    expect(result.skipped).toEqual(['outside/oref.md']);
+    expect(await readFile(join(tmpDir, 'scope/sref.md'), 'utf8')).toBe('[[srenamed]]');
+    // Out-of-scope note untouched on disk — its stale link is reported, not modified.
+    expect(await readFile(join(tmpDir, 'outside/oref.md'), 'utf8')).toBe('[[starget]]');
   });
 
   it('rejects a move whose destination is outside the write-path allowlist', async () => {

--- a/packages/server/src/tools/move_note.ts
+++ b/packages/server/src/tools/move_note.ts
@@ -1,9 +1,11 @@
-import { access, mkdir, rename } from 'node:fs/promises';
+import { access, mkdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { z } from 'zod';
 import type { ServerContext } from '../context.js';
+import { addNoteBacklinks, removeNoteBacklinks } from '../index/backlinks.js';
 import { buildDoc, upsertDoc } from '../index/doc.js';
-import { assertWritable } from '../policy.js';
+import { assertWritable, isWritable } from '../policy.js';
+import { hasMarkdownLinkTo, rewriteNoteLinks } from './rewrite_links.js';
 
 export const MoveNoteInput = z.object({
   from: z.string().describe('Vault-relative path of the note to move.'),
@@ -12,15 +14,33 @@ export const MoveNoteInput = z.object({
     .boolean()
     .default(false)
     .describe('Overwrite the destination if it exists. Defaults to false.'),
+  rewriteLinks: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Rewrite wikilinks and markdown links in other notes that point at the moved note, so nothing breaks. Defaults to true; pass false to move the file only.',
+    ),
 });
 export type MoveNoteInput = z.input<typeof MoveNoteInput>;
 
 export interface MoveNoteResult {
   from: string;
   to: string;
+  /** Referencing notes whose content was rewritten. */
+  notesRewritten: number;
+  /** Individual links rewritten across those notes. */
+  linksRewritten: number;
+  /** Referencing notes left untouched because SEEKSTONE_WRITE_PATHS excludes them. */
+  skipped?: string[];
 }
 
-export async function moveNote(ctx: ServerContext, input: MoveNoteInput): Promise<MoveNoteResult> {
+export async function moveNote(
+  ctx: ServerContext,
+  rawInput: MoveNoteInput,
+): Promise<MoveNoteResult> {
+  // Parse here (not only in dispatch) so defaults like rewriteLinks apply to
+  // direct callers too — same pattern as periodic_note.
+  const input = MoveNoteInput.parse(rawInput);
   const absFrom = join(ctx.vaultRoot, input.from);
   const absTo = join(ctx.vaultRoot, input.to);
 
@@ -46,18 +66,81 @@ export async function moveNote(ctx: ServerContext, input: MoveNoteInput): Promis
     }
   }
 
+  // Snapshot pre-move state: link resolution before/after the move differs,
+  // and the rewriter needs both views to rewrite only what breaks.
+  const preNotes = new Map(ctx.notes);
+
+  // Candidate referencing notes: wikilink sources from the backlink index,
+  // plus a scan for markdown links (which the backlink index doesn't cover).
+  // The moved note's own outgoing links are untouched by design — wikilinks
+  // are path-independent, and rewriting its relative markdown links is a
+  // separate concern from "don't orphan the note in the graph".
+  const candidates = new Set<string>();
+  if (input.rewriteLinks) {
+    for (const ref of ctx.backlinks.get(input.from) ?? []) candidates.add(ref.path);
+    for (const [path, doc] of preNotes) {
+      if (path === input.from || candidates.has(path)) continue;
+      if (hasMarkdownLinkTo(doc.raw, path, input.from)) candidates.add(path);
+    }
+    candidates.delete(input.from);
+  }
+
   await mkdir(dirname(absTo), { recursive: true });
   await rename(absFrom, absTo);
 
-  // Grab raw before removing the old entry.
+  // Grab raw before removing the old entry, and clear the moved note's own
+  // outgoing backlink refs while its old entry is still readable — otherwise
+  // they stay registered under the stale source path forever.
   const raw = ctx.notes.get(input.from)?.raw ?? '';
+  removeNoteBacklinks(ctx, input.from);
 
-  // Remove old index entry.
   if (ctx.notes.has(input.from)) {
     ctx.index.discard(input.from);
     ctx.notes.delete(input.from);
   }
   upsertDoc(ctx, buildDoc(input.to, raw));
+  addNoteBacklinks(ctx, input.to, raw);
 
-  return { from: input.from, to: input.to };
+  let notesRewritten = 0;
+  let linksRewritten = 0;
+  const skipped: string[] = [];
+
+  for (const path of [...candidates].sort()) {
+    const doc = ctx.notes.get(path);
+    if (doc === undefined) continue;
+    if (!isWritable(ctx.policy, path)) {
+      // Out of write scope: leave the note untouched but report it, so the
+      // caller knows which references were NOT updated.
+      skipped.push(path);
+      continue;
+    }
+    const { content, count } = rewriteNoteLinks(
+      doc.raw,
+      path,
+      input.from,
+      input.to,
+      preNotes,
+      ctx.notes,
+    );
+    // Re-register this note's backlinks against post-move resolution even
+    // when nothing was rewritten (basename links now resolve to the new
+    // path); remove reads the old raw, so call it before updating the entry.
+    removeNoteBacklinks(ctx, path);
+    if (count > 0) {
+      await writeFile(join(ctx.vaultRoot, path), content, 'utf8');
+      upsertDoc(ctx, buildDoc(path, content));
+      notesRewritten++;
+      linksRewritten += count;
+      addNoteBacklinks(ctx, path, content);
+    } else {
+      addNoteBacklinks(ctx, path, doc.raw);
+    }
+  }
+
+  // Nothing resolves to the old path anymore — drop the stale key.
+  ctx.backlinks.delete(input.from);
+
+  const result: MoveNoteResult = { from: input.from, to: input.to, notesRewritten, linksRewritten };
+  if (skipped.length > 0) result.skipped = skipped;
+  return result;
 }

--- a/packages/server/src/tools/rewrite_links.test.ts
+++ b/packages/server/src/tools/rewrite_links.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { hasMarkdownLinkTo, rewriteNoteLinks } from './rewrite_links.js';
+
+/** Build pre/post note maps for a move of oldPath → newPath among `others`. */
+function maps(oldPath: string, newPath: string, others: string[] = []) {
+  const pre = new Map<string, unknown>([[oldPath, {}], ...others.map((p) => [p, {}] as const)]);
+  const post = new Map<string, unknown>([[newPath, {}], ...others.map((p) => [p, {}] as const)]);
+  return { pre, post };
+}
+
+describe('rewriteNoteLinks — wikilinks', () => {
+  it('rewrites a basename wikilink when the basename changes', () => {
+    const { pre, post } = maps('Old Name.md', 'New Name.md');
+    const r = rewriteNoteLinks(
+      'See [[Old Name]].',
+      'ref.md',
+      'Old Name.md',
+      'New Name.md',
+      pre,
+      post,
+    );
+    expect(r.content).toBe('See [[New Name]].');
+    expect(r.count).toBe(1);
+  });
+
+  it('leaves a basename wikilink byte-identical on a folder move (still resolves)', () => {
+    const { pre, post } = maps('Italy.md', 'Archive/Italy.md');
+    const r = rewriteNoteLinks(
+      'See [[Italy]].',
+      'ref.md',
+      'Italy.md',
+      'Archive/Italy.md',
+      pre,
+      post,
+    );
+    expect(r.content).toBe('See [[Italy]].');
+    expect(r.count).toBe(0);
+  });
+
+  it('preserves alias, fragment, and embed prefix', () => {
+    const { pre, post } = maps('a.md', 'b.md');
+    const r = rewriteNoteLinks(
+      'X ![[a#Section|shown]] and [[a#^blk]] end.',
+      'ref.md',
+      'a.md',
+      'b.md',
+      pre,
+      post,
+    );
+    expect(r.content).toBe('X ![[b#Section|shown]] and [[b#^blk]] end.');
+    expect(r.count).toBe(2);
+  });
+
+  it('uses the full path when the new basename is ambiguous', () => {
+    const { pre, post } = maps('x.md', 'moved/note.md', ['other/note.md']);
+    const r = rewriteNoteLinks('[[x]]', 'ref.md', 'x.md', 'moved/note.md', pre, post);
+    expect(r.content).toBe('[[moved/note]]');
+  });
+
+  it('does not touch wikilinks that pointed elsewhere', () => {
+    const { pre, post } = maps('a.md', 'b.md', ['c.md']);
+    const r = rewriteNoteLinks('[[c]] and [[missing]]', 'ref.md', 'a.md', 'b.md', pre, post);
+    expect(r.content).toBe('[[c]] and [[missing]]');
+    expect(r.count).toBe(0);
+  });
+
+  it('skips links inside fenced code blocks', () => {
+    const { pre, post } = maps('a.md', 'b.md');
+    const raw = '[[a]]\n```\n[[a]]\n```\n[[a]]';
+    const r = rewriteNoteLinks(raw, 'ref.md', 'a.md', 'b.md', pre, post);
+    expect(r.content).toBe('[[b]]\n```\n[[a]]\n```\n[[b]]');
+    expect(r.count).toBe(2);
+  });
+
+  it('rewrites path-style wikilinks that no longer resolve', () => {
+    const { pre, post } = maps('notes/a.md', 'archive/a2.md');
+    const r = rewriteNoteLinks('[[notes/a|A]]', 'ref.md', 'notes/a.md', 'archive/a2.md', pre, post);
+    expect(r.content).toBe('[[a2|A]]');
+  });
+});
+
+describe('rewriteNoteLinks — markdown links', () => {
+  it('rewrites a relative markdown link, preserving %20 encoding', () => {
+    const { pre, post } = maps('notes/My Note.md', 'archive/My Note.md');
+    const r = rewriteNoteLinks(
+      'See [it](My%20Note.md).',
+      'notes/ref.md',
+      'notes/My Note.md',
+      'archive/My Note.md',
+      pre,
+      post,
+    );
+    expect(r.content).toBe('See [it](../archive/My%20Note.md).');
+    expect(r.count).toBe(1);
+  });
+
+  it('rewrites a ../-style relative link from a sibling folder', () => {
+    const { pre, post } = maps('a/target.md', 'b/target.md');
+    const r = rewriteNoteLinks(
+      '[t](../a/target.md)',
+      'c/ref.md',
+      'a/target.md',
+      'b/target.md',
+      pre,
+      post,
+    );
+    expect(r.content).toBe('[t](../b/target.md)');
+  });
+
+  it('rewrites a vault-absolute markdown link in vault-absolute style', () => {
+    const { pre, post } = maps('notes/a.md', 'archive/a.md');
+    const r = rewriteNoteLinks(
+      '[t](notes/a.md)',
+      'ref.md',
+      'notes/a.md',
+      'archive/a.md',
+      pre,
+      post,
+    );
+    expect(r.content).toBe('[t](archive/a.md)');
+  });
+
+  it('preserves <...> wrapping and fragments', () => {
+    const { pre, post } = maps('a note.md', 'b note.md');
+    const r = rewriteNoteLinks(
+      '[t](<a note.md#sec>)',
+      'ref.md',
+      'a note.md',
+      'b note.md',
+      pre,
+      post,
+    );
+    expect(r.content).toBe('[t](<b note.md#sec>)');
+  });
+
+  it('leaves external URLs and unrelated links alone', () => {
+    const { pre, post } = maps('a.md', 'b.md');
+    const raw = '[x](https://example.com/a.md) [y](other.md) [z](#anchor)';
+    const r = rewriteNoteLinks(raw, 'ref.md', 'a.md', 'b.md', pre, post);
+    expect(r.content).toBe(raw);
+    expect(r.count).toBe(0);
+  });
+
+  it('rewrites markdown embeds', () => {
+    const { pre, post } = maps('a.md', 'b.md');
+    const r = rewriteNoteLinks('![t](a.md)', 'ref.md', 'a.md', 'b.md', pre, post);
+    expect(r.content).toBe('![t](b.md)');
+  });
+});
+
+describe('hasMarkdownLinkTo', () => {
+  it('detects relative, encoded, and vault-absolute forms', () => {
+    expect(hasMarkdownLinkTo('[t](target.md)', 'ref.md', 'target.md')).toBe(true);
+    expect(hasMarkdownLinkTo('[t](My%20Note.md)', 'ref.md', 'My Note.md')).toBe(true);
+    expect(hasMarkdownLinkTo('[t](../a/t.md)', 'b/ref.md', 'a/t.md')).toBe(true);
+    expect(hasMarkdownLinkTo('[t](a/t.md)', 'ref.md', 'a/t.md')).toBe(true);
+  });
+  it('ignores wikilinks, URLs, and non-matching targets', () => {
+    expect(hasMarkdownLinkTo('[[target]]', 'ref.md', 'target.md')).toBe(false);
+    expect(hasMarkdownLinkTo('[t](https://x.com/target.md)', 'ref.md', 'target.md')).toBe(false);
+    expect(hasMarkdownLinkTo('[t](other.md)', 'ref.md', 'target.md')).toBe(false);
+  });
+});

--- a/packages/server/src/tools/rewrite_links.ts
+++ b/packages/server/src/tools/rewrite_links.ts
@@ -1,0 +1,160 @@
+import { posix } from 'node:path';
+import { resolveLink } from '../index/resolve.js';
+
+/**
+ * Pure link-rewriting for link-aware moves: given a referencing note's raw
+ * content, rewrite every wikilink, embed, and relative/vault-absolute markdown
+ * link that pointed at `oldPath` so it points at `newPath`.
+ *
+ * Principles:
+ * - **Rewrite only what breaks.** A link is left byte-identical when it still
+ *   resolves to the moved note after the move (Obsidian's shortest-unique-
+ *   basename semantics — e.g. `[[Italy]]` survives a folder move unchanged).
+ * - **Preserve everything around the target**: embed `!`, `#fragment`,
+ *   `|alias`, `%20`-encoding and `<...>` wrapping in markdown links.
+ * - **Skip fenced code blocks** (``` / ~~~). Inline backtick spans are NOT
+ *   skipped — consistent with the repo's deliberately loose link parsing.
+ *
+ * `preNotes` is the notes map as it was before the move (oldPath present),
+ * `postNotes` after (newPath present) — both are needed to decide whether a
+ * link used to point at the moved note and whether it still does.
+ */
+
+// Mirrors LINK_WITH_LINES_RE in @seekstone/core/extract (same bounded
+// quantifiers), split into groups for reconstruction.
+const WIKI_RE = /(!?)\[\[([^\]|#\n]{1,512})(#[^\]|\n]{1,512})?(\|[^\]\n]{1,512})?\]\]/g;
+
+// Markdown links/embeds: target is everything to the first `)` (titles like
+// `[t](x "title")` are out of scope, matching the loose-parsing ethos).
+const MD_RE = /(!?)\[([^\]\n]*)\]\(([^)\n]+)\)/g;
+
+const FENCE_RE = /^\s*(```|~~~)/;
+
+export interface RewriteNoteLinksResult {
+  content: string;
+  /** Number of individual links rewritten. */
+  count: number;
+}
+
+/** Shortest target that still uniquely resolves to newPath: basename if unambiguous, else full path. */
+function wikiTargetFor(newPath: string, postNotes: Map<string, unknown>): string {
+  const noExt = newPath.replace(/\.md$/i, '');
+  const base = noExt.split('/').pop() ?? noExt;
+  // Count basename collisions directly — resolveLink picks the first match by
+  // map iteration order, which is not a stable notion of "unambiguous".
+  const baseLower = base.toLowerCase();
+  let matches = 0;
+  for (const p of postNotes.keys()) {
+    const pBase = (p.replace(/\.md$/i, '').split('/').pop() ?? '').toLowerCase();
+    if (pBase === baseLower && ++matches > 1) return noExt;
+  }
+  return base;
+}
+
+/** Interpret a markdown-link target as a vault-relative note path (or undefined). */
+function mdTargetToVaultPath(rawTarget: string, sourceDir: string): string | undefined {
+  let t = rawTarget.trim();
+  if (t.startsWith('<') && t.endsWith('>')) t = t.slice(1, -1);
+  if (/^[a-z][a-z0-9+.-]*:/i.test(t)) return undefined; // http:, mailto:, obsidian:, …
+  if (t.startsWith('#') || t === '') return undefined; // intra-note anchor
+  const hashIdx = t.indexOf('#');
+  if (hashIdx !== -1) t = t.slice(0, hashIdx);
+  try {
+    t = decodeURIComponent(t);
+  } catch {
+    /* malformed escape — use as-is */
+  }
+  const joined = posix.normalize(posix.join(sourceDir, t));
+  if (joined.startsWith('..')) return undefined; // escapes the vault
+  return joined;
+}
+
+export function rewriteNoteLinks(
+  raw: string,
+  sourcePath: string,
+  oldPath: string,
+  newPath: string,
+  preNotes: Map<string, unknown>,
+  postNotes: Map<string, unknown>,
+): RewriteNoteLinksResult {
+  const sourceDir = posix.dirname(sourcePath);
+  const oldNoExt = oldPath.replace(/\.md$/i, '');
+  let count = 0;
+
+  const rewriteWikiLine = (line: string): string =>
+    line.replace(WIKI_RE, (full, bang: string, target: string, frag?: string, alias?: string) => {
+      const t = target.trim();
+      // Still resolves to the moved note → Obsidian keeps working; don't touch.
+      if (resolveLink(t, postNotes) === newPath) return full;
+      // Only rewrite links that used to point at the moved note.
+      if (resolveLink(t, preNotes) !== oldPath) return full;
+      count++;
+      const next = wikiTargetFor(newPath, postNotes);
+      return `${bang}[[${next}${frag ?? ''}${alias ?? ''}]]`;
+    });
+
+  const rewriteMdLine = (line: string): string =>
+    line.replace(MD_RE, (full, bang: string, text: string, rawTarget: string) => {
+      // Relative-to-source interpretation first, then vault-absolute.
+      const asRelative = mdTargetToVaultPath(rawTarget, sourceDir);
+      const asAbsolute = mdTargetToVaultPath(rawTarget, '.');
+      let vaultAbsoluteStyle: boolean;
+      if (asRelative === oldPath || asRelative === oldNoExt) vaultAbsoluteStyle = false;
+      else if (asAbsolute === oldPath || asAbsolute === oldNoExt) vaultAbsoluteStyle = true;
+      else return full;
+      count++;
+
+      const trimmed = rawTarget.trim();
+      const wrapped = trimmed.startsWith('<') && trimmed.endsWith('>');
+      const inner = wrapped ? trimmed.slice(1, -1) : trimmed;
+      const hashIdx = inner.indexOf('#');
+      const fragment = hashIdx === -1 ? '' : inner.slice(hashIdx);
+      const hadExt = /\.md(#|$)/i.test(inner);
+
+      let next = vaultAbsoluteStyle ? newPath : posix.relative(sourceDir, newPath);
+      if (!hadExt) next = next.replace(/\.md$/i, '');
+      // Preserve the original encoding style for spaces; wrap in <> when the
+      // new path has spaces and the original used neither style.
+      if (inner.includes('%20')) next = next.replaceAll(' ', '%20');
+      const needsWrap = wrapped || next.includes(' ');
+      const target = needsWrap ? `<${next}${fragment}>` : `${next}${fragment}`;
+      return `${bang}[${text}](${target})`;
+    });
+
+  let inFence = false;
+  const lines = raw.split('\n').map((line) => {
+    if (FENCE_RE.test(line)) {
+      inFence = !inFence;
+      return line;
+    }
+    if (inFence) return line;
+    return rewriteMdLine(rewriteWikiLine(line));
+  });
+
+  return { content: lines.join('\n'), count };
+}
+
+/**
+ * Scan a note's raw content for markdown links resolving to `targetPath` —
+ * the candidate-discovery pass for referencing notes the backlink index can't
+ * see (it only indexes wikilinks).
+ */
+export function hasMarkdownLinkTo(raw: string, sourcePath: string, targetPath: string): boolean {
+  if (!raw.includes('](')) return false;
+  const sourceDir = posix.dirname(sourcePath);
+  const noExt = targetPath.replace(/\.md$/i, '');
+  for (const m of raw.matchAll(MD_RE)) {
+    const rawTarget = m[3] ?? '';
+    const asRelative = mdTargetToVaultPath(rawTarget, sourceDir);
+    const asAbsolute = mdTargetToVaultPath(rawTarget, '.');
+    if (
+      asRelative === targetPath ||
+      asRelative === noExt ||
+      asAbsolute === targetPath ||
+      asAbsolute === noExt
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/server/src/watcher.ts
+++ b/packages/server/src/watcher.ts
@@ -1,11 +1,10 @@
 import { realpathSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
-import { extractLinksWithLines } from '@seekstone/core/extract';
 import chokidar from 'chokidar';
-import type { BacklinkRef, ServerContext } from './context.js';
+import type { ServerContext } from './context.js';
+import { addNoteBacklinks, removeNoteBacklinks } from './index/backlinks.js';
 import { buildDoc, upsertDoc } from './index/doc.js';
-import { resolveLink } from './index/resolve.js';
 import type { Logger } from './log.js';
 
 /**
@@ -45,38 +44,6 @@ export interface WatcherOptions {
    * emits when a failure needs investigation.
    */
   onRawEvent?: (event: 'add' | 'change' | 'unlink', absPath: string, relPath: string) => void;
-}
-
-function removeNoteBacklinks(ctx: ServerContext, relPath: string): void {
-  const oldDoc = ctx.notes.get(relPath);
-  if (oldDoc === undefined) return;
-  for (const link of extractLinksWithLines(oldDoc.raw)) {
-    const resolved = resolveLink(link.target, ctx.notes);
-    if (resolved === undefined) continue;
-    const arr = ctx.backlinks.get(resolved);
-    if (arr === undefined) continue;
-    const filtered = arr.filter((r) => r.path !== relPath);
-    ctx.backlinks.set(resolved, filtered);
-  }
-}
-
-function addNoteBacklinks(ctx: ServerContext, relPath: string, raw: string): void {
-  const seen = new Set<string>();
-  for (const link of extractLinksWithLines(raw)) {
-    const resolved = resolveLink(link.target, ctx.notes);
-    if (resolved === undefined) continue;
-    const dedupeKey = `${relPath}\0${resolved}`;
-    if (seen.has(dedupeKey)) continue;
-    seen.add(dedupeKey);
-    let arr = ctx.backlinks.get(resolved);
-    if (arr === undefined) {
-      arr = [];
-      ctx.backlinks.set(resolved, arr);
-    }
-    const ref: BacklinkRef = { path: relPath, line: link.line, linkType: link.linkType };
-    arr.push(ref);
-    arr.sort((a, b) => a.path.localeCompare(b.path));
-  }
 }
 
 export function startWatcher(


### PR DESCRIPTION
Closes [SHA-249](https://linear.app/shaqster/issue/SHA-249).

`move_note` previously moved the file and silently broke every reference to it. It now rewrites wikilinks, embeds, and relative/vault-absolute markdown links in referencing notes — the meatiest parity gap with obsidian-mcp-rs, and our warm backlink index makes candidate discovery O(referencing notes) instead of a vault scan.

## Behavior

- **Rewrite only what breaks.** Each link in a candidate note is resolved against the post-move notes map; a basename link like `[[Italy]]` that still resolves after a folder move is left byte-identical (Obsidian shortest-unique-basename semantics). The new target uses the basename when unambiguous, the full path when a collision exists.
- **Everything around the target is preserved**: `|aliases`, `#fragments`/`#^blocks`, `!` embed prefixes, `%20` encoding and `<...>` wrapping in markdown links. Fenced code blocks are skipped (inline backtick spans are not — consistent with the repo's deliberately loose link parsing).
- **Markdown links are discovered by scan** — the backlink index only covers wikilinks (a fact the original issue got wrong), so candidates = backlink sources ∪ an in-memory markdown-link scan (tens of ms at 10k notes, no disk I/O).
- **`rewriteLinks: false`** restores the old move-only behavior.
- **Write-path scoping**: referencing notes outside `SEEKSTONE_WRITE_PATHS` are left untouched and reported in the result as `skipped` (per prior decision — a scoping feature shouldn't block the move). Tool result reads e.g. `Moved a.md → b/c.md. Rewrote 3 links in 2 notes.`

## Implementation notes

- `tools/rewrite_links.ts` is a pure module (raw in → content + count out) — most tests live there.
- `removeNoteBacklinks`/`addNoteBacklinks` extracted from the watcher into `index/backlinks.ts` and reused so the backlink map stays coherent through the move. This also fixes a **pre-existing gap**: the moved note's own outgoing links stayed registered under its old source path forever.
- The issue's other incorrect assumption is documented in code: backlink refs are deduped per (source, target), so ref line numbers can't drive rewriting — the index is used for discovery only, with re-extraction from each candidate's in-memory raw.
- `moveNote` now parses its own input (like `periodic_note`) so the `rewriteLinks` default applies to direct callers, not just dispatch.

## Verification

- 15 rewriter unit tests (alias/fragment/embed preservation, fence skipping, basename-survives-folder-move, ambiguity → full path, `%20`/`<>`/vault-absolute markdown forms, external URLs untouched) + 7 new move_note orchestration tests (disk + index + backlink-map assertions, markdown-only candidates, `rewriteLinks: false`, scoped skip-reporting). 368 server tests green; full workspace green.
- `npm run build` + `npm run conformance` pass.
- Live smoke on the built bundle: moved a note to a new folder+name via MCP — `[[Target|alias]]` → `[[Renamed|alias]]`, `[md](Target.md)` → `[md](Archive/Renamed.md)`, `get_backlinks` on the new path returns the referencing note.

Changeset: minor. Follow-up (out of scope, noted for the record): rewriting the moved note's *own* relative markdown links when it changes folders.