### PR TITLE
feat(server): recoverable deletes — delete_note moves to .trash/ (SHA-248)

### DIFF
--- a/.changeset/tough-jars-repair.md
+++ b/.changeset/tough-jars-repair.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+Recoverable deletes: `delete_note` now moves the note to the vault's `.trash/` folder (Obsidian-compatible, restore by moving it back) instead of permanently removing it; name collisions get a timestamp suffix, and the tool result says where the note went. Pass `permanent: true` for the old unlink behavior. Also fixes a gap where a deleted note's outgoing links stayed registered in the backlink index.

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -86,6 +86,7 @@ const META_KEYS = [
   'maxSizeBytes',
   'period',
   'date',
+  'permanent',
 ] as const;
 
 function safeMeta(args: unknown): Record<string, unknown> {
@@ -196,8 +197,11 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
     }
     case 'delete_note': {
       const input = DeleteNoteInput.parse(args);
-      await deleteNote(ctx, input);
-      return { content: [{ type: 'text', text: `Deleted ${input.path}.` }] };
+      const result = await deleteNote(ctx, input);
+      const text = result.trashedTo
+        ? `Moved ${result.path} to ${result.trashedTo} (recoverable — restore by moving it back).`
+        : `Permanently deleted ${result.path}.`;
+      return { content: [{ type: 'text', text }] };
     }
     case 'move_note': {
       const input = MoveNoteInput.parse(args);

--- a/packages/server/src/tool-list.ts
+++ b/packages/server/src/tool-list.ts
@@ -188,11 +188,16 @@ export const ALL_TOOLS = [
   },
   {
     name: 'delete_note',
-    description: 'Permanently delete a note from the vault. This cannot be undone.',
+    description:
+      'Delete a note. By default it is moved to the vault .trash/ folder (recoverable by moving it back); pass permanent: true to remove it outright.',
     inputSchema: {
       type: 'object',
       properties: {
         path: { type: 'string', description: 'Vault-relative path of the note to delete.' },
+        permanent: {
+          type: 'boolean',
+          description: 'Permanently remove instead of moving to .trash/. Defaults to false.',
+        },
       },
       required: ['path'],
     },

--- a/packages/server/src/tools/delete_note.test.ts
+++ b/packages/server/src/tools/delete_note.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import MiniSearch from 'minisearch';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ServerContext } from '../context.js';
+import { addNoteBacklinks } from '../index/backlinks.js';
 import type { IndexedNote } from '../index/types.js';
 import { PERMISSIVE_POLICY } from '../policy.js';
 import { deleteNote } from './delete_note.js';
@@ -54,10 +55,45 @@ afterAll(async () => {
 });
 
 describe('deleteNote', () => {
-  it('deletes the file from disk', async () => {
-    await writeFile(join(tmpDir, 'gone.md'), 'bye', 'utf8');
-    await deleteNote(ctx, { path: 'gone.md' });
+  it('moves the note to .trash/ with byte-identical content by default', async () => {
+    await writeFile(join(tmpDir, 'gone.md'), 'bye — exact bytes\n', 'utf8');
+    const result = await deleteNote(ctx, { path: 'gone.md' });
+
     await expect(readFile(join(tmpDir, 'gone.md'), 'utf8')).rejects.toThrow();
+    expect(result.trashedTo).toBe('.trash/gone.md');
+    expect(result.permanent).toBe(false);
+    expect(await readFile(join(tmpDir, '.trash/gone.md'), 'utf8')).toBe('bye — exact bytes\n');
+  });
+
+  it('creates .trash/ on demand', async () => {
+    // First delete in the suite already exercised this, but assert explicitly.
+    await access(join(tmpDir, '.trash'));
+  });
+
+  it('suffixes on name collision and keeps both trashed files', async () => {
+    await writeFile(join(tmpDir, 'dup.md'), 'first', 'utf8');
+    const first = await deleteNote(ctx, { path: 'dup.md' });
+    await writeFile(join(tmpDir, 'dup.md'), 'second', 'utf8');
+    const second = await deleteNote(ctx, { path: 'dup.md' });
+
+    expect(first.trashedTo).toBe('.trash/dup.md');
+    expect(second.trashedTo).toMatch(/^\.trash\/dup\.\d+\.md$/);
+    expect(await readFile(join(tmpDir, first.trashedTo ?? ''), 'utf8')).toBe('first');
+    expect(await readFile(join(tmpDir, second.trashedTo ?? ''), 'utf8')).toBe('second');
+  });
+
+  it('permanent: true removes the file outright', async () => {
+    await writeFile(join(tmpDir, 'forever.md'), 'x', 'utf8');
+    const result = await deleteNote(ctx, { path: 'forever.md' });
+    expect(result.permanent).toBe(false);
+
+    await writeFile(join(tmpDir, 'forever2.md'), 'x', 'utf8');
+    const perm = await deleteNote(ctx, { path: 'forever2.md', permanent: true });
+    expect(perm.permanent).toBe(true);
+    expect(perm.trashedTo).toBeUndefined();
+    await expect(readFile(join(tmpDir, 'forever2.md'), 'utf8')).rejects.toThrow();
+    const trashed = await readdir(join(tmpDir, '.trash'));
+    expect(trashed).not.toContain('forever2.md');
   });
 
   it('removes the note from the in-memory index', async () => {
@@ -70,14 +106,28 @@ describe('deleteNote', () => {
     expect(ctx.index.search('unique_xyzzy_delete').some((h) => h.id === 'indexed.md')).toBe(false);
   });
 
+  it('clears the deleted note`s outgoing backlink refs', async () => {
+    await writeFile(join(tmpDir, 'linker.md'), 'See [[anchor-target]].', 'utf8');
+    await writeFile(join(tmpDir, 'anchor-target.md'), '# T', 'utf8');
+    seedNote('linker.md', 'See [[anchor-target]].');
+    seedNote('anchor-target.md', '# T');
+    addNoteBacklinks(ctx, 'linker.md', 'See [[anchor-target]].');
+    expect(ctx.backlinks.get('anchor-target.md')?.map((r) => r.path)).toEqual(['linker.md']);
+
+    await deleteNote(ctx, { path: 'linker.md' });
+
+    expect(ctx.backlinks.get('anchor-target.md') ?? []).toEqual([]);
+  });
+
   it('returns the deleted path', async () => {
     await writeFile(join(tmpDir, 'ret.md'), '', 'utf8');
     const result = await deleteNote(ctx, { path: 'ret.md' });
     expect(result.path).toBe('ret.md');
   });
 
-  it('throws if the note does not exist', async () => {
+  it('throws if the note does not exist (both modes)', async () => {
     await expect(deleteNote(ctx, { path: 'nonexistent.md' })).rejects.toThrow();
+    await expect(deleteNote(ctx, { path: 'nonexistent.md', permanent: true })).rejects.toThrow();
   });
 
   it('throws on path traversal', async () => {

--- a/packages/server/src/tools/delete_note.ts
+++ b/packages/server/src/tools/delete_note.ts
@@ -1,35 +1,80 @@
-import { rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { access, mkdir, rename, rm } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
 import { z } from 'zod';
 import type { ServerContext } from '../context.js';
+import { removeNoteBacklinks } from '../index/backlinks.js';
 import { assertWritable } from '../policy.js';
 
 export const DeleteNoteInput = z.object({
   path: z.string().describe('Vault-relative path of the note to delete.'),
+  permanent: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Permanently remove the note instead of moving it to the vault .trash/ folder. Defaults to false — deletes are recoverable.',
+    ),
 });
 export type DeleteNoteInput = z.input<typeof DeleteNoteInput>;
 
 export interface DeleteNoteResult {
   path: string;
+  /** Vault-relative path the note was moved to, when not permanent. */
+  trashedTo?: string;
+  permanent: boolean;
+}
+
+/** Find a free destination name inside .trash/, suffixing before the extension on collision. */
+async function freeTrashPath(vaultRoot: string, noteBase: string): Promise<string> {
+  const ext = extname(noteBase);
+  const stem = noteBase.slice(0, noteBase.length - ext.length);
+  let candidate = `.trash/${noteBase}`;
+  for (;;) {
+    try {
+      await access(join(vaultRoot, candidate));
+    } catch {
+      return candidate;
+    }
+    // Epoch-ms suffix; loop guards the (test-speed) case of two collisions in one ms.
+    candidate = `.trash/${stem}.${Date.now()}${ext}`;
+  }
 }
 
 export async function deleteNote(
   ctx: ServerContext,
-  input: DeleteNoteInput,
+  rawInput: DeleteNoteInput,
 ): Promise<DeleteNoteResult> {
+  const input = DeleteNoteInput.parse(rawInput);
   const absPath = join(ctx.vaultRoot, input.path);
   if (!absPath.startsWith(ctx.vaultRoot)) {
     throw new Error(`Path outside vault: ${input.path}`);
   }
+  // Policy applies to the note being deleted; the .trash/ destination is the
+  // safety mechanism itself, not a user write.
   assertWritable(ctx.policy, input.path);
 
-  // rm throws ENOENT if the file doesn't exist — let it propagate.
-  await rm(absPath);
+  let trashedTo: string | undefined;
+  if (input.permanent) {
+    // rm throws ENOENT if the file doesn't exist — let it propagate.
+    await rm(absPath);
+  } else {
+    // access first so a missing note throws ENOENT like rm does, not a
+    // half-made .trash/ dir plus a rename error.
+    await access(absPath);
+    await mkdir(join(ctx.vaultRoot, '.trash'), { recursive: true });
+    trashedTo = await freeTrashPath(ctx.vaultRoot, basename(input.path));
+    // Same-volume rename: atomic, byte-identical, and invisible to the index —
+    // the walker and watcher both exclude .trash/.
+    await rename(absPath, join(ctx.vaultRoot, trashedTo));
+  }
 
+  // Clear the note's own outgoing refs while its entry is still readable.
+  removeNoteBacklinks(ctx, input.path);
   if (ctx.notes.has(input.path)) {
     ctx.index.discard(input.path);
     ctx.notes.delete(input.path);
   }
 
-  return { path: input.path };
+  const result: DeleteNoteResult = { path: input.path, permanent: input.permanent };
+  if (trashedTo !== undefined) result.trashedTo = trashedTo;
+  return result;
 }


### PR DESCRIPTION
Closes [SHA-248](https://linear.app/shaqster/issue/SHA-248).

An agent deleting the wrong note was the single scariest failure mode for a write-enabled vault server — a permanent `rm` with no undo. `delete_note` now matches Obsidian's own behavior: the note moves to the vault's `.trash/` folder, byte-identical, restorable by moving it back.

## Behavior

- Default: `access` → `mkdir .trash` → same-volume `rename` (atomic). Result includes `trashedTo`; the tool reply reads *"Moved X to .trash/X (recoverable — restore by moving it back)."*
- Name collisions in `.trash/` get an epoch-ms suffix before the extension (`Note.md` → `Note.1754…md`), looping until free.
- `permanent: true` keeps the old unlink for callers that want it.
- Policy: `assertWritable` applies to the note being deleted; writing into `.trash/` is the safety mechanism itself, not a user write.
- The walker (`**/.trash/**` ignore) and watcher (dot-segment ignore) already exclude `.trash/`, so trashed notes never re-enter the index; in-memory state is updated directly as before.
- **Bug fix**: `delete_note` previously left the deleted note's outgoing links registered in the backlink index forever; it now clears them via the shared `removeNoteBacklinks` helper.

Decision note: Obsidian's `app.json` `trashOption` is deliberately not read — system-trash would need a platform dependency in a zero-runtime-dep bundle, and the issue explicitly blesses starting with `.trash/` unconditionally. `permanent: true` covers the `trashOption: none` preference.

## Verification

- 8 tests: byte-identical trash move, collision suffix, `permanent: true`, backlink cleanup (new coverage), index removal, ENOENT both modes, traversal guard, `.trash` on-demand creation. Full server suite green (372).
- Build + MCP conformance pass; live smoke on the built bundle confirms the trash round-trip and reply text.

Changeset: minor.