### PR TITLE
feat(server): optional CAS on edits + unified atomic writes (SHA-250)

### DIFF
--- a/.changeset/eight-moons-invent.md
+++ b/.changeset/eight-moons-invent.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+Guarded writes: `read_note` (and every mutating tool) now returns a `contentHash` (sha-256 of the note's disk bytes), and the edit tools — `append_note`, `patch_note`, `patch_frontmatter`, `replace_in_note`, `append_periodic_note`, plus `create_note` with `overwrite: true` — accept an optional `prevHash` for compare-and-swap: if the note changed since it was read, the write fails with a structured `hash_conflict` error carrying the current hash instead of silently discarding the concurrent edit. Returned hashes chain, so multi-step edits need no re-reads. All write paths now also go through one shared crash-safe temp-file+rename helper — previously only `patch_note` and `replace_in_note` wrote atomically.

--- a/packages/server/src/atomic-write.test.ts
+++ b/packages/server/src/atomic-write.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { atomicWrite } from './atomic-write.js';
+
+let dir: string;
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'seekstone-atomic-write-'));
+});
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('atomicWrite', () => {
+  it('creates a new file with the exact content', async () => {
+    const p = join(dir, 'new.md');
+    await atomicWrite(p, '# New\ncontent — exact\n');
+    expect(await readFile(p, 'utf8')).toBe('# New\ncontent — exact\n');
+  });
+
+  it('replaces an existing file', async () => {
+    const p = join(dir, 'existing.md');
+    await writeFile(p, 'old', 'utf8');
+    await atomicWrite(p, 'replacement');
+    expect(await readFile(p, 'utf8')).toBe('replacement');
+  });
+
+  it('leaves no temp file behind on success', async () => {
+    await atomicWrite(join(dir, 'clean.md'), 'x');
+    const entries = await readdir(dir);
+    expect(entries.some((e) => e.includes('.seekstone-tmp'))).toBe(false);
+  });
+});

--- a/packages/server/src/atomic-write.ts
+++ b/packages/server/src/atomic-write.ts
@@ -1,0 +1,17 @@
+import { rename, writeFile } from 'node:fs/promises';
+
+/**
+ * Crash-safe file write: write to a same-directory temp file, then rename
+ * over the destination. A crash mid-write leaves either the old content or
+ * the new content on disk — never a torn file. rename-over-existing works on
+ * the full CI OS matrix (proven by patch_note's original implementation).
+ *
+ * Not a lock: two seekstone processes writing the same note share this temp
+ * suffix and can race each other — same exposure as any two writers on one
+ * file. CAS (content-hash.ts) is the conflict-detection layer above this.
+ */
+export async function atomicWrite(absPath: string, content: string): Promise<void> {
+  const tmpPath = `${absPath}.seekstone-tmp`;
+  await writeFile(tmpPath, content, 'utf8');
+  await rename(tmpPath, absPath);
+}

--- a/packages/server/src/content-hash.test.ts
+++ b/packages/server/src/content-hash.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { assertHashMatch, contentHash } from './content-hash.js';
+
+describe('contentHash', () => {
+  it('is the sha-256 hex of the content', () => {
+    // Known vector: sha256("hello") — stable across platforms.
+    expect(contentHash('hello')).toBe(
+      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    );
+  });
+  it('is byte-sensitive (newline matters)', () => {
+    expect(contentHash('a')).not.toBe(contentHash('a\n'));
+  });
+  it('accepts Buffers identically to strings', () => {
+    expect(contentHash(Buffer.from('café', 'utf8'))).toBe(contentHash('café'));
+  });
+});
+
+describe('assertHashMatch', () => {
+  it('passes silently on a match', () => {
+    expect(() => assertHashMatch('x', contentHash('x'), 'n.md')).not.toThrow();
+  });
+  it('throws structured hash_conflict with the current hash on mismatch', () => {
+    let thrown: Error | undefined;
+    try {
+      assertHashMatch('current content', contentHash('stale content'), 'n.md');
+    } catch (err) {
+      thrown = err as Error;
+    }
+    expect(thrown).toBeDefined();
+    const parsed = JSON.parse(thrown?.message ?? '{}');
+    expect(parsed.error).toBe('hash_conflict');
+    expect(parsed.path).toBe('n.md');
+    expect(parsed.expected).toBe(contentHash('stale content'));
+    expect(parsed.actual).toBe(contentHash('current content'));
+    expect(parsed.hint).toContain('Re-read');
+  });
+});

--- a/packages/server/src/content-hash.ts
+++ b/packages/server/src/content-hash.ts
@@ -1,0 +1,36 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Content hashing for optional compare-and-swap edits.
+ *
+ * The hash is sha-256 (hex) of the exact raw string a tool read from disk —
+ * disk bytes are the version identity. `read_note` and every mutating tool
+ * return `contentHash`; edit tools accept `prevHash` and refuse to write when
+ * the note changed since it was read. This is conflict DETECTION, not
+ * locking: the window between check and rename is the same one the OS gives
+ * any two writers. node:crypto is fully offline — the zero-network guarantee
+ * is unaffected.
+ */
+export function contentHash(raw: string | Buffer): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+/**
+ * Throw the structured hash_conflict error when `prevHash` no longer matches
+ * the freshly-read content. Call immediately after the disk read, before any
+ * edit is computed.
+ */
+export function assertHashMatch(raw: string, prevHash: string, path: string): void {
+  const actual = contentHash(raw);
+  if (actual !== prevHash) {
+    throw new Error(
+      JSON.stringify({
+        error: 'hash_conflict',
+        path,
+        expected: prevHash,
+        actual,
+        hint: 'Note changed on disk since it was read. Re-read it and retry with the new contentHash.',
+      }),
+    );
+  }
+}

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -87,6 +87,7 @@ const META_KEYS = [
   'period',
   'date',
   'permanent',
+  'prevHash',
 ] as const;
 
 function safeMeta(args: unknown): Record<string, unknown> {
@@ -192,7 +193,12 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
       const input = CreateNoteInput.parse(args);
       const result = await createNote(ctx, input);
       return {
-        content: [{ type: 'text', text: `Created ${result.path} (${result.bytesWritten} bytes).` }],
+        content: [
+          {
+            type: 'text',
+            text: `Created ${result.path} (${result.bytesWritten} bytes). contentHash: ${result.contentHash}`,
+          },
+        ],
       };
     }
     case 'delete_note': {
@@ -219,7 +225,10 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
       const result = await appendNote(ctx, input);
       return {
         content: [
-          { type: 'text', text: `Appended ${result.bytesWritten} bytes to ${result.path}.` },
+          {
+            type: 'text',
+            text: `Appended ${result.bytesWritten} bytes to ${result.path}. contentHash: ${result.contentHash}`,
+          },
         ],
       };
     }
@@ -265,7 +274,7 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
         content: [
           {
             type: 'text',
-            text: `Appended ${result.bytesWritten} bytes to ${result.path}.`,
+            text: `Appended ${result.bytesWritten} bytes to ${result.path}. contentHash: ${result.contentHash}`,
           },
         ],
       };

--- a/packages/server/src/tool-list.ts
+++ b/packages/server/src/tool-list.ts
@@ -85,7 +85,7 @@ export const ALL_TOOLS = [
   {
     name: 'read_note',
     description:
-      'Read a note or a span of it — by heading section, block reference, or line range. Returns structured JSON with the content, bytes returned, and total note size so payload savings are measurable. Use search or outline_note first to find the right path and section names.',
+      'Read a note or a span of it — by heading section, block reference, or line range. Returns structured JSON with the content, bytes returned, total note size, and a contentHash to pass as prevHash to edit tools for compare-and-swap. Use search or outline_note first to find the right path and section names.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -164,7 +164,7 @@ export const ALL_TOOLS = [
   {
     name: 'create_note',
     description:
-      'Create a new note at a vault-relative path. Optionally sets frontmatter and body content. Parent directories are created automatically. Fails if the note already exists unless overwrite is true.',
+      'Create a new note at a vault-relative path. Optionally sets frontmatter and body content. Parent directories are created automatically. Fails if the note already exists unless overwrite is true (prevHash may guard the overwrite).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -181,6 +181,11 @@ export const ALL_TOOLS = [
         overwrite: {
           type: 'boolean',
           description: 'Overwrite an existing note. Defaults to false.',
+        },
+        prevHash: {
+          type: 'string',
+          description:
+            'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
         },
       },
       required: ['path'],
@@ -233,6 +238,11 @@ export const ALL_TOOLS = [
       properties: {
         path: { type: 'string', description: 'Vault-relative path to the note.' },
         content: { type: 'string', description: 'Text to append.' },
+        prevHash: {
+          type: 'string',
+          description:
+            'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
+        },
       },
       required: ['path', 'content'],
     },
@@ -249,6 +259,11 @@ export const ALL_TOOLS = [
           type: 'object',
           description: 'Key-value pairs to set. Null value removes the key.',
           additionalProperties: true,
+        },
+        prevHash: {
+          type: 'string',
+          description:
+            'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
         },
       },
       required: ['path', 'patch'],
@@ -298,6 +313,11 @@ export const ALL_TOOLS = [
           type: 'boolean',
           description:
             'If the heading target is not found, append a new heading (level 2) + content. Only valid for heading targets. Default false.',
+        },
+        prevHash: {
+          type: 'string',
+          description:
+            'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
         },
       },
       required: ['path', 'target', 'operation', 'content'],
@@ -368,6 +388,11 @@ export const ALL_TOOLS = [
           type: 'boolean',
           description: 'If true, report matches without writing. Default false.',
         },
+        prevHash: {
+          type: 'string',
+          description:
+            'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
+        },
       },
       required: ['path', 'find', 'replace'],
     },
@@ -420,6 +445,11 @@ export const ALL_TOOLS = [
         createIfMissing: {
           type: 'boolean',
           description: 'Create the note if it does not exist before appending. Default true.',
+        },
+        prevHash: {
+          type: 'string',
+          description:
+            'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
         },
       },
       required: ['content'],

--- a/packages/server/src/tools/append_note.ts
+++ b/packages/server/src/tools/append_note.ts
@@ -1,7 +1,9 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { z } from 'zod';
+import { atomicWrite } from '../atomic-write.js';
+import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { assertWritable } from '../policy.js';
 
@@ -13,12 +15,20 @@ export const AppendNoteInput = z.object({
     .describe(
       'Text to append to the note body. Will be separated from existing content by a blank line.',
     ),
+  prevHash: z
+    .string()
+    .optional()
+    .describe(
+      'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
+    ),
 });
 export type AppendNoteInput = z.infer<typeof AppendNoteInput>;
 
 export interface AppendNoteResult {
   path: string;
   bytesWritten: number;
+  /** sha-256 (hex) of the new content — usable as prevHash for a chained edit. */
+  contentHash: string;
 }
 
 /**
@@ -28,7 +38,7 @@ export interface AppendNoteResult {
  *   - The frontmatter block (if any) is preserved byte-for-byte.
  *   - A blank line is inserted before the appended content if the body
  *     does not already end with one (keeps Obsidian's visual spacing).
- *   - The file is written atomically (overwrite in place, same path).
+ *   - The file is written atomically (temp file + rename).
  */
 export async function appendNote(
   ctx: ServerContext,
@@ -41,6 +51,7 @@ export async function appendNote(
   assertWritable(ctx.policy, input.path);
 
   const original = await readFile(absPath, 'utf8');
+  if (input.prevHash !== undefined) assertHashMatch(original, input.prevHash, input.path);
   const fm = parseFrontmatter(original);
 
   // Ensure body ends with exactly one trailing newline before appending.
@@ -52,7 +63,7 @@ export async function appendNote(
   const header = original.slice(0, fm.bodyStart);
   const newContent = `${header}${newBody}`;
 
-  await writeFile(absPath, newContent, 'utf8');
+  await atomicWrite(absPath, newContent);
 
   // Update the in-memory index entry so subsequent searches reflect the change.
   const cached = ctx.notes.get(input.path);
@@ -61,5 +72,9 @@ export async function appendNote(
     cached.raw = newContent;
   }
 
-  return { path: input.path, bytesWritten: Buffer.byteLength(newContent, 'utf8') };
+  return {
+    path: input.path,
+    bytesWritten: Buffer.byteLength(newContent, 'utf8'),
+    contentHash: contentHash(newContent),
+  };
 }

--- a/packages/server/src/tools/cas.test.ts
+++ b/packages/server/src/tools/cas.test.ts
@@ -1,0 +1,176 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import MiniSearch from 'minisearch';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { contentHash } from '../content-hash.js';
+import type { ServerContext } from '../context.js';
+import type { IndexedNote } from '../index/types.js';
+import { PERMISSIVE_POLICY } from '../policy.js';
+import { appendNote } from './append_note.js';
+import { createNote } from './create_note.js';
+import { patchFrontmatter } from './patch_frontmatter.js';
+import { patchNote } from './patch_note.js';
+import { readNote } from './read_note.js';
+import { replaceInNote } from './replace_in_note.js';
+
+/**
+ * Compare-and-swap behavior across every edit tool that accepts prevHash:
+ * matching hash succeeds, stale hash fails with hash_conflict + current hash
+ * and leaves the disk untouched, omitted hash keeps today's behavior.
+ */
+
+const NOTE = `---
+title: CAS target
+---
+
+# Heading
+
+Original body words here.
+`;
+
+let tmpDir: string;
+let ctx: ServerContext;
+
+function freshCtx(): ServerContext {
+  const index = new MiniSearch<IndexedNote>({
+    idField: 'id',
+    fields: ['title', 'body', 'tags', 'fmKeys'],
+    storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
+    searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
+  });
+  return {
+    vaultRoot: tmpDir,
+    index,
+    notes: new Map(),
+    backlinks: new Map(),
+    policy: PERMISSIVE_POLICY,
+  };
+}
+
+beforeAll(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'seekstone-cas-test-'));
+  ctx = freshCtx();
+});
+
+afterAll(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function seed(name: string): Promise<{ path: string; hash: string }> {
+  await writeFile(join(tmpDir, name), NOTE, 'utf8');
+  return { path: name, hash: contentHash(NOTE) };
+}
+
+function expectHashConflict(err: unknown, expectedStale: string): void {
+  const parsed = JSON.parse((err as Error).message);
+  expect(parsed.error).toBe('hash_conflict');
+  expect(parsed.expected).toBe(expectedStale);
+  expect(typeof parsed.actual === 'string' || parsed.actual === null).toBe(true);
+}
+
+describe('read_note contentHash', () => {
+  it('returns the whole-file hash for whole and span reads', async () => {
+    const { path, hash } = await seed('rn.md');
+    const whole = await readNote(ctx, { path });
+    expect(whole.contentHash).toBe(hash);
+    const span = await readNote(ctx, { path, section: 'Heading' });
+    expect(span.contentHash).toBe(hash); // still the file's hash, not the span's
+  });
+});
+
+describe('CAS on edit tools', () => {
+  it('append_note: match succeeds and returns the new hash; stale conflicts and leaves disk untouched', async () => {
+    const { path, hash } = await seed('ap.md');
+    const ok = await appendNote(ctx, { path, content: 'appended', prevHash: hash });
+    expect(ok.contentHash).toBe(contentHash(await readFile(join(tmpDir, path), 'utf8')));
+
+    const before = await readFile(join(tmpDir, path), 'utf8');
+    const stale = hash; // file changed since this hash
+    await appendNote(ctx, { path, content: 'nope', prevHash: stale }).then(
+      () => {
+        throw new Error('expected hash_conflict');
+      },
+      (err) => expectHashConflict(err, stale),
+    );
+    expect(await readFile(join(tmpDir, path), 'utf8')).toBe(before);
+  });
+
+  it('supports chained edits using each result hash', async () => {
+    const { path, hash } = await seed('chain.md');
+    const first = await appendNote(ctx, { path, content: 'one', prevHash: hash });
+    const second = await appendNote(ctx, { path, content: 'two', prevHash: first.contentHash });
+    expect(second.contentHash).toBe(contentHash(await readFile(join(tmpDir, path), 'utf8')));
+  });
+
+  it('patch_note: stale hash conflicts before any edit', async () => {
+    const { path, hash } = await seed('pn.md');
+    await appendNote(ctx, { path, content: 'drift' }); // invalidate hash
+    await expect(
+      patchNote(ctx, {
+        path,
+        target: { heading: 'Heading' },
+        operation: 'append',
+        content: 'x',
+        createIfMissing: false,
+        prevHash: hash,
+      }),
+    ).rejects.toThrow(/hash_conflict/);
+  });
+
+  it('patch_frontmatter: match succeeds, stale conflicts', async () => {
+    const { path, hash } = await seed('pf.md');
+    const ok = await patchFrontmatter(ctx, { path, patch: { status: 'done' }, prevHash: hash });
+    expect(ok.contentHash).toBe(contentHash(await readFile(join(tmpDir, path), 'utf8')));
+    await expect(
+      patchFrontmatter(ctx, { path, patch: { status: 'again' }, prevHash: hash }),
+    ).rejects.toThrow(/hash_conflict/);
+  });
+
+  it('replace_in_note: stale conflicts even on dryRun', async () => {
+    const { path, hash } = await seed('rin.md');
+    const flags = { regex: false, caseSensitive: false, wholeWord: false };
+    const ok = await replaceInNote(ctx, {
+      path,
+      find: 'Original',
+      replace: 'Replaced',
+      ...flags,
+      dryRun: false,
+      prevHash: hash,
+    });
+    expect(ok.contentHash).toBeDefined();
+    await expect(
+      replaceInNote(ctx, { path, find: 'x', replace: 'y', ...flags, dryRun: true, prevHash: hash }),
+    ).rejects.toThrow(/hash_conflict/);
+  });
+
+  it('omitting prevHash keeps unguarded behavior', async () => {
+    const { path } = await seed('open.md');
+    await appendNote(ctx, { path, content: 'no guard' });
+    const disk = await readFile(join(tmpDir, path), 'utf8');
+    expect(disk).toContain('no guard');
+  });
+});
+
+describe('create_note prevHash', () => {
+  it('rejects prevHash without overwrite (zod refine)', async () => {
+    await expect(
+      createNote(ctx, { path: 'ref.md', content: 'x', prevHash: 'abc' }),
+    ).rejects.toThrow(/overwrite/);
+  });
+
+  it('guards overwrite: match replaces, stale conflicts', async () => {
+    const { path, hash } = await seed('ow.md');
+    const ok = await createNote(ctx, {
+      path,
+      content: 'replaced',
+      overwrite: true,
+      prevHash: hash,
+    });
+    expect(ok.contentHash).toBe(contentHash('replaced'));
+    await expect(
+      createNote(ctx, { path, content: 'again', overwrite: true, prevHash: hash }),
+    ).rejects.toThrow(/hash_conflict/);
+    expect(await readFile(join(tmpDir, path), 'utf8')).toBe('replaced');
+  });
+});

--- a/packages/server/src/tools/create_note.ts
+++ b/packages/server/src/tools/create_note.ts
@@ -1,38 +1,56 @@
-import { access, mkdir, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { stringify as stringifyYaml } from 'yaml';
 import { z } from 'zod';
+import { atomicWrite } from '../atomic-write.js';
+import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { buildDoc, upsertDoc } from '../index/doc.js';
 import { assertWritable } from '../policy.js';
 
-export const CreateNoteInput = z.object({
-  path: z
-    .string()
-    .describe(
-      'Vault-relative path for the new note, e.g. "Daily Notes/2026-06-01.md". Parent directories are created automatically.',
-    ),
-  content: z.string().default('').describe('Body content for the note.'),
-  frontmatter: z
-    .record(z.string(), z.unknown())
-    .optional()
-    .describe('Frontmatter key-value pairs to write as a YAML block at the top of the note.'),
-  overwrite: z
-    .boolean()
-    .default(false)
-    .describe('Overwrite an existing note. Defaults to false — throws if the note already exists.'),
-});
+export const CreateNoteInput = z
+  .object({
+    path: z
+      .string()
+      .describe(
+        'Vault-relative path for the new note, e.g. "Daily Notes/2026-06-01.md". Parent directories are created automatically.',
+      ),
+    content: z.string().default('').describe('Body content for the note.'),
+    frontmatter: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('Frontmatter key-value pairs to write as a YAML block at the top of the note.'),
+    overwrite: z
+      .boolean()
+      .default(false)
+      .describe(
+        'Overwrite an existing note. Defaults to false — throws if the note already exists.',
+      ),
+    prevHash: z
+      .string()
+      .optional()
+      .describe(
+        'Optional compare-and-swap guard for overwrite: true — the contentHash of the note being replaced. Fails with hash_conflict if it changed since it was read.',
+      ),
+  })
+  .refine((v) => v.prevHash === undefined || v.overwrite === true, {
+    message:
+      'prevHash only makes sense with overwrite: true (a fresh create has no prior version).',
+  });
 export type CreateNoteInput = z.input<typeof CreateNoteInput>;
 
 export interface CreateNoteResult {
   path: string;
   bytesWritten: number;
+  /** sha-256 (hex) of the written content — usable as prevHash for a chained edit. */
+  contentHash: string;
 }
 
 export async function createNote(
   ctx: ServerContext,
-  input: CreateNoteInput,
+  rawInput: CreateNoteInput,
 ): Promise<CreateNoteResult> {
+  const input = CreateNoteInput.parse(rawInput);
   const absPath = join(ctx.vaultRoot, input.path);
   if (!absPath.startsWith(ctx.vaultRoot)) {
     throw new Error(`Path outside vault: ${input.path}`);
@@ -46,6 +64,24 @@ export async function createNote(
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
     }
+  } else if (input.prevHash !== undefined) {
+    // CAS on the note being replaced; a missing file is a conflict too (the
+    // version the caller read no longer exists).
+    let existing: string;
+    try {
+      existing = await readFile(absPath, 'utf8');
+    } catch {
+      throw new Error(
+        JSON.stringify({
+          error: 'hash_conflict',
+          path: input.path,
+          expected: input.prevHash,
+          actual: null,
+          hint: 'The note no longer exists on disk. Re-check before overwriting.',
+        }),
+      );
+    }
+    assertHashMatch(existing, input.prevHash, input.path);
   }
 
   let raw = '';
@@ -55,10 +91,14 @@ export async function createNote(
   raw += input.content ?? '';
 
   await mkdir(dirname(absPath), { recursive: true });
-  await writeFile(absPath, raw, 'utf8');
+  await atomicWrite(absPath, raw);
 
   // Sync in-memory index so the new note is immediately searchable.
   upsertDoc(ctx, buildDoc(input.path, raw));
 
-  return { path: input.path, bytesWritten: Buffer.byteLength(raw, 'utf8') };
+  return {
+    path: input.path,
+    bytesWritten: Buffer.byteLength(raw, 'utf8'),
+    contentHash: contentHash(raw),
+  };
 }

--- a/packages/server/src/tools/move_note.ts
+++ b/packages/server/src/tools/move_note.ts
@@ -1,6 +1,7 @@
-import { access, mkdir, rename, writeFile } from 'node:fs/promises';
+import { access, mkdir, rename } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { z } from 'zod';
+import { atomicWrite } from '../atomic-write.js';
 import type { ServerContext } from '../context.js';
 import { addNoteBacklinks, removeNoteBacklinks } from '../index/backlinks.js';
 import { buildDoc, upsertDoc } from '../index/doc.js';
@@ -127,7 +128,7 @@ export async function moveNote(
     // path); remove reads the old raw, so call it before updating the entry.
     removeNoteBacklinks(ctx, path);
     if (count > 0) {
-      await writeFile(join(ctx.vaultRoot, path), content, 'utf8');
+      await atomicWrite(join(ctx.vaultRoot, path), content);
       upsertDoc(ctx, buildDoc(path, content));
       notesRewritten++;
       linksRewritten += count;

--- a/packages/server/src/tools/patch_frontmatter.ts
+++ b/packages/server/src/tools/patch_frontmatter.ts
@@ -1,8 +1,10 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { parseDocument } from 'yaml';
 import { z } from 'zod';
+import { atomicWrite } from '../atomic-write.js';
+import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { assertWritable } from '../policy.js';
 
@@ -13,6 +15,12 @@ export const PatchFrontmatterInput = z.object({
     .describe(
       'Key-value pairs to set in the frontmatter. Existing keys not in the patch are unchanged. Pass null as a value to remove a key.',
     ),
+  prevHash: z
+    .string()
+    .optional()
+    .describe(
+      'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
+    ),
 });
 export type PatchFrontmatterInput = z.infer<typeof PatchFrontmatterInput>;
 
@@ -21,6 +29,8 @@ export interface PatchFrontmatterResult {
   keysChanged: string[];
   keysAdded: string[];
   keysRemoved: string[];
+  /** sha-256 (hex) of the new content — usable as prevHash for a chained edit. */
+  contentHash: string;
 }
 
 /**
@@ -46,6 +56,7 @@ export async function patchFrontmatter(
   assertWritable(ctx.policy, input.path);
 
   const original = await readFile(absPath, 'utf8');
+  if (input.prevHash !== undefined) assertHashMatch(original, input.prevHash, input.path);
   const fm = parseFrontmatter(original);
 
   const keysChanged: string[] = [];
@@ -94,7 +105,7 @@ export async function patchFrontmatter(
     newContent = `${head}${doc.toString()}${tail}${fm.body}`;
   }
 
-  await writeFile(absPath, newContent, 'utf8');
+  await atomicWrite(absPath, newContent);
 
   // Update in-memory cache.
   const cached = ctx.notes.get(input.path);
@@ -104,5 +115,11 @@ export async function patchFrontmatter(
     cached.fmKeys = updated.keys.join(' ');
   }
 
-  return { path: input.path, keysChanged, keysAdded, keysRemoved };
+  return {
+    path: input.path,
+    keysChanged,
+    keysAdded,
+    keysRemoved,
+    contentHash: contentHash(newContent),
+  };
 }

--- a/packages/server/src/tools/patch_note.ts
+++ b/packages/server/src/tools/patch_note.ts
@@ -1,8 +1,10 @@
-import { readFile, rename, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { buildOutline } from '@seekstone/core/outline';
 import { z } from 'zod';
+import { atomicWrite } from '../atomic-write.js';
+import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { assertWritable } from '../policy.js';
 
@@ -26,6 +28,12 @@ export const PatchNoteInput = z.object({
     .describe(
       'If the heading target is not found, append a new heading (level 2) + content. Only valid for heading targets.',
     ),
+  prevHash: z
+    .string()
+    .optional()
+    .describe(
+      'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
+    ),
 });
 export type PatchNoteInput = z.infer<typeof PatchNoteInput>;
 
@@ -34,6 +42,8 @@ export interface PatchNoteResult {
   bytesWritten: number;
   targetResolvedAt: { line: number; byteOffset: number };
   frontmatterUnchanged: true;
+  /** sha-256 (hex) of the new content — usable as prevHash for a chained edit. */
+  contentHash: string;
 }
 
 /** Character offset of the start of the next line after `offset`. */
@@ -49,12 +59,6 @@ function lineStart(raw: string, offset: number): number {
   return prev === -1 ? 0 : prev + 1;
 }
 
-async function atomicWrite(absPath: string, content: string): Promise<void> {
-  const tmpPath = `${absPath}.seekstone-patch-tmp`;
-  await writeFile(tmpPath, content, 'utf8');
-  await rename(tmpPath, absPath);
-}
-
 export async function patchNote(
   ctx: ServerContext,
   input: PatchNoteInput,
@@ -66,6 +70,7 @@ export async function patchNote(
   assertWritable(ctx.policy, input.path);
 
   const raw = await readFile(absPath, 'utf8');
+  if (input.prevHash !== undefined) assertHashMatch(raw, input.prevHash, input.path);
   const fm = parseFrontmatter(raw);
   const originalFmRegion = raw.slice(0, fm.bodyStart);
   const outline = buildOutline(raw, { includeBlocks: true });
@@ -95,6 +100,7 @@ export async function patchNote(
             byteOffset: headingOffset,
           },
           frontmatterUnchanged: true,
+          contentHash: contentHash(newContent),
         };
       }
       throw new Error(
@@ -165,6 +171,7 @@ export async function patchNote(
     bytesWritten: Buffer.byteLength(newContent, 'utf8'),
     targetResolvedAt: resolvedAt,
     frontmatterUnchanged: true,
+    contentHash: contentHash(newContent),
   };
 }
 

--- a/packages/server/src/tools/periodic_note.ts
+++ b/packages/server/src/tools/periodic_note.ts
@@ -1,7 +1,9 @@
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { z } from 'zod';
+import { atomicWrite } from '../atomic-write.js';
+import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { buildDoc, upsertDoc } from '../index/doc.js';
 import { assertWritable } from '../policy.js';
@@ -149,6 +151,8 @@ export interface GetPeriodicNoteResult {
   path: string;
   existed: boolean;
   created: boolean;
+  /** sha-256 (hex) of the created content; only set when created is true. */
+  contentHash?: string;
 }
 
 export async function getPeriodicNote(
@@ -192,10 +196,10 @@ export async function getPeriodicNote(
   }
 
   await mkdir(dirname(abs), { recursive: true });
-  await writeFile(abs, body, 'utf8');
+  await atomicWrite(abs, body);
   upsertDoc(ctx, buildDoc(path, body));
 
-  return { path, existed: false, created: true };
+  return { path, existed: false, created: true, contentHash: contentHash(body) };
 }
 
 // ── Tool: append_periodic_note ────────────────────────────────────────────────
@@ -211,12 +215,20 @@ export const AppendPeriodicNoteInput = z.object({
     .boolean()
     .default(true)
     .describe('Create the note if it does not exist before appending. Default true.'),
+  prevHash: z
+    .string()
+    .optional()
+    .describe(
+      'Optional compare-and-swap guard: the contentHash from a prior read of the resolved periodic note. Fails with hash_conflict if it changed since.',
+    ),
 });
 export type AppendPeriodicNoteInput = z.input<typeof AppendPeriodicNoteInput>;
 
 export interface AppendPeriodicNoteResult {
   path: string;
   bytesWritten: number;
+  /** sha-256 (hex) of the new content — usable as prevHash for a chained edit. */
+  contentHash: string;
 }
 
 export async function appendPeriodicNote(
@@ -235,13 +247,30 @@ export async function appendPeriodicNote(
   let original = '';
   try {
     original = await readFile(abs, 'utf8');
+    if (input.prevHash !== undefined) assertHashMatch(original, input.prevHash, path);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    if (input.prevHash !== undefined) {
+      // The caller pinned a version that no longer exists — conflict, not create.
+      throw new Error(
+        JSON.stringify({
+          error: 'hash_conflict',
+          path,
+          expected: input.prevHash,
+          actual: null,
+          hint: 'The periodic note no longer exists on disk. Re-read before retrying.',
+        }),
+      );
+    }
     if (!input.createIfMissing) throw new Error(`Periodic note not found: ${path}`);
     await mkdir(dirname(abs), { recursive: true });
-    await writeFile(abs, input.content, 'utf8');
+    await atomicWrite(abs, input.content);
     upsertDoc(ctx, buildDoc(path, input.content));
-    return { path, bytesWritten: Buffer.byteLength(input.content, 'utf8') };
+    return {
+      path,
+      bytesWritten: Buffer.byteLength(input.content, 'utf8'),
+      contentHash: contentHash(input.content),
+    };
   }
 
   // Preserve frontmatter, append to body.
@@ -252,7 +281,7 @@ export async function appendPeriodicNote(
   const header = original.slice(0, fm.bodyStart);
   const newRaw = `${header}${newBody}`;
 
-  await writeFile(abs, newRaw, 'utf8');
+  await atomicWrite(abs, newRaw);
 
   const cached = ctx.notes.get(path);
   if (cached) {
@@ -260,5 +289,9 @@ export async function appendPeriodicNote(
     cached.raw = newRaw;
   }
 
-  return { path, bytesWritten: Buffer.byteLength(newRaw, 'utf8') };
+  return {
+    path,
+    bytesWritten: Buffer.byteLength(newRaw, 'utf8'),
+    contentHash: contentHash(newRaw),
+  };
 }

--- a/packages/server/src/tools/read_note.ts
+++ b/packages/server/src/tools/read_note.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { buildOutline } from '@seekstone/core/outline';
 import { z } from 'zod';
+import { contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 
 export const ReadNoteInput = z
@@ -47,6 +48,8 @@ export interface ReadNoteResult {
   bytesReturned: number;
   /** Total UTF-8 byte size of the source file. */
   noteBytes: number;
+  /** sha-256 (hex) of the whole file — pass as prevHash to edit tools for compare-and-swap. */
+  contentHash: string;
   /** Character offsets of the returned span in the raw file. Absent for whole-note reads. */
   span?: { charStart: number; charEnd: number };
 }
@@ -59,10 +62,19 @@ export async function readNote(ctx: ServerContext, input: ReadNoteInput): Promis
 
   const raw = await readFile(absPath, 'utf8');
   const noteBytes = Buffer.byteLength(raw, 'utf8');
+  // Always the whole file's hash, even for span reads — it identifies the
+  // on-disk version an edit's prevHash is compared against.
+  const hash = contentHash(raw);
 
   // Whole-note read — no selector
   if (input.section === undefined && input.block === undefined && input.lines === undefined) {
-    return { path: input.path, content: raw, bytesReturned: noteBytes, noteBytes };
+    return {
+      path: input.path,
+      content: raw,
+      bytesReturned: noteBytes,
+      noteBytes,
+      contentHash: hash,
+    };
   }
 
   const fm = parseFrontmatter(raw);
@@ -145,6 +157,7 @@ export async function readNote(ctx: ServerContext, input: ReadNoteInput): Promis
     content,
     bytesReturned: Buffer.byteLength(content, 'utf8'),
     noteBytes,
+    contentHash: hash,
     span: { charStart, charEnd },
   };
 }

--- a/packages/server/src/tools/replace_in_note.ts
+++ b/packages/server/src/tools/replace_in_note.ts
@@ -1,7 +1,9 @@
-import { readFile, rename, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { z } from 'zod';
+import { atomicWrite } from '../atomic-write.js';
+import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { assertWritable } from '../policy.js';
 
@@ -25,6 +27,12 @@ export const ReplaceInNoteInput = z.object({
     .optional()
     .describe('Maximum number of replacements. Omit to replace all.'),
   dryRun: z.boolean().default(false).describe('If true, report matches without writing anything.'),
+  prevHash: z
+    .string()
+    .optional()
+    .describe(
+      'Optional compare-and-swap guard: the contentHash from a prior read. Fails with hash_conflict if the note changed since.',
+    ),
 });
 export type ReplaceInNoteInput = z.infer<typeof ReplaceInNoteInput>;
 
@@ -39,6 +47,8 @@ export interface ReplaceInNoteResult {
   matches: MatchPosition[];
   bytesWritten?: number;
   frontmatterUnchanged: true;
+  /** sha-256 (hex) of the new content after a write; absent on dry runs and zero-match calls. */
+  contentHash?: string;
 }
 
 function escapeRegex(s: string): string {
@@ -53,12 +63,6 @@ function buildRegex(
   if (opts.wholeWord) pattern = `\\b(?:${pattern})\\b`;
   const flags = `g${opts.caseSensitive ? '' : 'i'}`;
   return new RegExp(pattern, flags);
-}
-
-async function atomicWrite(absPath: string, content: string): Promise<void> {
-  const tmpPath = `${absPath}.seekstone-replace-tmp`;
-  await writeFile(tmpPath, content, 'utf8');
-  await rename(tmpPath, absPath);
 }
 
 export async function replaceInNote(
@@ -84,6 +88,7 @@ export async function replaceInNote(
   }
 
   const raw = await readFile(absPath, 'utf8');
+  if (input.prevHash !== undefined) assertHashMatch(raw, input.prevHash, input.path);
   const fm = parseFrontmatter(raw);
   const originalFmRegion = raw.slice(0, fm.bodyStart);
   const body = raw.slice(fm.bodyStart);
@@ -139,5 +144,6 @@ export async function replaceInNote(
     matches,
     bytesWritten: Buffer.byteLength(newContent, 'utf8'),
     frontmatterUnchanged: true,
+    contentHash: contentHash(newContent),
   };
 }


### PR DESCRIPTION
Closes [SHA-250](https://linear.app/shaqster/issue/SHA-250).

The last behavioral piece of the "safe FS-direct writes" story before the write-safety contract (SHA-259). Two hazards closed: stale writes silently discarding concurrent edits, and torn files from non-atomic writes. (The issue's other half — create/move overwrite protection — already shipped.)

## CAS (opt-in, per call)

- `read_note` returns **`contentHash`** — sha-256 hex of the note's exact disk bytes (whole-file hash even for span reads; it identifies the version an edit is compared against).
- Edit tools accept optional **`prevHash`**: `append_note`, `patch_note`, `patch_frontmatter`, `replace_in_note`, `append_periodic_note`, and `create_note` **only with `overwrite: true`** (a zod refine rejects the meaningless fresh-create case). `move_note`/`delete_note` deliberately excluded — neither destroys concurrent content edits (rename preserves them; deletes are recoverable since #216).
- Mismatch → structured `{"error":"hash_conflict", path, expected, actual, hint}` with the **current** disk hash, checked immediately after the read, before any edit; disk untouched. A pinned version that no longer exists is also a conflict, not a silent create.
- Every mutating result returns the **new** content's hash, so chained edits need zero re-reads.
- Naming is camelCase (`contentHash`/`prevHash`) per existing API convention, diverging from the issue's snake_case spelling deliberately.
- This is conflict **detection**, not locking — documented in the helper and reflected in the upcoming contract language.

## Atomic-write unification

One shared `atomicWrite` (temp file + rename, suffix `.seekstone-tmp`) replaces the two duplicated per-tool helpers and converts every remaining direct `writeFile`: `create_note`, `append_note` (whose doc comment falsely claimed atomicity), `patch_frontmatter`, both `periodic_note` paths, and `move_note`'s referencing-note rewrites. Every write path is now crash-safe: old content or new content, never a torn file. Windows rename-over-existing was already proven by `patch_note` across the CI OS matrix.

## Verification

- New `content-hash.test.ts` (known sha-256 vector, byte sensitivity, structured conflict shape), `atomic-write.test.ts`, and a cross-tool `cas.test.ts` (match/stale/omitted per tool, chained edits, dryRun conflict, create refine + guarded overwrite). 389 server tests green; full workspace green; build + conformance pass.
- Live smoke on the built bundle: `read_note` → hash, guarded append succeeds returning the chain hash, stale retry returns `hash_conflict` with the current hash.

Changeset: minor.