### PR TITLE
fix(deps): bump ip-address and fast-uri to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3571,9 +3571,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -4035,9 +4035,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Summary

Lockfile-only, in-range bumps for two of today's Dependabot alerts, both transitive via `@modelcontextprotocol/sdk`:

- **ip-address** 10.2.0 → 10.4.0 — fixes alerts #26–28 (SSRF / trust-boundary bypass: octal octet decoding, CIDR-suffix classification bypass, IPv4-mapped IPv6 misclassification; 1 high, 2 moderate)
- **fast-uri** 3.1.4 → 3.1.5 — fixes alert #20 (host confusion via backslash authority introducer; high)

The 5 undici alerts were already resolved by #207 (undici 8.9.0).

**Not fixed here:** the `@hono/node-server` alert (#16, moderate) — the fix is only in 2.0.5, a major, and the MCP SDK pins `^1.19.9`. Blocked on an upstream SDK bump. Low practical risk for seekstone: it's a Windows-only path traversal in Hono's HTTP static-file serving, and seekstone runs over stdio.

Full test suite passes locally.