### PR TITLE
feat(server): context_pack — one-call byte-budgeted context assembly (SHA-256)

### DIFF
--- a/.changeset/context-pack.md
+++ b/.changeset/context-pack.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+Add `context_pack` — one-call, byte-budgeted context assembly for answering a question about the vault. Returns ranked excerpts (with inline scalar frontmatter), backlink/outlink neighbor notes with one-line summaries, and overflow source refs for follow-up reads, all hard-capped at a caller-set byte budget (default 2048, never exceeded). Replaces the search → read → get_backlinks round-trip loop with a single payload, and reports explicit `totalMatches` + `confidence` so an empty or thin pack is never mistaken for coverage.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center"><strong>The Obsidian MCP server that needs no plugin, no running Obsidian app — and doesn't blow your context window.</strong></p>
-<p align="center"><em>Filesystem-direct · single-digit-ms search · ~2 KB payloads · 17 tools · macOS · Linux · Windows</em></p>
+<p align="center"><em>Filesystem-direct · single-digit-ms search · ~2 KB payloads · 18 tools · macOS · Linux · Windows</em></p>
 
 <p align="center"><a href="https://seekstone.dev"><strong>seekstone.dev →</strong></a></p>
 
@@ -258,7 +258,7 @@ Seekstone is a standard MCP stdio server — any MCP client can run it. Use the 
 
 ---
 
-After installing, restart the client. On startup Seekstone walks the vault, builds an in-memory full-text index (a few seconds for thousands of notes), and keeps it live as you edit. The 17 tools below are then available to Claude.
+After installing, restart the client. On startup Seekstone walks the vault, builds an in-memory full-text index (a few seconds for thousands of notes), and keeps it live as you edit. The 18 tools below are then available to Claude.
 
 Requires [Node.js](https://nodejs.org) ≥ 22 for the CLI options. The one-click `.mcpb` bundle has no external requirements.
 
@@ -293,6 +293,7 @@ Claude never sees your full vault at once — it searches and reads selectively,
 |---|---|
 | `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy, prefix, and phrase queries. |
 | `query_notes` | Structured metadata query. Filter by frontmatter key/value predicates (`eq`, `ne`, `contains`, `exists`, `missing`, `gt`/`gte`/`lt`/`lte`), tag, folder, modified time, and size; sort and select the fields you need. Returns compact rows (path + title by default), not note content. |
+| `context_pack` | Answer-ready context for a natural-language question in one call, hard-capped at a byte budget (default 2 KB): ranked excerpts, linked neighbor notes with one-line summaries, and follow-up source paths — replaces a search → read → get_backlinks round-trip loop. |
 | `read_note` | Read the full content of a note by vault-relative path. Supports returning a single section, block, or line range. |
 | `list_notes` | List notes, optionally filtered by folder prefix or tag. |
 | `list_tags` | List all tags in the vault sorted by usage count (or alphabetically). |
@@ -405,7 +406,7 @@ npx tsc -p packages/server/tsconfig.json --noEmit        # typecheck
 
 | Package | Purpose |
 |---|---|
-| `packages/server` | The published `seekstone` MCP server (17 tools, stdio, MiniSearch index, chokidar watcher). |
+| `packages/server` | The published `seekstone` MCP server (18 tools, stdio, MiniSearch index, chokidar watcher). |
 | `packages/core` | Shared vault primitives — walk, frontmatter parser, link/tag extractor, percentiles. Bundled into the server build. |
 | `packages/harness` | Profiler + benchmark + write-safety harness (REST vs filesystem) that produced the payload numbers above. Dev-only; not published. |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,7 +167,7 @@ sequenceDiagram
 ```
 
 `ListToolsRequest` is answered directly from the bootstrap's static schema list
-(the 17 tools). On error, `dispatch()` catches and returns
+(the 18 tools). On error, `dispatch()` catches and returns
 `{ isError: true, content: [...] }` rather than throwing — the session stays
 alive.
 
@@ -294,12 +294,13 @@ are the receipts.
 
 ---
 
-## The 17 tools
+## The 18 tools
 
 | Tool | Kind | Purpose |
 | --- | --- | --- |
 | `search` | read | Ranked full-text search; returns ~200-char excerpts, not full notes |
 | `query_notes` | read | Structured metadata query: frontmatter predicates + mtime/size/tag/folder filters; compact rows, no note content |
+| `context_pack` | read | Byte-budgeted context pack for a question: ranked excerpts + link-neighborhood summaries + follow-up sources in one call |
 | `read_note` | read | Read a note (with optional outline/frontmatter metadata) |
 | `list_notes` | read | Enumerate notes, optionally by folder |
 | `list_tags` | read | All tags with usage counts |

--- a/docs/CLIENT-TESTING.md
+++ b/docs/CLIENT-TESTING.md
@@ -18,7 +18,7 @@ If protocol conformance passes, any spec-compliant stdio client can talk to Seek
 For each client, three steps against a scratch vault (never a personal one):
 
 1. **Install** exactly as the README documents it for that client — no undocumented workarounds. If a workaround is needed, that's a docs bug; fix the docs.
-2. **Tools appear** — the client's MCP/server UI lists seekstone with 17 tools.
+2. **Tools appear** — the client's MCP/server UI lists seekstone with 18 tools.
 3. **One search + one write** — ask for a term seeded in the scratch vault (search must return it), then ask to append a line to a note (file on disk must change, frontmatter untouched).
 
 Record each pass here (newest first):

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -12,11 +12,11 @@ Seekstone is published as [`seekstone`](https://www.npmjs.com/package/seekstone)
 
 - **Name:** Seekstone
 - **Tagline:** An Obsidian MCP server — filesystem-direct, low context-tax.
-- **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 17 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
+- **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 18 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
 - **Install:** `npx -y seekstone`; env `SEEKSTONE_VAULT=/path/to/vault`
 - **Repo:** https://github.com/shaqmughal/seekstone
 - **npm:** https://www.npmjs.com/package/seekstone
-- **Tools (17):** _Read_ — search, query_notes, read_note, list_notes, list_tags, outline_note, get_backlinks, get_links, get_periodic_note · _Write_ — create_note, delete_note, move_note, append_note, patch_frontmatter, patch_note, replace_in_note, append_periodic_note
+- **Tools (18):** _Read_ — search, query_notes, context_pack, read_note, list_notes, list_tags, outline_note, get_backlinks, get_links, get_periodic_note · _Write_ — create_note, delete_note, move_note, append_note, patch_frontmatter, patch_note, replace_in_note, append_periodic_note
 - **Categories/tags:** obsidian, notes, knowledge-base, markdown, search, obsidian-mcp
 
 <!-- Note: the official registry caps server.json `description` at 100 characters. -->

--- a/docs/WRITE-SAFETY.md
+++ b/docs/WRITE-SAFETY.md
@@ -27,7 +27,7 @@ telemetry, no update checks, no cloud calls. Nothing leaves your machine.
   the MCP SDK, chokidar, fast-glob, minisearch, yaml, zod, picomatch.
 - Proven by: [`no-network.test.ts`](../packages/server/src/no-network.test.ts)
   replaces Node's socket/http/https primitives with throwing stubs, then runs
-  the real index build **and all 17 tools** through the real dispatcher. Any
+  the real index build **and all 18 tools** through the real dispatcher. Any
   connection attempt fails the suite.
 
 ### 2. Vault sandbox

--- a/llms.txt
+++ b/llms.txt
@@ -48,11 +48,12 @@ npx -y seekstone init --client cursor --write
 
 Or add the same `mcpServers` JSON block as Claude Desktop to `~/.cursor/mcp.json`. Any other MCP-over-stdio client (VS Code/Copilot, Windsurf, Cline, Continue, JetBrains, Zed) takes the identical block in its own MCP config file.
 
-## Tools (17)
+## Tools (18)
 
 Read:
 - `search` — full-text search returning ranked excerpts, ~120 chars by default and tunable (not full notes)
 - `query_notes` — structured metadata query: filter notes by frontmatter key/value predicates, tag, folder, modified time, and size; returns compact rows (path + title by default), not note content
+- `context_pack` — answer-ready context for a natural-language question in one call, hard-capped at a byte budget (default 2048): ranked excerpts, linked neighbor notes with one-line summaries, and follow-up source paths
 - `read_note` — read the full content of a note by vault-relative path; supports section, block, or line-range slices
 - `list_notes` — list notes filtered by folder prefix or tag
 - `list_tags` — list all tags sorted by usage count or alphabetically

--- a/packages/harness/src/bench/adapters/seekstone.test.ts
+++ b/packages/harness/src/bench/adapters/seekstone.test.ts
@@ -54,6 +54,7 @@ describe('SeekstoneAdapter', () => {
       'write',
       'list',
       'listTags',
+      'contextPack',
       'outline',
       'getBacklinks',
       'getLinks',
@@ -103,6 +104,22 @@ describe('SeekstoneAdapter', () => {
     const { result, payloadBytes } = await adapter.listTags();
     expect(result).toBeDefined();
     expect(payloadBytes).toBeGreaterThan(0);
+  });
+
+  it('contextPack() assembles a pack within the byte budget', async () => {
+    const { result, payloadBytes, payloadText } = await adapter.contextPack('alpha content', 1024);
+    const pack = result as { excerpts: unknown[]; totalMatches: number; confidence: string };
+    expect(pack.excerpts.length).toBeGreaterThan(0);
+    expect(pack.totalMatches).toBeGreaterThan(0);
+    expect(pack.confidence).toBe('high');
+    expect(payloadBytes).toBeLessThanOrEqual(1024);
+    expect(payloadText).toBeDefined();
+  });
+
+  it('contextPack() applies the default budget when omitted', async () => {
+    const { payloadBytes } = await adapter.contextPack('alpha');
+    expect(payloadBytes).toBeGreaterThan(0);
+    expect(payloadBytes).toBeLessThanOrEqual(2048);
   });
 
   it('outline() returns a structural outline of a note', async () => {

--- a/packages/harness/src/bench/adapters/seekstone.ts
+++ b/packages/harness/src/bench/adapters/seekstone.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import type { ServerContext } from '../../../../server/src/context.js';
 import { buildIndex } from '../../../../server/src/index/build.js';
 import { PERMISSIVE_POLICY } from '../../../../server/src/policy.js';
+import { contextPack as contextPackTool } from '../../../../server/src/tools/context_pack.js';
 import { createNote as createNoteTool } from '../../../../server/src/tools/create_note.js';
 import { deleteNote as deleteNoteTool } from '../../../../server/src/tools/delete_note.js';
 import { getBacklinks as getBacklinksTool } from '../../../../server/src/tools/get_backlinks.js';
@@ -96,6 +97,17 @@ export class SeekstoneAdapter implements Backend {
 
   async listTags(): Promise<BackendResponse<unknown>> {
     const result = listTagsTool(this.ctx, { sort: 'count' });
+    const payload = JSON.stringify(result);
+    return {
+      result,
+      payloadBytes: Buffer.byteLength(payload, 'utf8'),
+      payloadText: payload,
+    };
+  }
+
+  async contextPack(query: string, budgetBytes?: number): Promise<BackendResponse<unknown>> {
+    // Direct fn call bypasses the zod schema, so apply its default here.
+    const result = contextPackTool(this.ctx, { query, budgetBytes: budgetBytes ?? 2048 });
     const payload = JSON.stringify(result);
     return {
       result,

--- a/packages/harness/src/bench/backend.ts
+++ b/packages/harness/src/bench/backend.ts
@@ -62,6 +62,8 @@ export interface Backend {
 
   /** list_tags — all tags with usage counts. */
   listTags?(): Promise<BackendResponse<unknown>>;
+  /** context_pack — byte-budgeted one-call context assembly for a question. */
+  contextPack?(query: string, budgetBytes?: number): Promise<BackendResponse<unknown>>;
   /** outline_note — heading tree + block anchors without body content. */
   outline?(path: string): Promise<BackendResponse<unknown>>;
   /** get_backlinks — reverse-link lookup. */

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -1,6 +1,7 @@
 import type { ServerContext } from './context.js';
 import type { Logger } from './log.js';
 import { AppendNoteInput, appendNote } from './tools/append_note.js';
+import { ContextPackInput, contextPack } from './tools/context_pack.js';
 import { CreateNoteInput, createNote } from './tools/create_note.js';
 import { DeleteNoteInput, deleteNote } from './tools/delete_note.js';
 import { GetBacklinksInput, getBacklinks } from './tools/get_backlinks.js';
@@ -31,6 +32,7 @@ export type ToolResult = {
 export const HANDLED_TOOLS = [
   'search',
   'query_notes',
+  'context_pack',
   'read_note',
   'list_notes',
   'list_tags',
@@ -88,6 +90,7 @@ const META_KEYS = [
   'date',
   'permanent',
   'prevHash',
+  'budgetBytes',
 ] as const;
 
 function safeMeta(args: unknown): Record<string, unknown> {
@@ -173,6 +176,12 @@ async function run(ctx: ServerContext, name: string, args: unknown): Promise<Too
       const hits = queryNotes(ctx, input);
       // Minified like search — a second search mode, same context-tax discipline.
       return { content: [{ type: 'text', text: JSON.stringify(hits) }] };
+    }
+    case 'context_pack': {
+      const input = ContextPackInput.parse(args);
+      const pack = contextPack(ctx, input);
+      // Minified: the assembler meters its byte budget against exactly this serialization.
+      return { content: [{ type: 'text', text: JSON.stringify(pack) }] };
     }
     case 'read_note': {
       const input = ReadNoteInput.parse(args);

--- a/packages/server/src/no-network.test.ts
+++ b/packages/server/src/no-network.test.ts
@@ -74,10 +74,11 @@ describe('the server makes no outbound network calls', () => {
   });
 
   it('every tool runs without opening a connection', async () => {
-    // Covers ALL 17 HANDLED_TOOLS — cited by docs/WRITE-SAFETY.md guarantee 1.
+    // Covers ALL 18 HANDLED_TOOLS — cited by docs/WRITE-SAFETY.md guarantee 1.
     const calls: Array<[string, unknown]> = [
       ['search', { query: 'hello' }],
       ['query_notes', { where: [{ key: 'title', op: 'ne', value: 'x' }] }],
+      ['context_pack', { query: 'hello' }],
       ['read_note', { path: 'a.md' }],
       ['list_notes', {}],
       ['list_tags', {}],

--- a/packages/server/src/tool-list.test.ts
+++ b/packages/server/src/tool-list.test.ts
@@ -15,18 +15,18 @@ describe('ALL_TOOLS', () => {
 });
 
 describe('visibleTools', () => {
-  it('returns all 17 tools under a permissive policy', () => {
-    expect(visibleTools(PERMISSIVE_POLICY)).toHaveLength(17);
+  it('returns all 18 tools under a permissive policy', () => {
+    expect(visibleTools(PERMISSIVE_POLICY)).toHaveLength(18);
   });
   it('unregisters the 8 write tools in read-only mode', () => {
     const visible = visibleTools({ readOnly: true });
-    expect(visible).toHaveLength(9);
+    expect(visible).toHaveLength(10);
     for (const t of visible) expect(WRITE_TOOLS.has(t.name)).toBe(false);
     // get_periodic_note stays listed — it is a read tool; its createIfMissing
     // side-effect is neutralized at dispatch.
     expect(visible.map((t) => t.name)).toContain('get_periodic_note');
   });
   it('write-path scoping alone hides nothing', () => {
-    expect(visibleTools({ readOnly: false, writeGlobs: ['journal/**'] })).toHaveLength(17);
+    expect(visibleTools({ readOnly: false, writeGlobs: ['journal/**'] })).toHaveLength(18);
   });
 });

--- a/packages/server/src/tool-list.ts
+++ b/packages/server/src/tool-list.ts
@@ -83,6 +83,22 @@ export const ALL_TOOLS = [
     },
   },
   {
+    name: 'context_pack',
+    description:
+      'Assemble everything needed to ANSWER a natural-language question in one call, under a strict byte budget (default 2048): ranked excerpts, linked neighbor notes (backlinks/outlinks) with one-line summaries, and follow-up source paths. Use search to locate notes and query_notes for metadata filters; use context_pack when you want answer-ready context without multiple round-trips. Empty excerpts with confidence "none" or "low" means the vault lacks coverage — do not infer content.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Natural-language question or topic.' },
+        budgetBytes: {
+          type: 'number',
+          description: 'Hard cap on response JSON bytes (256–16384, default 2048).',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
     name: 'read_note',
     description:
       'Read a note or a span of it — by heading section, block reference, or line range. Returns structured JSON with the content, bytes returned, total note size, and a contentHash to pass as prevHash to edit tools for compare-and-swap. Use search or outline_note first to find the right path and section names.',

--- a/packages/server/src/tools/context_pack.test.ts
+++ b/packages/server/src/tools/context_pack.test.ts
@@ -307,6 +307,61 @@ describe('contextPack', () => {
     expect(pack.excerpts[0]?.fm).toBeUndefined();
   });
 
+  it('caps the neighborhood at 5 and overflows the rest into sources', () => {
+    const stubs = [];
+    const refs: BacklinkRef[] = [];
+    for (let i = 0; i < 8; i++) {
+      stubs.push({
+        id: `refs/stub-${i}.md`,
+        title: `Stub ${i}`,
+        body: `Cross-reference stub number ${i}.`,
+      });
+      refs.push({ path: `refs/stub-${i}.md`, line: i + 1, linkType: 'wikilink' });
+    }
+    const backlinks = new Map<string, BacklinkRef[]>([['hub/axolotl.md', refs]]);
+    const ctx = buildCtx(
+      '/vault',
+      [
+        { id: 'hub/axolotl.md', title: 'Axolotl', body: 'Axolotl regeneration research hub.' },
+        ...stubs,
+      ],
+      backlinks,
+    );
+    const pack = contextPack(ctx, { query: 'axolotl regeneration', budgetBytes: 8192 });
+    expect(pack.neighborhood.length).toBe(5);
+    // The 3 over-cap neighbors overflow into sources; a count cap is not a
+    // budget drop, so truncated stays unset.
+    expect(pack.sources.length).toBe(3);
+    expect(pack.truncated).toBeUndefined();
+  });
+
+  it('stops the neighborhood mid-phase when the budget runs out', () => {
+    const stubs = [];
+    const refs: BacklinkRef[] = [];
+    for (let i = 0; i < 4; i++) {
+      stubs.push({
+        id: `refs/stub-${i}.md`,
+        title: `Stub ${i}`,
+        body: `Cross-reference stub number ${i} with a long enough body to make each neighborhood summary cost real bytes against a tight budget.`,
+      });
+      refs.push({ path: `refs/stub-${i}.md`, line: i + 1, linkType: 'wikilink' });
+    }
+    const backlinks = new Map<string, BacklinkRef[]>([['hub/axolotl.md', refs]]);
+    const ctx = buildCtx(
+      '/vault',
+      [
+        { id: 'hub/axolotl.md', title: 'Axolotl', body: 'Axolotl regeneration research hub.' },
+        ...stubs,
+      ],
+      backlinks,
+    );
+    const pack = contextPack(ctx, { query: 'axolotl regeneration', budgetBytes: 420 });
+    expect(Buffer.byteLength(JSON.stringify(pack), 'utf8')).toBeLessThanOrEqual(420);
+    // Budget forces neighbor drops: fewer than the 4 available, flagged truncated.
+    expect(pack.neighborhood.length).toBeLessThan(4);
+    expect(pack.truncated).toBe(true);
+  });
+
   it('signals truncation with overflow sources when the budget forces drops', () => {
     const ctx = buildCtx('/vault', bigVault());
     const pack = contextPack(ctx, { query: 'photosynthesis chlorophyll', budgetBytes: 512 });

--- a/packages/server/src/tools/context_pack.test.ts
+++ b/packages/server/src/tools/context_pack.test.ts
@@ -1,0 +1,355 @@
+import MiniSearch from 'minisearch';
+import { describe, expect, it } from 'vitest';
+import type { BacklinkRef, ServerContext } from '../context.js';
+import type { IndexedNote } from '../index/types.js';
+import { PERMISSIVE_POLICY } from '../policy.js';
+import { contextPack } from './context_pack.js';
+
+function buildCtx(
+  vaultRoot: string,
+  notes: Array<{
+    id: string;
+    title: string;
+    body: string;
+    tags?: string;
+    fmKeys?: string;
+    fm?: Record<string, unknown> | null;
+    raw?: string;
+  }>,
+  backlinks?: Map<string, BacklinkRef[]>,
+): ServerContext {
+  const index = new MiniSearch<IndexedNote>({
+    idField: 'id',
+    fields: ['title', 'body', 'tags', 'fmKeys'],
+    storeFields: ['id', 'title', 'tags', 'sizeBytes', 'mtimeMs'],
+    searchOptions: { boost: { title: 3, tags: 2, body: 1 }, fuzzy: 0.2, prefix: true },
+  });
+  const notesMap = new Map<string, IndexedNote>();
+  const docs: IndexedNote[] = notes.map((n) => ({
+    id: n.id,
+    title: n.title,
+    body: n.body,
+    tags: n.tags ?? '',
+    fmKeys: n.fmKeys ?? '',
+    fm: n.fm ?? null,
+    raw: n.raw ?? n.body,
+    sizeBytes: Buffer.byteLength(n.raw ?? n.body, 'utf8'),
+    mtimeMs: Date.now(),
+  }));
+  index.addAll(docs);
+  for (const doc of docs) notesMap.set(doc.id, doc);
+  return {
+    vaultRoot,
+    index,
+    notes: notesMap,
+    backlinks: backlinks ?? new Map(),
+    policy: PERMISSIVE_POLICY,
+  };
+}
+
+const packedBytes = (ctx: ServerContext, query: string, budgetBytes: number) =>
+  Buffer.byteLength(JSON.stringify(contextPack(ctx, { query, budgetBytes })), 'utf8');
+
+/** A vault with enough matter to overflow small budgets. */
+function bigVault() {
+  const notes = [];
+  for (let i = 0; i < 20; i++) {
+    notes.push({
+      id: `topics/photosynthesis-${i}.md`,
+      title: `Photosynthesis Study ${i}`,
+      body: `Photosynthesis converts light into chemical energy. Chapter ${i} covers chlorophyll, chloroplasts, and the Calvin cycle in depth. ${'Additional detail sentence about light-dependent reactions. '.repeat(5)}`,
+      tags: 'biology',
+    });
+  }
+  return notes;
+}
+
+describe('contextPack', () => {
+  it('returns ranked excerpts with lean field conventions', () => {
+    const ctx = buildCtx('/vault', [
+      {
+        id: 'plants/photosynthesis.md',
+        title: 'photosynthesis', // equals basename → omitted
+        body: 'Photosynthesis converts light into chemical energy.',
+        tags: '',
+      },
+      {
+        id: 'plants/chlorophyll.md',
+        title: 'Chlorophyll Pigment', // differs from basename → kept
+        body: 'Chlorophyll absorbs light for photosynthesis.',
+        tags: 'biology pigments',
+      },
+    ]);
+    const pack = contextPack(ctx, { query: 'photosynthesis', budgetBytes: 2048 });
+    expect(pack.excerpts.length).toBe(2);
+    expect(pack.totalMatches).toBe(2);
+    const byPath = new Map(pack.excerpts.map((e) => [e.path, e]));
+    expect(byPath.get('plants/photosynthesis.md')?.title).toBeUndefined();
+    expect(byPath.get('plants/photosynthesis.md')?.tags).toBeUndefined();
+    expect(byPath.get('plants/chlorophyll.md')?.title).toBe('Chlorophyll Pigment');
+    expect(byPath.get('plants/chlorophyll.md')?.tags).toEqual(['biology', 'pigments']);
+    for (const e of pack.excerpts) {
+      expect(e.score).toBe(Math.round(e.score * 100) / 100);
+    }
+    // Scores descend in rank order.
+    const scores = pack.excerpts.map((e) => e.score);
+    expect([...scores].sort((a, b) => b - a)).toEqual(scores);
+  });
+
+  it('never exceeds the byte budget (hard-cap invariant)', () => {
+    const ctx = buildCtx('/vault', bigVault());
+    for (const budget of [256, 512, 1024, 2048]) {
+      expect(packedBytes(ctx, 'photosynthesis chlorophyll', budget)).toBeLessThanOrEqual(budget);
+    }
+  });
+
+  it('hard cap holds with multi-byte UTF-8 content', () => {
+    const notes = [];
+    for (let i = 0; i < 10; i++) {
+      notes.push({
+        id: `notes/emoji-${i}.md`,
+        title: `Emoji ${i}`,
+        body: `photosynthesis ${'🌱🌿☘️ has multi-byte content — '.repeat(30)}`,
+      });
+    }
+    const ctx = buildCtx('/vault', notes);
+    for (const budget of [256, 512, 1024]) {
+      expect(packedBytes(ctx, 'photosynthesis', budget)).toBeLessThanOrEqual(budget);
+    }
+  });
+
+  it('returns an explicit empty pack with confidence "none" for no matches', () => {
+    const ctx = buildCtx('/vault', bigVault());
+    const pack = contextPack(ctx, { query: 'zzzzabsolutelyunmatchablexyz', budgetBytes: 2048 });
+    expect(pack).toEqual({
+      excerpts: [],
+      neighborhood: [],
+      sources: [],
+      totalMatches: 0,
+      confidence: 'none',
+    });
+    expect(pack.truncated).toBeUndefined();
+  });
+
+  it('reports confidence "low" when no included excerpt contains a query term', () => {
+    // Match on title only — body has no query term, so the excerpt is fallback text.
+    const ctx = buildCtx('/vault', [
+      { id: 'notes/mitochondria.md', title: 'Mitochondria', body: 'The powerhouse of the cell.' },
+    ]);
+    const pack = contextPack(ctx, { query: 'mitochondria', budgetBytes: 2048 });
+    expect(pack.excerpts.length).toBe(1);
+    expect(pack.confidence).toBe('low');
+  });
+
+  it('includes backlink neighbors with rel, line, and summary', () => {
+    const backlinks = new Map<string, BacklinkRef[]>([
+      [
+        'plants/photosynthesis.md',
+        [{ path: 'journal/2026-05-01.md', line: 4, linkType: 'wikilink' }],
+      ],
+    ]);
+    const ctx = buildCtx(
+      '/vault',
+      [
+        {
+          id: 'plants/photosynthesis.md',
+          title: 'Photosynthesis',
+          body: 'Photosynthesis converts light into chemical energy.',
+        },
+        {
+          id: 'journal/2026-05-01.md',
+          title: 'May Journal',
+          body: 'Read about plant biology today.',
+          raw: 'Read about plant biology today.\n\n\nSee [[photosynthesis]].',
+        },
+      ],
+      backlinks,
+    );
+    const pack = contextPack(ctx, { query: 'photosynthesis converts', budgetBytes: 2048 });
+    const neighbor = pack.neighborhood.find((n) => n.path === 'journal/2026-05-01.md');
+    expect(neighbor).toBeDefined();
+    // The journal note also outlinks to the hit, so rel merges to 'both'... unless
+    // it matched the query itself and became an excerpt. It shouldn't here.
+    expect(neighbor?.rel).toBe('backlink');
+    expect(neighbor?.line).toBe(4);
+    expect(neighbor?.summary.length).toBeGreaterThan(0);
+  });
+
+  it('includes outlink neighbors resolved from wikilinks in the hit note', () => {
+    const ctx = buildCtx('/vault', [
+      {
+        id: 'plants/photosynthesis.md',
+        title: 'Photosynthesis',
+        body: 'Photosynthesis needs chlorophyll.',
+        raw: 'Photosynthesis needs [[chlorophyll]].',
+      },
+      {
+        id: 'plants/chlorophyll.md',
+        title: 'Chlorophyll',
+        body: 'A green pigment found in chloroplasts.',
+      },
+    ]);
+    const pack = contextPack(ctx, { query: 'photosynthesis needs', budgetBytes: 2048 });
+    const neighbor = pack.neighborhood.find((n) => n.path === 'plants/chlorophyll.md');
+    expect(neighbor).toBeDefined();
+    expect(neighbor?.rel).toBe('outlink');
+    expect(neighbor?.line).toBeUndefined();
+  });
+
+  it('dedups: a note that is both hit and neighbor appears only in excerpts', () => {
+    const backlinks = new Map<string, BacklinkRef[]>([
+      [
+        'plants/photosynthesis.md',
+        [{ path: 'plants/chlorophyll.md', line: 1, linkType: 'wikilink' }],
+      ],
+    ]);
+    const ctx = buildCtx(
+      '/vault',
+      [
+        {
+          id: 'plants/photosynthesis.md',
+          title: 'Photosynthesis',
+          body: 'Photosynthesis converts light energy.',
+        },
+        {
+          id: 'plants/chlorophyll.md',
+          title: 'Chlorophyll',
+          body: 'Chlorophyll enables photosynthesis.',
+          raw: 'Chlorophyll enables [[photosynthesis]].',
+        },
+      ],
+      backlinks,
+    );
+    const pack = contextPack(ctx, { query: 'photosynthesis', budgetBytes: 2048 });
+    const excerptPaths = pack.excerpts.map((e) => e.path);
+    expect(excerptPaths).toContain('plants/chlorophyll.md');
+    expect(pack.neighborhood.map((n) => n.path)).not.toContain('plants/chlorophyll.md');
+  });
+
+  it('merges backlink+outlink neighbors into rel "both"', () => {
+    const backlinks = new Map<string, BacklinkRef[]>([
+      ['hub/topic.md', [{ path: 'refs/sidecar.md', line: 2, linkType: 'wikilink' }]],
+    ]);
+    const ctx = buildCtx(
+      '/vault',
+      [
+        {
+          id: 'hub/topic.md',
+          title: 'Quantum Tunnelling',
+          body: 'Quantum tunnelling lets particles cross barriers.',
+          raw: 'Quantum tunnelling lets particles cross barriers. See [[sidecar]].',
+        },
+        {
+          id: 'refs/sidecar.md',
+          title: 'Sidecar',
+          body: 'Reference material on barrier penetration.',
+          raw: 'Reference material.\n\nBack to [[topic]].',
+        },
+      ],
+      backlinks,
+    );
+    const pack = contextPack(ctx, { query: 'quantum tunnelling', budgetBytes: 2048 });
+    const neighbor = pack.neighborhood.find((n) => n.path === 'refs/sidecar.md');
+    expect(neighbor?.rel).toBe('both');
+    expect(neighbor?.line).toBe(2);
+  });
+
+  it('ranks neighbors connected to more hits first', () => {
+    const backlinks = new Map<string, BacklinkRef[]>([
+      ['a/alpha.md', [{ path: 'n/shared.md', line: 1, linkType: 'wikilink' }]],
+      [
+        'a/beta.md',
+        [
+          { path: 'n/shared.md', line: 2, linkType: 'wikilink' },
+          { path: 'n/single.md', line: 3, linkType: 'wikilink' },
+        ],
+      ],
+    ]);
+    const ctx = buildCtx(
+      '/vault',
+      [
+        { id: 'a/alpha.md', title: 'Alpha', body: 'Wombat migration in alpha region.' },
+        { id: 'a/beta.md', title: 'Beta', body: 'Wombat migration in beta region.' },
+        { id: 'n/shared.md', title: 'Shared', body: 'Linked from both regions.' },
+        { id: 'n/single.md', title: 'Single', body: 'Linked from one region.' },
+      ],
+      backlinks,
+    );
+    const pack = contextPack(ctx, { query: 'wombat migration', budgetBytes: 4096 });
+    const paths = pack.neighborhood.map((n) => n.path);
+    expect(paths.indexOf('n/shared.md')).toBeLessThan(paths.indexOf('n/single.md'));
+  });
+
+  it('inlines small scalar frontmatter and caps oversized values', () => {
+    const ctx = buildCtx('/vault', [
+      {
+        id: 'notes/tracked.md',
+        title: 'Tracked',
+        body: 'Falconry techniques and equipment.',
+        fm: { status: 'draft', priority: 2, nested: { deep: true }, blob: 'x'.repeat(500) },
+      },
+    ]);
+    const pack = contextPack(ctx, { query: 'falconry', budgetBytes: 2048 });
+    const fm = pack.excerpts[0]?.fm;
+    expect(fm).toEqual({ status: 'draft', priority: 2 }); // nested skipped, blob over cap
+  });
+
+  it('omits fm entirely when nothing scalar fits', () => {
+    const ctx = buildCtx('/vault', [
+      {
+        id: 'notes/heavy.md',
+        title: 'Heavy',
+        body: 'Falconry techniques and equipment.',
+        fm: { blob: 'x'.repeat(500) },
+      },
+    ]);
+    const pack = contextPack(ctx, { query: 'falconry', budgetBytes: 2048 });
+    expect(pack.excerpts[0]?.fm).toBeUndefined();
+  });
+
+  it('signals truncation with overflow sources when the budget forces drops', () => {
+    const ctx = buildCtx('/vault', bigVault());
+    const pack = contextPack(ctx, { query: 'photosynthesis chlorophyll', budgetBytes: 512 });
+    expect(pack.truncated).toBe(true);
+    expect(pack.totalMatches).toBeGreaterThan(pack.excerpts.length);
+    expect(pack.sources.length).toBeGreaterThan(0);
+    const included = new Set(pack.excerpts.map((e) => e.path));
+    for (const s of pack.sources) expect(included.has(s.path)).toBe(false);
+  });
+
+  it('soft reserve leaves room for the neighborhood under pressure', () => {
+    const notes = bigVault();
+    const backlinks = new Map<string, BacklinkRef[]>();
+    // Every big-vault note gets a backlink from a small stub note.
+    notes.push({
+      id: 'refs/stub.md',
+      title: 'Stub',
+      body: 'Cross-reference stub note.',
+      tags: '',
+    });
+    for (const n of notes.slice(0, 5)) {
+      backlinks.set(n.id, [{ path: 'refs/stub.md', line: 1, linkType: 'wikilink' }]);
+    }
+    const ctx = buildCtx('/vault', notes, backlinks);
+    const pack = contextPack(ctx, { query: 'photosynthesis chlorophyll', budgetBytes: 1024 });
+    expect(pack.excerpts.length).toBeGreaterThan(0);
+    expect(pack.neighborhood.length).toBeGreaterThan(0);
+  });
+
+  it('is deterministic: repeat calls produce byte-identical output', () => {
+    const ctx = buildCtx('/vault', bigVault());
+    const a = JSON.stringify(contextPack(ctx, { query: 'photosynthesis', budgetBytes: 1024 }));
+    const b = JSON.stringify(contextPack(ctx, { query: 'photosynthesis', budgetBytes: 1024 }));
+    expect(a).toBe(b);
+  });
+
+  it('larger budgets never return fewer excerpts', () => {
+    const ctx = buildCtx('/vault', bigVault());
+    let prev = 0;
+    for (const budget of [256, 512, 1024, 2048, 4096]) {
+      const pack = contextPack(ctx, { query: 'photosynthesis chlorophyll', budgetBytes: budget });
+      expect(pack.excerpts.length).toBeGreaterThanOrEqual(prev);
+      prev = pack.excerpts.length;
+    }
+  });
+});

--- a/packages/server/src/tools/context_pack.ts
+++ b/packages/server/src/tools/context_pack.ts
@@ -1,0 +1,279 @@
+import { extractLinksWithLines } from '@seekstone/core/extract';
+import { z } from 'zod';
+import type { ServerContext } from '../context.js';
+import { extractExcerpt } from '../index/excerpt.js';
+import { resolveLink } from '../index/resolve.js';
+import { basenameNoExt } from './search.js';
+
+export const ContextPackInput = z.object({
+  query: z.string().min(1).describe('Natural-language question or topic to assemble context for.'),
+  budgetBytes: z
+    .number()
+    .int()
+    .min(256)
+    .max(16384)
+    .default(2048)
+    .describe('Hard cap on the response JSON size in bytes. The pack never exceeds it.'),
+});
+export type ContextPackInput = z.infer<typeof ContextPackInput>;
+
+const MAX_CANDIDATES = 10;
+const NEIGHBOR_HITS = 3;
+const MAX_NEIGHBORS = 5;
+const NEIGHBOR_SUMMARY_LEN = 100;
+const MIN_EXCERPT_LEN = 60;
+const FM_MAX_BYTES = 120;
+const SOURCES_MAX = 8;
+
+export interface ContextPackExcerpt {
+  path: string;
+  title?: string;
+  score: number;
+  excerpt: string;
+  tags?: string[];
+  /** Scalar frontmatter values, in key order, capped at FM_MAX_BYTES serialized. */
+  fm?: Record<string, unknown>;
+}
+
+export interface ContextPackNeighbor {
+  path: string;
+  rel: 'backlink' | 'outlink' | 'both';
+  /** Line in the neighbor where it links to a hit (backlinks only). */
+  line?: number;
+  summary: string;
+}
+
+export interface ContextPackSource {
+  path: string;
+  line?: number;
+}
+
+export interface ContextPackResult {
+  excerpts: ContextPackExcerpt[];
+  neighborhood: ContextPackNeighbor[];
+  /** Overflow refs only — matches and neighbors that did not fit the budget. */
+  sources: ContextPackSource[];
+  totalMatches: number;
+  confidence: 'high' | 'low' | 'none';
+  truncated?: true;
+}
+
+/** Serialized cost of one array entry, +1 for the separating comma (conservative). */
+function entryCost(entry: unknown): number {
+  return Buffer.byteLength(JSON.stringify(entry), 'utf8') + 1;
+}
+
+/** Pick scalar frontmatter values in key order until the serialized subset exceeds the cap. */
+function pickFm(fm: Record<string, unknown> | null): Record<string, unknown> | undefined {
+  if (!fm) return undefined;
+  const out: Record<string, unknown> = {};
+  let picked = 0;
+  for (const key of Object.keys(fm)) {
+    const v = fm[key];
+    const t = typeof v;
+    if (t !== 'string' && t !== 'number' && t !== 'boolean') continue;
+    const candidate = { ...out, [key]: v };
+    if (Buffer.byteLength(JSON.stringify(candidate), 'utf8') > FM_MAX_BYTES) break;
+    out[key] = v;
+    picked += 1;
+  }
+  return picked > 0 ? out : undefined;
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}
+
+export function contextPack(ctx: ServerContext, input: ContextPackInput): ContextPackResult {
+  const results = ctx.index.search(input.query, {
+    boost: { title: 3, tags: 2, body: 1 },
+    fuzzy: 0.2,
+    prefix: true,
+  });
+  const totalMatches = results.length;
+  if (totalMatches === 0) {
+    return { excerpts: [], neighborhood: [], sources: [], totalMatches: 0, confidence: 'none' };
+  }
+
+  const terms = input.query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 1);
+
+  const scoreByPath = new Map<string, number>();
+  for (const r of results) scoreByPath.set(r.id, r.score);
+
+  // Meter the fixed envelope with worst-case flags so emitting them later can
+  // never break the cap. Entries are metered against the same minified
+  // serialization dispatch ships, so the budget is exact, not an estimate.
+  const budget = input.budgetBytes;
+  let used = Buffer.byteLength(
+    JSON.stringify({
+      excerpts: [],
+      neighborhood: [],
+      sources: [],
+      totalMatches,
+      confidence: 'high',
+      truncated: true,
+    }),
+    'utf8',
+  );
+
+  // Phase 1 — excerpts: greedy fill in rank order, holding back a soft reserve
+  // for the neighborhood. On the first non-fit, shrink the excerpt (half, then
+  // the floor); a shrunk entry ends the phase so the pack isn't all fragments.
+  const excerptLen = clamp(Math.floor(budget / 10), 80, 400);
+  const reserve = Math.min(Math.floor(budget / 4), 600);
+  const candidates = results.slice(0, MAX_CANDIDATES);
+  const excerpts: ContextPackExcerpt[] = [];
+  const overflowHits: ContextPackSource[] = [];
+  let droppedForBudget = false;
+
+  const buildEntry = (r: (typeof results)[number], len: number): ContextPackExcerpt => {
+    const note = ctx.notes.get(r.id);
+    const body = note?.body ?? '';
+    const noteTags = note?.tags ? note.tags.split(' ').filter(Boolean) : [];
+    const entry: ContextPackExcerpt = {
+      path: r.id,
+      score: Math.round(r.score * 100) / 100,
+      excerpt: extractExcerpt(body, terms, len),
+    };
+    const title = r.title as string;
+    if (title && title !== basenameNoExt(r.id)) entry.title = title;
+    if (noteTags.length > 0) entry.tags = noteTags;
+    const fm = pickFm(note?.fm ?? null);
+    if (fm) entry.fm = fm;
+    return entry;
+  };
+
+  const excerptCap = budget - reserve;
+  let phaseOpen = true;
+  for (const r of candidates) {
+    if (!phaseOpen) {
+      overflowHits.push({ path: r.id });
+      continue;
+    }
+    let placed = false;
+    const shrinkLens = [
+      ...new Set([
+        excerptLen,
+        Math.max(Math.floor(excerptLen / 2), MIN_EXCERPT_LEN),
+        MIN_EXCERPT_LEN,
+      ]),
+    ];
+    for (const len of shrinkLens) {
+      const entry = buildEntry(r, len);
+      const cost = entryCost(entry);
+      if (used + cost <= excerptCap) {
+        excerpts.push(entry);
+        used += cost;
+        placed = true;
+        // A shrunk excerpt means the budget is nearly spent — stop before
+        // packing many useless fragments.
+        if (len !== excerptLen) phaseOpen = false;
+        break;
+      }
+    }
+    if (!placed) {
+      phaseOpen = false;
+      droppedForBudget = true;
+      overflowHits.push({ path: r.id });
+    }
+  }
+
+  // Phase 2 — neighborhood: backlinks + outlinks of the top included hits.
+  // The reserve is released; entries fill whatever budget remains.
+  const includedPaths = new Set(excerpts.map((e) => e.path));
+  const seeds = excerpts.slice(0, NEIGHBOR_HITS).map((e) => e.path);
+  const agg = new Map<
+    string,
+    { rels: Set<'backlink' | 'outlink'>; seedPaths: Set<string>; line?: number }
+  >();
+  const connect = (
+    neighborPath: string,
+    seed: string,
+    rel: 'backlink' | 'outlink',
+    line?: number,
+  ) => {
+    if (neighborPath === seed || includedPaths.has(neighborPath)) return; // excerpt wins dedup
+    if (!ctx.notes.has(neighborPath)) return;
+    let entry = agg.get(neighborPath);
+    if (!entry) {
+      entry = { rels: new Set(), seedPaths: new Set() };
+      agg.set(neighborPath, entry);
+    }
+    entry.rels.add(rel);
+    entry.seedPaths.add(seed);
+    if (rel === 'backlink' && entry.line === undefined && line !== undefined) entry.line = line;
+  };
+  for (const seed of seeds) {
+    for (const ref of ctx.backlinks.get(seed) ?? []) {
+      connect(ref.path, seed, 'backlink', ref.line);
+    }
+    const note = ctx.notes.get(seed);
+    if (!note) continue;
+    for (const link of extractLinksWithLines(note.raw)) {
+      const target = resolveLink(link.target, ctx.notes);
+      if (target !== undefined) connect(target, seed, 'outlink');
+    }
+  }
+
+  const ranked = [...agg.entries()].sort((a, b) => {
+    const conn = b[1].seedPaths.size - a[1].seedPaths.size;
+    if (conn !== 0) return conn;
+    const score = (scoreByPath.get(b[0]) ?? 0) - (scoreByPath.get(a[0]) ?? 0);
+    if (score !== 0) return score;
+    return a[0] < b[0] ? -1 : 1;
+  });
+
+  const neighborhood: ContextPackNeighbor[] = [];
+  const overflowNeighbors: ContextPackSource[] = [];
+  for (const [path, info] of ranked) {
+    if (neighborhood.length >= MAX_NEIGHBORS) {
+      overflowNeighbors.push(info.line !== undefined ? { path, line: info.line } : { path });
+      continue;
+    }
+    const note = ctx.notes.get(path);
+    const entry: ContextPackNeighbor = {
+      path,
+      rel: info.rels.size === 2 ? 'both' : info.rels.has('backlink') ? 'backlink' : 'outlink',
+      summary: extractExcerpt(note?.body ?? '', terms, NEIGHBOR_SUMMARY_LEN),
+    };
+    if (info.line !== undefined) entry.line = info.line;
+    const cost = entryCost(entry);
+    if (used + cost > budget) {
+      droppedForBudget = true;
+      overflowNeighbors.push(info.line !== undefined ? { path, line: info.line } : { path });
+      // First non-fit ends the phase — later entries rank lower anyway.
+      for (const [p, i] of ranked.slice(ranked.findIndex(([rp]) => rp === path) + 1)) {
+        overflowNeighbors.push(i.line !== undefined ? { path: p, line: i.line } : { path: p });
+      }
+      break;
+    }
+    neighborhood.push(entry);
+    used += cost;
+  }
+
+  // Phase 3 — sources: overflow refs ("read these next"), deduped, best-first.
+  const sources: ContextPackSource[] = [];
+  const sourcePaths = new Set<string>();
+  for (const ref of [...overflowHits, ...overflowNeighbors]) {
+    if (sources.length >= SOURCES_MAX) break;
+    if (includedPaths.has(ref.path) || sourcePaths.has(ref.path)) continue;
+    const cost = entryCost(ref);
+    if (used + cost > budget) break;
+    sources.push(ref);
+    sourcePaths.add(ref.path);
+    used += cost;
+  }
+
+  const hasTermInExcerpt = excerpts.some((e) =>
+    terms.some((t) => e.excerpt.toLowerCase().includes(t)),
+  );
+  const confidence: ContextPackResult['confidence'] =
+    excerpts.length === 0 || (terms.length > 0 && !hasTermInExcerpt) ? 'low' : 'high';
+
+  const result: ContextPackResult = { excerpts, neighborhood, sources, totalMatches, confidence };
+  if (droppedForBudget) result.truncated = true;
+  return result;
+}


### PR DESCRIPTION
## Summary

New read-only tool `context_pack(query, budgetBytes?)` — the flagship index-native feature from the moat epic (SHA-254). It answers a natural-language question in **one call, hard-capped at a caller-set byte budget** (default 2048, never exceeded), replacing the 4–6 round-trip search → read_note → get_backlinks loop:

- **excerpts** — ranked matching excerpts (search's MiniSearch config), with inline scalar frontmatter (≤120 B per note) and the usual lean-payload omissions
- **neighborhood** — backlink/outlink neighbors of the top hits with one-line summaries, ranked by connections to the hit set; a note that's already an excerpt is never duplicated
- **sources** — overflow refs only ("read these next")
- **failure honesty** — `totalMatches` + `confidence: high|low|none`, and `truncated` only when the budget forced drops, so a thin pack is never mistaken for coverage

The assembler meters every entry with `Buffer.byteLength` against the exact minified serialization dispatch ships — the cap is exact, not an estimate — with a soft reserve so excerpts can't starve the neighborhood, deterministic ranking, and no clock/randomness.

## Design notes (PRD questions from SHA-256)

- **Budget split:** relevance-driven greedy fill with a soft neighborhood reserve (¼ of budget, max 600 B), released after excerpts.
- **vs search:** sits beside it; tool descriptions draw the line (search = locate, context_pack = answer). Frontmatter section demoted — `query_notes` owns structured queries; fm rides inline on hits.
- **Dedup:** excerpt wins; backlink+outlink merge to `rel: "both"`.

## Smoke test (committed 10k-note fixture vault)

| budget | payload | excerpts | neighborhood | sources | totalMatches |
|---:|---:|---:|---:|---:|---:|
| 512 | 492 B | 1 | 0 | 4 | 9,131 |
| 2048 | 2,037 B | 4 | 4 | 1 | 9,131 |

## Coverage

16 new tests (hard-cap invariant incl. multi-byte UTF-8, confidence tiers, dedup, neighbor ranking, fm capping, truncation, determinism, budget monotonicity). Tool count 17 → 18 everywhere the registry guard checks (dispatch, tool-list, REGISTRIES.md, ARCHITECTURE.md, README, llms.txt, CLIENT-TESTING, WRITE-SAFETY, no-network test). Harness `Backend` gains optional `contextPack`; seekstone adapter implements it (bench-matrix wiring is a follow-up with the tokens-per-task metric).

Closes SHA-256.