### PR TITLE
feat(harness): tokens-per-task scenario benchmark (SHA-274)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ npm run format                                        # biome write
 # the harness itself (run after `npm install`)
 npm run harness -- profile --vault "$SEEKSTONE_VAULT"
 npm run harness -- bench   --queries packages/harness/queries/default.json --stats reports/vault-stats.json
+npm run harness -- scenarios --backend seekstone --vault "$PWD/packages/harness/fixtures/vault"   # tokens-per-task
 npm run harness -- safety  --vault "$SEEKSTONE_VAULT"
 
 # the committed synthetic benchmark vault (no personal vault needed)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -183,7 +183,7 @@ the boundary** as the headline "context tax" metric.
 
 ```mermaid
 flowchart TD
-    cli["CLI — cli.ts (cac)<br/>profile · bench · safety · compare<br/>scale-render · gen-vault · fetch-corpus"]
+    cli["CLI — cli.ts (cac)<br/>profile · bench · scenarios · safety · compare<br/>scenarios-compare · scale-render · gen-vault · fetch-corpus"]
 
     backend["Backend contract — bench/backend.ts<br/>search · read · write · list (+ optional tools)<br/>every method → BackendResponse{ result, payloadBytes }"]
 
@@ -198,7 +198,7 @@ flowchart TD
 
     subgraph modules["Three measurement modules"]
         profiler["profiler/<br/>walk · classify · aggregate → VaultStats"]
-        bench["bench/<br/>runN cold/warm → BenchmarkSummary<br/>report · compare · scaling · timer"]
+        bench["bench/<br/>runN cold/warm → BenchmarkSummary<br/>scenarios (tokens-per-task) → ScenarioSummary<br/>report · compare · scaling · timer"]
         safety["safety/<br/>copyVault → runSafety ops → SafetySummary<br/>identity · body-append · fm-edit · patch · replace"]
     end
 

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -144,14 +144,29 @@ Commit the captured `benchmark-{rest,mcp-obsidian,obsidian-mcp-server}.json` wit
 note of the date + Obsidian/plugin versions. The renderer merges whatever is
 present and lists anything still missing under "Not yet captured."
 
-## The three tools
+## The tools
 
 | Command | What it does | Output |
 | --- | --- | --- |
 | `profile` | Walks the vault, classifies files, aggregates note/link/tag/frontmatter stats | `vault-stats.{json,md}` |
 | `bench`   | Runs the query set against a `--backend` (`fs`, `rest`, …), capturing latency **and payload bytes/tokens** | `benchmark-<backend>.{json,md}` |
+| `scenarios` | Tokens-per-task: runs each task in `queries/tasks.json` as the call sequence an agent would make (one `context_pack` call where supported, else search → read ×K → backlinks) and sums payload across it | `scenarios-<label>.{json,md}` |
+| `scenarios-compare` | Cross-adapter tokens-per-task table from scenario JSONs | `scenarios-comparison.md` |
 | `safety`  | Byte-faithful write round-trip suite (operates on a vault **copy**) | `safety-<backend>.{json,md}` |
 | `compare` | Cross-adapter comparison from benchmark JSONs | `comparison.md` |
+
+### Tokens per task (`scenarios`)
+
+`queries/tasks.json` is a methodology artifact like the query set: each task is one
+question an agent must gather context to answer. The runner picks the cheapest
+sequence the backend supports — backends with `context_pack` answer in one call;
+everything else pays for `search` → `read` per top hit → `get_backlinks`, with reads
+following **that backend's own** hit ranking. Payload bytes and (encoder-approximate,
+tiktoken `cl100k_base`) tokens are summed per task; latency is whole-task cold/warm.
+`--strategy multicall` forces a context_pack-capable backend down the multi-call path
+(reported as `<name>-multicall`) — the ablation that shows the win is `context_pack`
+itself, not the adapter. Committed baselines live in
+`fixtures/baseline-reports/scenarios-*.{json,md}` + `scenarios-comparison.md`.
 
 See the root [`CLAUDE.md`](../../CLAUDE.md) for architecture details (the `Backend`
 contract, percentile shapes, write-safety guard rails) and required env vars for the

--- a/packages/harness/fixtures/baseline-reports/scenarios-comparison.md
+++ b/packages/harness/fixtures/baseline-reports/scenarios-comparison.md
@@ -1,0 +1,53 @@
+# Tokens per answered question — scenario comparison
+
+> Generated 2026-08-04 · 5 runs per task · darwin/arm64 · Node v26.0.0
+
+Total context an agent consumes to answer each question: one `context_pack` call on backends that support it, versus search → read ×K → backlinks everywhere else. Lower is better.
+
+## Tokens (approx) per task
+
+| Task | seekstone | seekstone-multicall | fs | obsidian-mcp-rs | obsidian-tc |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| phlogiston-theory | 551 | 106,523 | 106,612 | 3,861 | 7,410 |
+| roman-empire-extent | 1,115 | 41,397 | 41,534 | 22,550 | 120,619 |
+| church-architecture | 1,084 | 25,298 | 22,529 | 15,172 | 17† |
+| rome-hub-navigation | 630 | 1,016 | 1,355 | 1,942 | 1,581 |
+
+> Token counts are encoder-approximate: tiktoken `cl100k_base` (an OpenAI encoder) on the raw payload text; per-model tokenizers differ in absolute counts but the cross-adapter ratios hold. Steps without raw text fall back to bytes÷4.
+
+> † Search returned no hits — the task went unanswered. The payload is the cost of the failed attempt, not of an answer; a low number here is a retrieval failure, not a win.
+
+## Payload bytes per task
+
+| Task | seekstone | seekstone-multicall | fs | obsidian-mcp-rs | obsidian-tc |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| phlogiston-theory | 2.0 KB | 416.5 KB | 416.8 KB | 15.3 KB | 29.4 KB |
+| roman-empire-extent | 4.0 KB | 159.5 KB | 160.1 KB | 89.6 KB | 485.8 KB |
+| church-architecture | 4.0 KB | 98.8 KB | 88.2 KB | 56.8 KB | 56 B |
+| rome-hub-navigation | 2.0 KB | 3.0 KB | 4.0 KB | 5.6 KB | 3.6 KB |
+
+## Calls per task
+
+| Task | seekstone | seekstone-multicall | fs | obsidian-mcp-rs | obsidian-tc |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| phlogiston-theory | 1 | 5 | 4 | 4 | 4 |
+| roman-empire-extent | 1 | 5 | 4 | 4 | 4 |
+| church-architecture | 1 | 5 | 4 | 4 | 1 |
+| rome-hub-navigation | 1 | 4 | 3 | 3 | 3 |
+
+## Context multiplier vs seekstone (tokens)
+
+| Task | seekstone | seekstone-multicall | fs | obsidian-mcp-rs | obsidian-tc |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| phlogiston-theory | 1.0× | 193.3× | 193.5× | 7.0× | 13.4× |
+| roman-empire-extent | 1.0× | 37.1× | 37.3× | 20.2× | 108.2× |
+| church-architecture | 1.0× | 23.3× | 20.8× | 14.0× | —† |
+| rome-hub-navigation | 1.0× | 1.6× | 2.2× | 3.1× | 2.5× |
+
+## Adapters
+
+- **seekstone**: Seekstone server (in-process function calls, no IPC)
+- **seekstone-multicall**: Seekstone server (in-process function calls, no IPC) — ablation: context_pack disabled, forced down the search→read path
+- **fs**: Filesystem-direct (MiniSearch in-process, no HTTP round-trip)
+- **obsidian-mcp-rs**: obsidian-mcp-rs (Rust, filesystem-direct, per-query scan, no Obsidian required)
+- **obsidian-tc**: obsidian-tc (SQLite governance platform, direct tool calls, no Obsidian required)

--- a/packages/harness/fixtures/baseline-reports/scenarios-fs.json
+++ b/packages/harness/fixtures/baseline-reports/scenarios-fs.json
@@ -1,0 +1,207 @@
+{
+  "snapshotDate": "2026-08-04T12:49:20.144Z",
+  "machine": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "node": "v26.0.0",
+    "cpus": 10
+  },
+  "backend": {
+    "name": "fs",
+    "description": "Filesystem-direct (MiniSearch in-process, no HTTP round-trip)"
+  },
+  "label": "fs",
+  "runs": 5,
+  "tasks": [
+    {
+      "id": "phlogiston-theory",
+      "question": "What was the phlogiston theory and which chemists overturned it?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "phlogiston",
+          "payloadBytes": 2789,
+          "payloadTokens": 741
+        },
+        {
+          "op": "read",
+          "target": "Sources/Combustion.md",
+          "payloadBytes": 3966,
+          "payloadTokens": 924
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/C/Chemistry.md",
+          "payloadBytes": 416889,
+          "payloadTokens": 104141
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/K/Kirwan.md",
+          "payloadBytes": 3195,
+          "payloadTokens": 806
+        }
+      ],
+      "calls": 4,
+      "totalPayloadBytes": 426839,
+      "totalPayloadTokens": 106612,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 79.490167,
+        "warm": {
+          "n": 4,
+          "min": 67.351209,
+          "median": 68.418375,
+          "p90": 72.5655,
+          "p95": 72.5655,
+          "p99": 72.5655,
+          "max": 72.5655,
+          "mean": 69.96122925
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "roman-empire-extent",
+      "question": "What did the Roman Empire comprise at its greatest extent?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "Roman Empire",
+          "payloadBytes": 2809,
+          "payloadTokens": 751
+        },
+        {
+          "op": "read",
+          "target": "Reference/Empire.md",
+          "payloadBytes": 80108,
+          "payloadTokens": 19276
+        },
+        {
+          "op": "read",
+          "target": "Sources/Macedonian Empire.md",
+          "payloadBytes": 71065,
+          "payloadTokens": 18931
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/H/Heroic Romances.md",
+          "payloadBytes": 9930,
+          "payloadTokens": 2576
+        }
+      ],
+      "calls": 4,
+      "totalPayloadBytes": 163912,
+      "totalPayloadTokens": 41534,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 36.9595,
+        "warm": {
+          "n": 4,
+          "min": 32.526542,
+          "median": 32.591208,
+          "p90": 33.937375,
+          "p95": 33.937375,
+          "p99": 33.937375,
+          "max": 33.937375,
+          "mean": 33.0665835
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "church-architecture",
+      "question": "How is a mediaeval church laid out architecturally?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "church architecture nave",
+          "payloadBytes": 2831,
+          "payloadTokens": 775
+        },
+        {
+          "op": "read",
+          "target": "Reference/Church.md",
+          "payloadBytes": 31257,
+          "payloadTokens": 7356
+        },
+        {
+          "op": "read",
+          "target": "0 Inbox/Basilica.md",
+          "payloadBytes": 42401,
+          "payloadTokens": 10927
+        },
+        {
+          "op": "read",
+          "target": "Sources/Catholic Apostolic Church.md",
+          "payloadBytes": 13874,
+          "payloadTokens": 3471
+        }
+      ],
+      "calls": 4,
+      "totalPayloadBytes": 90363,
+      "totalPayloadTokens": 22529,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 29.424667,
+        "warm": {
+          "n": 4,
+          "min": 27.457292,
+          "median": 27.885792,
+          "p90": 29.070166,
+          "p95": 29.070166,
+          "p99": 29.070166,
+          "max": 29.070166,
+          "mean": 28.34321875
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "rome-hub-navigation",
+      "question": "Which articles does the ancient-rome map of content link to?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "ancient-rome MOC",
+          "payloadBytes": 2860,
+          "payloadTokens": 923
+        },
+        {
+          "op": "read",
+          "target": "MOCs/ancient-rome MOC.md",
+          "payloadBytes": 657,
+          "payloadTokens": 240
+        },
+        {
+          "op": "read",
+          "target": "MOCs/ancient-rome-studies MOC.md",
+          "payloadBytes": 529,
+          "payloadTokens": 192
+        }
+      ],
+      "calls": 3,
+      "totalPayloadBytes": 4046,
+      "totalPayloadTokens": 1355,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 11.703959,
+        "warm": {
+          "n": 4,
+          "min": 11.104291,
+          "median": 11.35875,
+          "p90": 12.403958,
+          "p95": 12.403958,
+          "p99": 12.403958,
+          "max": 12.403958,
+          "mean": 11.644656000000001
+        },
+        "runs": 5
+      }
+    }
+  ]
+}

--- a/packages/harness/fixtures/baseline-reports/scenarios-fs.md
+++ b/packages/harness/fixtures/baseline-reports/scenarios-fs.md
@@ -1,0 +1,62 @@
+# Scenarios — fs
+
+- **Adapter:** Filesystem-direct (MiniSearch in-process, no HTTP round-trip)
+- **Snapshot:** 2026-08-04T12:49:20.144Z
+- **Runs per task:** 5 (cold = run 1; warm = runs 2..N)
+- **Machine:** darwin/arm64, Node v26.0.0, 10 logical CPUs
+
+Each task is one question an agent must gather context to answer. Payload and tokens are summed across every call in the sequence — the context tax per answered question.
+
+| Task | Strategy | Calls | Payload | Tokens (approx) | Cold | Warm p50 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| phlogiston-theory | search-read | 4 | 416.8 KB | 106,612 | 79.49 ms | 68.42 ms |
+| roman-empire-extent | search-read | 4 | 160.1 KB | 41,534 | 36.96 ms | 32.59 ms |
+| church-architecture | search-read | 4 | 88.2 KB | 22,529 | 29.42 ms | 27.89 ms |
+| rome-hub-navigation | search-read | 3 | 4.0 KB | 1,355 | 11.70 ms | 11.36 ms |
+
+> Token counts are encoder-approximate: tiktoken `cl100k_base` (an OpenAI encoder) on the raw payload text; per-model tokenizers differ in absolute counts but the cross-adapter ratios hold. Steps without raw text fall back to bytes÷4.
+
+## Step breakdown (run 1)
+
+### phlogiston-theory
+
+> What was the phlogiston theory and which chemists overturned it?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `phlogiston` | 2.7 KB | 741 |
+| 2 | `read` | `Sources/Combustion.md` | 3.9 KB | 924 |
+| 3 | `read` | `Encyclopedia/C/Chemistry.md` | 407.1 KB | 104,141 |
+| 4 | `read` | `Encyclopedia/K/Kirwan.md` | 3.1 KB | 806 |
+
+### roman-empire-extent
+
+> What did the Roman Empire comprise at its greatest extent?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `Roman Empire` | 2.7 KB | 751 |
+| 2 | `read` | `Reference/Empire.md` | 78.2 KB | 19,276 |
+| 3 | `read` | `Sources/Macedonian Empire.md` | 69.4 KB | 18,931 |
+| 4 | `read` | `Encyclopedia/H/Heroic Romances.md` | 9.7 KB | 2,576 |
+
+### church-architecture
+
+> How is a mediaeval church laid out architecturally?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `church architecture nave` | 2.8 KB | 775 |
+| 2 | `read` | `Reference/Church.md` | 30.5 KB | 7,356 |
+| 3 | `read` | `0 Inbox/Basilica.md` | 41.4 KB | 10,927 |
+| 4 | `read` | `Sources/Catholic Apostolic Church.md` | 13.5 KB | 3,471 |
+
+### rome-hub-navigation
+
+> Which articles does the ancient-rome map of content link to?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `ancient-rome MOC` | 2.8 KB | 923 |
+| 2 | `read` | `MOCs/ancient-rome MOC.md` | 657 B | 240 |
+| 3 | `read` | `MOCs/ancient-rome-studies MOC.md` | 529 B | 192 |

--- a/packages/harness/fixtures/baseline-reports/scenarios-obsidian-mcp-rs.json
+++ b/packages/harness/fixtures/baseline-reports/scenarios-obsidian-mcp-rs.json
@@ -1,0 +1,207 @@
+{
+  "snapshotDate": "2026-08-04T12:53:33.511Z",
+  "machine": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "node": "v26.0.0",
+    "cpus": 10
+  },
+  "backend": {
+    "name": "obsidian-mcp-rs",
+    "description": "obsidian-mcp-rs (Rust, filesystem-direct, per-query scan, no Obsidian required)"
+  },
+  "label": "obsidian-mcp-rs",
+  "runs": 5,
+  "tasks": [
+    {
+      "id": "phlogiston-theory",
+      "question": "What was the phlogiston theory and which chemists overturned it?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "phlogiston",
+          "payloadBytes": 2773,
+          "payloadTokens": 762
+        },
+        {
+          "op": "read",
+          "target": "Sources/Combustion.md",
+          "payloadBytes": 3966,
+          "payloadTokens": 924
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/B/Black.md",
+          "payloadBytes": 5783,
+          "payloadTokens": 1369
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/K/Kirwan.md",
+          "payloadBytes": 3195,
+          "payloadTokens": 806
+        }
+      ],
+      "calls": 4,
+      "totalPayloadBytes": 15717,
+      "totalPayloadTokens": 3861,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 313.474083,
+        "warm": {
+          "n": 4,
+          "min": 40.986083,
+          "median": 41.075541,
+          "p90": 44.154916,
+          "p95": 44.154916,
+          "p99": 44.154916,
+          "max": 44.154916,
+          "mean": 42.43141625
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "roman-empire-extent",
+      "question": "What did the Roman Empire comprise at its greatest extent?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "Roman Empire",
+          "payloadBytes": 7542,
+          "payloadTokens": 2135
+        },
+        {
+          "op": "read",
+          "target": "Reference/Empire.md",
+          "payloadBytes": 80534,
+          "payloadTokens": 19413
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/C/Comnenus.md",
+          "payloadBytes": 1909,
+          "payloadTokens": 523
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/G/Gallienus.md",
+          "payloadBytes": 1779,
+          "payloadTokens": 479
+        }
+      ],
+      "calls": 4,
+      "totalPayloadBytes": 91764,
+      "totalPayloadTokens": 22550,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 88.481583,
+        "warm": {
+          "n": 4,
+          "min": 76.225125,
+          "median": 79.485416,
+          "p90": 83.639042,
+          "p95": 83.639042,
+          "p99": 83.639042,
+          "max": 83.639042,
+          "mean": 80.30639575000001
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "church-architecture",
+      "question": "How is a mediaeval church laid out architecturally?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "church architecture nave",
+          "payloadBytes": 7589,
+          "payloadTokens": 2079
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/D/Dunkeld.md",
+          "payloadBytes": 5268,
+          "payloadTokens": 1386
+        },
+        {
+          "op": "read",
+          "target": "0 Inbox/Basilica.md",
+          "payloadBytes": 42571,
+          "payloadTokens": 10981
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/A/Arcade.md",
+          "payloadBytes": 2763,
+          "payloadTokens": 726
+        }
+      ],
+      "calls": 4,
+      "totalPayloadBytes": 58191,
+      "totalPayloadTokens": 15172,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 70.017625,
+        "warm": {
+          "n": 4,
+          "min": 71.754334,
+          "median": 72.313375,
+          "p90": 155.809459,
+          "p95": 155.809459,
+          "p99": 155.809459,
+          "max": 155.809459,
+          "mean": 93.10444824999999
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "rome-hub-navigation",
+      "question": "Which articles does the ancient-rome map of content link to?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "ancient-rome MOC",
+          "payloadBytes": 4574,
+          "payloadTokens": 1510
+        },
+        {
+          "op": "read",
+          "target": "MOCs/ancient-rome-studies MOC.md",
+          "payloadBytes": 529,
+          "payloadTokens": 192
+        },
+        {
+          "op": "read",
+          "target": "MOCs/ancient-rome MOC.md",
+          "payloadBytes": 657,
+          "payloadTokens": 240
+        }
+      ],
+      "calls": 3,
+      "totalPayloadBytes": 5760,
+      "totalPayloadTokens": 1942,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 67.477209,
+        "warm": {
+          "n": 4,
+          "min": 66.417667,
+          "median": 68.876583,
+          "p90": 71.863833,
+          "p95": 71.863833,
+          "p99": 71.863833,
+          "max": 71.863833,
+          "mean": 69.24134375
+        },
+        "runs": 5
+      }
+    }
+  ]
+}

--- a/packages/harness/fixtures/baseline-reports/scenarios-obsidian-mcp-rs.md
+++ b/packages/harness/fixtures/baseline-reports/scenarios-obsidian-mcp-rs.md
@@ -1,0 +1,62 @@
+# Scenarios — obsidian-mcp-rs
+
+- **Adapter:** obsidian-mcp-rs (Rust, filesystem-direct, per-query scan, no Obsidian required)
+- **Snapshot:** 2026-08-04T12:53:33.511Z
+- **Runs per task:** 5 (cold = run 1; warm = runs 2..N)
+- **Machine:** darwin/arm64, Node v26.0.0, 10 logical CPUs
+
+Each task is one question an agent must gather context to answer. Payload and tokens are summed across every call in the sequence — the context tax per answered question.
+
+| Task | Strategy | Calls | Payload | Tokens (approx) | Cold | Warm p50 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| phlogiston-theory | search-read | 4 | 15.3 KB | 3,861 | 313.47 ms | 41.08 ms |
+| roman-empire-extent | search-read | 4 | 89.6 KB | 22,550 | 88.48 ms | 79.49 ms |
+| church-architecture | search-read | 4 | 56.8 KB | 15,172 | 70.02 ms | 72.31 ms |
+| rome-hub-navigation | search-read | 3 | 5.6 KB | 1,942 | 67.48 ms | 68.88 ms |
+
+> Token counts are encoder-approximate: tiktoken `cl100k_base` (an OpenAI encoder) on the raw payload text; per-model tokenizers differ in absolute counts but the cross-adapter ratios hold. Steps without raw text fall back to bytes÷4.
+
+## Step breakdown (run 1)
+
+### phlogiston-theory
+
+> What was the phlogiston theory and which chemists overturned it?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `phlogiston` | 2.7 KB | 762 |
+| 2 | `read` | `Sources/Combustion.md` | 3.9 KB | 924 |
+| 3 | `read` | `Encyclopedia/B/Black.md` | 5.6 KB | 1,369 |
+| 4 | `read` | `Encyclopedia/K/Kirwan.md` | 3.1 KB | 806 |
+
+### roman-empire-extent
+
+> What did the Roman Empire comprise at its greatest extent?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `Roman Empire` | 7.4 KB | 2,135 |
+| 2 | `read` | `Reference/Empire.md` | 78.6 KB | 19,413 |
+| 3 | `read` | `Encyclopedia/C/Comnenus.md` | 1.9 KB | 523 |
+| 4 | `read` | `Encyclopedia/G/Gallienus.md` | 1.7 KB | 479 |
+
+### church-architecture
+
+> How is a mediaeval church laid out architecturally?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `church architecture nave` | 7.4 KB | 2,079 |
+| 2 | `read` | `Encyclopedia/D/Dunkeld.md` | 5.1 KB | 1,386 |
+| 3 | `read` | `0 Inbox/Basilica.md` | 41.6 KB | 10,981 |
+| 4 | `read` | `Encyclopedia/A/Arcade.md` | 2.7 KB | 726 |
+
+### rome-hub-navigation
+
+> Which articles does the ancient-rome map of content link to?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `ancient-rome MOC` | 4.5 KB | 1,510 |
+| 2 | `read` | `MOCs/ancient-rome-studies MOC.md` | 529 B | 192 |
+| 3 | `read` | `MOCs/ancient-rome MOC.md` | 657 B | 240 |

--- a/packages/harness/fixtures/baseline-reports/scenarios-obsidian-tc.json
+++ b/packages/harness/fixtures/baseline-reports/scenarios-obsidian-tc.json
@@ -1,0 +1,189 @@
+{
+  "snapshotDate": "2026-08-04T12:55:22.545Z",
+  "machine": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "node": "v26.0.0",
+    "cpus": 10
+  },
+  "backend": {
+    "name": "obsidian-tc",
+    "description": "obsidian-tc (SQLite governance platform, direct tool calls, no Obsidian required)"
+  },
+  "label": "obsidian-tc",
+  "runs": 5,
+  "tasks": [
+    {
+      "id": "phlogiston-theory",
+      "question": "What was the phlogiston theory and which chemists overturned it?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "phlogiston",
+          "payloadBytes": 4953,
+          "payloadTokens": 1410
+        },
+        {
+          "op": "read",
+          "target": "Sources/Combustion.md",
+          "payloadBytes": 8369,
+          "payloadTokens": 2000
+        },
+        {
+          "op": "read",
+          "target": "Sources/Combustion.md",
+          "payloadBytes": 8369,
+          "payloadTokens": 2000
+        },
+        {
+          "op": "read",
+          "target": "Sources/Combustion.md",
+          "payloadBytes": 8369,
+          "payloadTokens": 2000
+        }
+      ],
+      "calls": 4,
+      "totalPayloadBytes": 30060,
+      "totalPayloadTokens": 7410,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 3574.8645,
+        "warm": {
+          "n": 4,
+          "min": 3298.940417,
+          "median": 3369.203666,
+          "p90": 3430.775,
+          "p95": 3430.775,
+          "p99": 3430.775,
+          "max": 3430.775,
+          "mean": 3369.6073749999996
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "roman-empire-extent",
+      "question": "What did the Roman Empire comprise at its greatest extent?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "Roman Empire",
+          "payloadBytes": 7895,
+          "payloadTokens": 2326
+        },
+        {
+          "op": "read",
+          "target": "Reference/Empire.md",
+          "payloadBytes": 163185,
+          "payloadTokens": 39431
+        },
+        {
+          "op": "read",
+          "target": "Reference/Empire.md",
+          "payloadBytes": 163185,
+          "payloadTokens": 39431
+        },
+        {
+          "op": "read",
+          "target": "Reference/Empire.md",
+          "payloadBytes": 163185,
+          "payloadTokens": 39431
+        }
+      ],
+      "calls": 4,
+      "totalPayloadBytes": 497450,
+      "totalPayloadTokens": 120619,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 3536.361334,
+        "warm": {
+          "n": 4,
+          "min": 3385.892709,
+          "median": 3403.191167,
+          "p90": 3489.669959,
+          "p95": 3489.669959,
+          "p99": 3489.669959,
+          "max": 3489.669959,
+          "mean": 3424.3143547500003
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "church-architecture",
+      "question": "How is a mediaeval church laid out architecturally?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "church architecture nave",
+          "payloadBytes": 56,
+          "payloadTokens": 17
+        }
+      ],
+      "calls": 1,
+      "totalPayloadBytes": 56,
+      "totalPayloadTokens": 17,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 3410.167083,
+        "warm": {
+          "n": 4,
+          "min": 3323.646042,
+          "median": 3386.115667,
+          "p90": 3553.520416,
+          "p95": 3553.520416,
+          "p99": 3553.520416,
+          "max": 3553.520416,
+          "mean": 3413.81198975
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "rome-hub-navigation",
+      "question": "Which articles does the ancient-rome map of content link to?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "ancient-rome MOC",
+          "payloadBytes": 286,
+          "payloadTokens": 103
+        },
+        {
+          "op": "read",
+          "target": "MOCs/ancient-rome MOC.md",
+          "payloadBytes": 1678,
+          "payloadTokens": 739
+        },
+        {
+          "op": "read",
+          "target": "MOCs/ancient-rome MOC.md",
+          "payloadBytes": 1678,
+          "payloadTokens": 739
+        }
+      ],
+      "calls": 3,
+      "totalPayloadBytes": 3642,
+      "totalPayloadTokens": 1581,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 3495.875084,
+        "warm": {
+          "n": 4,
+          "min": 3362.468166,
+          "median": 3502.307959,
+          "p90": 3779.673458,
+          "p95": 3779.673458,
+          "p99": 3779.673458,
+          "max": 3779.673458,
+          "mean": 3538.26662475
+        },
+        "runs": 5
+      }
+    }
+  ]
+}

--- a/packages/harness/fixtures/baseline-reports/scenarios-obsidian-tc.md
+++ b/packages/harness/fixtures/baseline-reports/scenarios-obsidian-tc.md
@@ -1,0 +1,61 @@
+# Scenarios — obsidian-tc
+
+- **Adapter:** obsidian-tc (SQLite governance platform, direct tool calls, no Obsidian required)
+- **Snapshot:** 2026-08-04T12:55:22.545Z
+- **Runs per task:** 5 (cold = run 1; warm = runs 2..N)
+- **Machine:** darwin/arm64, Node v26.0.0, 10 logical CPUs
+
+Each task is one question an agent must gather context to answer. Payload and tokens are summed across every call in the sequence — the context tax per answered question.
+
+| Task | Strategy | Calls | Payload | Tokens (approx) | Cold | Warm p50 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| phlogiston-theory | search-read | 4 | 29.4 KB | 7,410 | 3574.86 ms | 3369.20 ms |
+| roman-empire-extent | search-read | 4 | 485.8 KB | 120,619 | 3536.36 ms | 3403.19 ms |
+| church-architecture† | search-read | 1 | 56 B | 17 | 3410.17 ms | 3386.12 ms |
+| rome-hub-navigation | search-read | 3 | 3.6 KB | 1,581 | 3495.88 ms | 3502.31 ms |
+
+> † Search returned no hits — the task went unanswered. The payload is the cost of the failed attempt, not of an answer; a low number here is a retrieval failure, not a win.
+
+> Token counts are encoder-approximate: tiktoken `cl100k_base` (an OpenAI encoder) on the raw payload text; per-model tokenizers differ in absolute counts but the cross-adapter ratios hold. Steps without raw text fall back to bytes÷4.
+
+## Step breakdown (run 1)
+
+### phlogiston-theory
+
+> What was the phlogiston theory and which chemists overturned it?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `phlogiston` | 4.8 KB | 1,410 |
+| 2 | `read` | `Sources/Combustion.md` | 8.2 KB | 2,000 |
+| 3 | `read` | `Sources/Combustion.md` | 8.2 KB | 2,000 |
+| 4 | `read` | `Sources/Combustion.md` | 8.2 KB | 2,000 |
+
+### roman-empire-extent
+
+> What did the Roman Empire comprise at its greatest extent?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `Roman Empire` | 7.7 KB | 2,326 |
+| 2 | `read` | `Reference/Empire.md` | 159.4 KB | 39,431 |
+| 3 | `read` | `Reference/Empire.md` | 159.4 KB | 39,431 |
+| 4 | `read` | `Reference/Empire.md` | 159.4 KB | 39,431 |
+
+### church-architecture
+
+> How is a mediaeval church laid out architecturally?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `church architecture nave` | 56 B | 17 |
+
+### rome-hub-navigation
+
+> Which articles does the ancient-rome map of content link to?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `ancient-rome MOC` | 286 B | 103 |
+| 2 | `read` | `MOCs/ancient-rome MOC.md` | 1.6 KB | 739 |
+| 3 | `read` | `MOCs/ancient-rome MOC.md` | 1.6 KB | 739 |

--- a/packages/harness/fixtures/baseline-reports/scenarios-seekstone-multicall.json
+++ b/packages/harness/fixtures/baseline-reports/scenarios-seekstone-multicall.json
@@ -1,0 +1,231 @@
+{
+  "snapshotDate": "2026-08-04T12:49:06.775Z",
+  "machine": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "node": "v26.0.0",
+    "cpus": 10
+  },
+  "backend": {
+    "name": "seekstone",
+    "description": "Seekstone server (in-process function calls, no IPC)"
+  },
+  "label": "seekstone-multicall",
+  "runs": 5,
+  "tasks": [
+    {
+      "id": "phlogiston-theory",
+      "question": "What was the phlogiston theory and which chemists overturned it?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "phlogiston",
+          "payloadBytes": 2347,
+          "payloadTokens": 634
+        },
+        {
+          "op": "read",
+          "target": "Sources/Combustion.md",
+          "payloadBytes": 3966,
+          "payloadTokens": 924
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/C/Chemistry.md",
+          "payloadBytes": 416889,
+          "payloadTokens": 104141
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/K/Kirwan.md",
+          "payloadBytes": 3195,
+          "payloadTokens": 806
+        },
+        {
+          "op": "get_backlinks",
+          "target": "Sources/Combustion.md",
+          "payloadBytes": 59,
+          "payloadTokens": 18
+        }
+      ],
+      "calls": 5,
+      "totalPayloadBytes": 426456,
+      "totalPayloadTokens": 106523,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 83.05375,
+        "warm": {
+          "n": 4,
+          "min": 66.484292,
+          "median": 66.827459,
+          "p90": 70.557417,
+          "p95": 70.557417,
+          "p99": 70.557417,
+          "max": 70.557417,
+          "mean": 68.105813
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "roman-empire-extent",
+      "question": "What did the Roman Empire comprise at its greatest extent?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "Roman Empire",
+          "payloadBytes": 2144,
+          "payloadTokens": 597
+        },
+        {
+          "op": "read",
+          "target": "Reference/Empire.md",
+          "payloadBytes": 80108,
+          "payloadTokens": 19276
+        },
+        {
+          "op": "read",
+          "target": "Sources/Macedonian Empire.md",
+          "payloadBytes": 71065,
+          "payloadTokens": 18931
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/H/Heroic Romances.md",
+          "payloadBytes": 9930,
+          "payloadTokens": 2576
+        },
+        {
+          "op": "get_backlinks",
+          "target": "Reference/Empire.md",
+          "payloadBytes": 57,
+          "payloadTokens": 17
+        }
+      ],
+      "calls": 5,
+      "totalPayloadBytes": 163304,
+      "totalPayloadTokens": 41397,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 36.838542,
+        "warm": {
+          "n": 4,
+          "min": 33.584792,
+          "median": 33.589375,
+          "p90": 34.593792,
+          "p95": 34.593792,
+          "p99": 34.593792,
+          "max": 34.593792,
+          "mean": 33.87767725
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "church-architecture",
+      "question": "How is a mediaeval church laid out architecturally?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "church architecture nave",
+          "payloadBytes": 1884,
+          "payloadTokens": 510
+        },
+        {
+          "op": "read",
+          "target": "Reference/Church.md",
+          "payloadBytes": 31257,
+          "payloadTokens": 7356
+        },
+        {
+          "op": "read",
+          "target": "0 Inbox/Basilica.md",
+          "payloadBytes": 42401,
+          "payloadTokens": 10927
+        },
+        {
+          "op": "read",
+          "target": "Encyclopedia/L/Lyons.md",
+          "payloadBytes": 25351,
+          "payloadTokens": 6435
+        },
+        {
+          "op": "get_backlinks",
+          "target": "Reference/Church.md",
+          "payloadBytes": 235,
+          "payloadTokens": 70
+        }
+      ],
+      "calls": 5,
+      "totalPayloadBytes": 101128,
+      "totalPayloadTokens": 25298,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 37.232833,
+        "warm": {
+          "n": 4,
+          "min": 30.144083,
+          "median": 30.187125,
+          "p90": 30.768541,
+          "p95": 30.768541,
+          "p99": 30.768541,
+          "max": 30.768541,
+          "mean": 30.3824475
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "rome-hub-navigation",
+      "question": "Which articles does the ancient-rome map of content link to?",
+      "strategy": "search-read",
+      "steps": [
+        {
+          "op": "search",
+          "target": "ancient-rome MOC",
+          "payloadBytes": 1788,
+          "payloadTokens": 561
+        },
+        {
+          "op": "read",
+          "target": "MOCs/ancient-rome MOC.md",
+          "payloadBytes": 657,
+          "payloadTokens": 240
+        },
+        {
+          "op": "read",
+          "target": "MOCs/ancient-rome-studies MOC.md",
+          "payloadBytes": 529,
+          "payloadTokens": 192
+        },
+        {
+          "op": "get_backlinks",
+          "target": "MOCs/ancient-rome MOC.md",
+          "payloadBytes": 62,
+          "payloadTokens": 23
+        }
+      ],
+      "calls": 4,
+      "totalPayloadBytes": 3036,
+      "totalPayloadTokens": 1016,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 11.248667,
+        "warm": {
+          "n": 4,
+          "min": 7.853334,
+          "median": 8.693334,
+          "p90": 9.505459,
+          "p95": 9.505459,
+          "p99": 9.505459,
+          "max": 9.505459,
+          "mean": 8.814115000000001
+        },
+        "runs": 5
+      }
+    }
+  ]
+}

--- a/packages/harness/fixtures/baseline-reports/scenarios-seekstone-multicall.md
+++ b/packages/harness/fixtures/baseline-reports/scenarios-seekstone-multicall.md
@@ -1,0 +1,66 @@
+# Scenarios — seekstone-multicall
+
+- **Adapter:** Seekstone server (in-process function calls, no IPC)
+- **Snapshot:** 2026-08-04T12:49:06.775Z
+- **Runs per task:** 5 (cold = run 1; warm = runs 2..N)
+- **Machine:** darwin/arm64, Node v26.0.0, 10 logical CPUs
+
+Each task is one question an agent must gather context to answer. Payload and tokens are summed across every call in the sequence — the context tax per answered question.
+
+| Task | Strategy | Calls | Payload | Tokens (approx) | Cold | Warm p50 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| phlogiston-theory | search-read | 5 | 416.5 KB | 106,523 | 83.05 ms | 66.83 ms |
+| roman-empire-extent | search-read | 5 | 159.5 KB | 41,397 | 36.84 ms | 33.59 ms |
+| church-architecture | search-read | 5 | 98.8 KB | 25,298 | 37.23 ms | 30.19 ms |
+| rome-hub-navigation | search-read | 4 | 3.0 KB | 1,016 | 11.25 ms | 8.69 ms |
+
+> Token counts are encoder-approximate: tiktoken `cl100k_base` (an OpenAI encoder) on the raw payload text; per-model tokenizers differ in absolute counts but the cross-adapter ratios hold. Steps without raw text fall back to bytes÷4.
+
+## Step breakdown (run 1)
+
+### phlogiston-theory
+
+> What was the phlogiston theory and which chemists overturned it?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `phlogiston` | 2.3 KB | 634 |
+| 2 | `read` | `Sources/Combustion.md` | 3.9 KB | 924 |
+| 3 | `read` | `Encyclopedia/C/Chemistry.md` | 407.1 KB | 104,141 |
+| 4 | `read` | `Encyclopedia/K/Kirwan.md` | 3.1 KB | 806 |
+| 5 | `get_backlinks` | `Sources/Combustion.md` | 59 B | 18 |
+
+### roman-empire-extent
+
+> What did the Roman Empire comprise at its greatest extent?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `Roman Empire` | 2.1 KB | 597 |
+| 2 | `read` | `Reference/Empire.md` | 78.2 KB | 19,276 |
+| 3 | `read` | `Sources/Macedonian Empire.md` | 69.4 KB | 18,931 |
+| 4 | `read` | `Encyclopedia/H/Heroic Romances.md` | 9.7 KB | 2,576 |
+| 5 | `get_backlinks` | `Reference/Empire.md` | 57 B | 17 |
+
+### church-architecture
+
+> How is a mediaeval church laid out architecturally?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `church architecture nave` | 1.8 KB | 510 |
+| 2 | `read` | `Reference/Church.md` | 30.5 KB | 7,356 |
+| 3 | `read` | `0 Inbox/Basilica.md` | 41.4 KB | 10,927 |
+| 4 | `read` | `Encyclopedia/L/Lyons.md` | 24.8 KB | 6,435 |
+| 5 | `get_backlinks` | `Reference/Church.md` | 235 B | 70 |
+
+### rome-hub-navigation
+
+> Which articles does the ancient-rome map of content link to?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `search` | `ancient-rome MOC` | 1.7 KB | 561 |
+| 2 | `read` | `MOCs/ancient-rome MOC.md` | 657 B | 240 |
+| 3 | `read` | `MOCs/ancient-rome-studies MOC.md` | 529 B | 192 |
+| 4 | `get_backlinks` | `MOCs/ancient-rome MOC.md` | 62 B | 23 |

--- a/packages/harness/fixtures/baseline-reports/scenarios-seekstone.json
+++ b/packages/harness/fixtures/baseline-reports/scenarios-seekstone.json
@@ -1,0 +1,141 @@
+{
+  "snapshotDate": "2026-08-04T12:48:08.929Z",
+  "machine": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "node": "v26.0.0",
+    "cpus": 10
+  },
+  "backend": {
+    "name": "seekstone",
+    "description": "Seekstone server (in-process function calls, no IPC)"
+  },
+  "label": "seekstone",
+  "runs": 5,
+  "tasks": [
+    {
+      "id": "phlogiston-theory",
+      "question": "What was the phlogiston theory and which chemists overturned it?",
+      "strategy": "context-pack",
+      "steps": [
+        {
+          "op": "context_pack",
+          "target": "phlogiston",
+          "payloadBytes": 2025,
+          "payloadTokens": 551
+        }
+      ],
+      "calls": 1,
+      "totalPayloadBytes": 2025,
+      "totalPayloadTokens": 551,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 43.844875,
+        "warm": {
+          "n": 4,
+          "min": 36.110792,
+          "median": 36.141542,
+          "p90": 37.832333,
+          "p95": 37.832333,
+          "p99": 37.832333,
+          "max": 37.832333,
+          "mean": 36.694354249999996
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "roman-empire-extent",
+      "question": "What did the Roman Empire comprise at its greatest extent?",
+      "strategy": "context-pack",
+      "steps": [
+        {
+          "op": "context_pack",
+          "target": "Roman Empire",
+          "payloadBytes": 4062,
+          "payloadTokens": 1115
+        }
+      ],
+      "calls": 1,
+      "totalPayloadBytes": 4062,
+      "totalPayloadTokens": 1115,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 28.543584,
+        "warm": {
+          "n": 4,
+          "min": 25.555333,
+          "median": 25.774,
+          "p90": 27.435333,
+          "p95": 27.435333,
+          "p99": 27.435333,
+          "max": 27.435333,
+          "mean": 26.146489250000002
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "church-architecture",
+      "question": "How is a mediaeval church laid out architecturally?",
+      "strategy": "context-pack",
+      "steps": [
+        {
+          "op": "context_pack",
+          "target": "church architecture nave",
+          "payloadBytes": 4066,
+          "payloadTokens": 1084
+        }
+      ],
+      "calls": 1,
+      "totalPayloadBytes": 4066,
+      "totalPayloadTokens": 1084,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 29.762208,
+        "warm": {
+          "n": 4,
+          "min": 29.212542,
+          "median": 30.088291,
+          "p90": 30.765042,
+          "p95": 30.765042,
+          "p99": 30.765042,
+          "max": 30.765042,
+          "mean": 30.095062499999997
+        },
+        "runs": 5
+      }
+    },
+    {
+      "id": "rome-hub-navigation",
+      "question": "Which articles does the ancient-rome map of content link to?",
+      "strategy": "context-pack",
+      "steps": [
+        {
+          "op": "context_pack",
+          "target": "ancient-rome MOC",
+          "payloadBytes": 2019,
+          "payloadTokens": 630
+        }
+      ],
+      "calls": 1,
+      "totalPayloadBytes": 2019,
+      "totalPayloadTokens": 630,
+      "payloadStable": true,
+      "latency": {
+        "coldMs": 153.635208,
+        "warm": {
+          "n": 4,
+          "min": 150.086375,
+          "median": 150.145208,
+          "p90": 153.436125,
+          "p95": 153.436125,
+          "p99": 153.436125,
+          "max": 153.436125,
+          "mean": 150.97620825
+        },
+        "runs": 5
+      }
+    }
+  ]
+}

--- a/packages/harness/fixtures/baseline-reports/scenarios-seekstone.md
+++ b/packages/harness/fixtures/baseline-reports/scenarios-seekstone.md
@@ -1,0 +1,51 @@
+# Scenarios — seekstone
+
+- **Adapter:** Seekstone server (in-process function calls, no IPC)
+- **Snapshot:** 2026-08-04T12:48:08.929Z
+- **Runs per task:** 5 (cold = run 1; warm = runs 2..N)
+- **Machine:** darwin/arm64, Node v26.0.0, 10 logical CPUs
+
+Each task is one question an agent must gather context to answer. Payload and tokens are summed across every call in the sequence — the context tax per answered question.
+
+| Task | Strategy | Calls | Payload | Tokens (approx) | Cold | Warm p50 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| phlogiston-theory | context-pack | 1 | 2.0 KB | 551 | 43.84 ms | 36.14 ms |
+| roman-empire-extent | context-pack | 1 | 4.0 KB | 1,115 | 28.54 ms | 25.77 ms |
+| church-architecture | context-pack | 1 | 4.0 KB | 1,084 | 29.76 ms | 30.09 ms |
+| rome-hub-navigation | context-pack | 1 | 2.0 KB | 630 | 153.64 ms | 150.15 ms |
+
+> Token counts are encoder-approximate: tiktoken `cl100k_base` (an OpenAI encoder) on the raw payload text; per-model tokenizers differ in absolute counts but the cross-adapter ratios hold. Steps without raw text fall back to bytes÷4.
+
+## Step breakdown (run 1)
+
+### phlogiston-theory
+
+> What was the phlogiston theory and which chemists overturned it?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `context_pack` | `phlogiston` | 2.0 KB | 551 |
+
+### roman-empire-extent
+
+> What did the Roman Empire comprise at its greatest extent?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `context_pack` | `Roman Empire` | 4.0 KB | 1,115 |
+
+### church-architecture
+
+> How is a mediaeval church laid out architecturally?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `context_pack` | `church architecture nave` | 4.0 KB | 1,084 |
+
+### rome-hub-navigation
+
+> Which articles does the ancient-rome map of content link to?
+
+| # | Call | Target | Payload | Tokens (approx) |
+| ---: | --- | --- | ---: | ---: |
+| 1 | `context_pack` | `ancient-rome MOC` | 2.0 KB | 630 |

--- a/packages/harness/queries/tasks.json
+++ b/packages/harness/queries/tasks.json
@@ -1,0 +1,39 @@
+{
+  "comment": "Task set for the tokens-per-task scenario benchmark (SHA-274). Methodology artifact like default.json: each task is one question an agent must gather context to answer, measured against the committed seed-42 EB1911 fixture vault (packages/harness/fixtures/vault). The scenario runner picks the cheapest sequence the backend supports — one context_pack call, or search → read ×K → backlinks without it — and sums payload bytes/tokens across the calls. Re-measure the notes below if you regenerate the vault.",
+  "tasks": [
+    {
+      "id": "phlogiston-theory",
+      "question": "What was the phlogiston theory and which chemists overturned it?",
+      "searchQuery": "phlogiston",
+      "readTopK": 3,
+      "budgetBytes": 2048,
+      "notes": "Rare term (~9 notes). The multi-call path reads 3 full articles; context_pack answers in one budgeted call."
+    },
+    {
+      "id": "roman-empire-extent",
+      "question": "What did the Roman Empire comprise at its greatest extent?",
+      "searchQuery": "Roman Empire",
+      "readTopK": 3,
+      "budgetBytes": 4096,
+      "notes": "Mid-frequency multi-term (~135 notes); EB1911 articles are long, so full reads are expensive."
+    },
+    {
+      "id": "church-architecture",
+      "question": "How is a mediaeval church laid out architecturally?",
+      "searchQuery": "church architecture nave",
+      "readTopK": 3,
+      "budgetBytes": 4096,
+      "notes": "High-frequency head term ('church' ~2,226 notes) narrowed by modifiers; stresses ranking plus read cost."
+    },
+    {
+      "id": "rome-hub-navigation",
+      "question": "Which articles does the ancient-rome map of content link to?",
+      "searchQuery": "ancient-rome MOC",
+      "readTopK": 2,
+      "budgetBytes": 2048,
+      "notes": "Wikilink-hub task: MOCs/ notes are link hubs. context_pack folds the link neighborhood in; the multi-call path needs read + get_backlinks. Zero hits from content-only searchers is a legitimate, reportable result."
+    }
+  ],
+  "runs": 5,
+  "_runsHint": "Tasks are multi-op and heavier than micro-benchmarks; 5 runs keeps latency honest (cold vs warm) while payload is deterministic anyway."
+}

--- a/packages/harness/src/bench/compare.test.ts
+++ b/packages/harness/src/bench/compare.test.ts
@@ -44,6 +44,7 @@ function summary(
     tools: {
       list: stats(800),
       listTags: stats(400),
+      contextPack: null,
       outline: null,
       getBacklinks: null,
       getLinks: null,
@@ -102,6 +103,7 @@ describe('renderComparisonMarkdown', () => {
       tools: {
         list: stats(800),
         listTags: stats(400),
+        contextPack: { query: 'hello world', stats: stats(700) },
         outline: { path: 'notes/o.md', stats: stats(600) },
         getBacklinks: null,
         getLinks: null,

--- a/packages/harness/src/bench/compare.ts
+++ b/packages/harness/src/bench/compare.ts
@@ -175,6 +175,7 @@ export function renderComparisonMarkdown(summaries: BenchmarkSummary[]): string 
   const toolNames: Array<[string, keyof import('./runner.js').ToolBenchmarks]> = [
     ['list_notes', 'list'],
     ['list_tags', 'listTags'],
+    ['context_pack', 'contextPack'],
     ['outline_note', 'outline'],
     ['get_backlinks', 'getBacklinks'],
     ['get_links', 'getLinks'],

--- a/packages/harness/src/bench/index.ts
+++ b/packages/harness/src/bench/index.ts
@@ -10,3 +10,15 @@ export type { Backend, BackendResponse, ListEntry, SearchHit } from './backend.j
 export { loadQuerySet, type QueryDef, type QuerySet } from './queries.js';
 export { renderBenchmarkMarkdown } from './report.js';
 export { type BenchmarkSummary, runBenchmark, type ToolBenchmarks } from './runner.js';
+export {
+  runScenarios,
+  type ScenarioStrategy,
+  type ScenarioSummary,
+  type TaskResult,
+  type TaskStep,
+} from './scenarios.js';
+export {
+  renderScenarioComparisonMarkdown,
+  renderScenarioMarkdown,
+} from './scenarios-report.js';
+export { loadTaskSet, type TaskDef, type TaskSet } from './tasks.js';

--- a/packages/harness/src/bench/report.test.ts
+++ b/packages/harness/src/bench/report.test.ts
@@ -43,6 +43,7 @@ const minimalSummary: BenchmarkSummary = {
   tools: {
     list: null,
     listTags: null,
+    contextPack: null,
     outline: null,
     getBacklinks: null,
     getLinks: null,
@@ -207,6 +208,7 @@ describe('renderBenchmarkMarkdown', () => {
       tools: {
         list: toolStats,
         listTags: toolStats,
+        contextPack: { query: 'hello world', stats: toolStats },
         outline: { path: 'notes/small.md', stats: toolStats },
         getBacklinks: { path: 'notes/small.md', stats: toolStats },
         getLinks: { path: 'notes/small.md', stats: toolStats },
@@ -217,6 +219,7 @@ describe('renderBenchmarkMarkdown', () => {
     expect(md).toContain('## Tools');
     expect(md).toContain('list_notes');
     expect(md).toContain('list_tags');
+    expect(md).toContain('context_pack');
     expect(md).toContain('outline_note');
     expect(md).toContain('get_backlinks');
     expect(md).toContain('get_links');
@@ -237,6 +240,7 @@ describe('renderBenchmarkMarkdown', () => {
       tools: {
         list: toolStats,
         listTags: null,
+        contextPack: null,
         outline: null,
         getBacklinks: null,
         getLinks: null,
@@ -246,6 +250,7 @@ describe('renderBenchmarkMarkdown', () => {
     const md = renderBenchmarkMarkdown(s);
     expect(md).toContain('Not supported by this backend');
     expect(md).toContain('list_tags');
+    expect(md).toContain('context_pack');
     expect(md).toContain('outline_note');
   });
 

--- a/packages/harness/src/bench/report.ts
+++ b/packages/harness/src/bench/report.ts
@@ -48,7 +48,7 @@ export function renderBenchmarkMarkdown(s: BenchmarkSummary): string {
   }
   push();
   push(
-    `> **Context tax.** Payload is the raw bytes returned for the query. Token count uses tiktoken \`cl100k_base\`.`,
+    `> **Context tax.** Payload is the raw bytes returned for the query. Token count is encoder-approximate: tiktoken \`cl100k_base\` (an OpenAI encoder) on the raw payload text — per-model tokenizers differ in absolute counts, but cross-adapter ratios hold.`,
   );
   push();
 
@@ -74,7 +74,13 @@ export function renderBenchmarkMarkdown(s: BenchmarkSummary): string {
   if (s.tools) {
     const t = s.tools;
     const hasAny =
-      t.list || t.listTags || t.outline || t.getBacklinks || t.getLinks || t.getPeriodicNote;
+      t.list ||
+      t.listTags ||
+      t.contextPack ||
+      t.outline ||
+      t.getBacklinks ||
+      t.getLinks ||
+      t.getPeriodicNote;
 
     if (hasAny) {
       push(`## Tools`);
@@ -91,6 +97,10 @@ export function renderBenchmarkMarkdown(s: BenchmarkSummary): string {
 
       if (t.list) push(toolRow('list_notes', 'vault root', t.list));
       if (t.listTags) push(toolRow('list_tags', 'all tags', t.listTags));
+      if (t.contextPack)
+        push(
+          toolRow('context_pack', `\`${mdCellEscape(t.contextPack.query)}\``, t.contextPack.stats),
+        );
       if (t.outline) push(toolRow('outline_note', `\`${t.outline.path}\``, t.outline.stats));
       if (t.getBacklinks)
         push(toolRow('get_backlinks', `\`${t.getBacklinks.path}\``, t.getBacklinks.stats));
@@ -103,6 +113,7 @@ export function renderBenchmarkMarkdown(s: BenchmarkSummary): string {
       const unsupported: string[] = [];
       if (!t.list) unsupported.push('list_notes');
       if (!t.listTags) unsupported.push('list_tags');
+      if (!t.contextPack) unsupported.push('context_pack');
       if (!t.outline) unsupported.push('outline_note');
       if (!t.getBacklinks) unsupported.push('get_backlinks');
       if (!t.getLinks) unsupported.push('get_links');

--- a/packages/harness/src/bench/runner.test.ts
+++ b/packages/harness/src/bench/runner.test.ts
@@ -130,6 +130,44 @@ describe('runBenchmark', () => {
     expect(summary.search[0]?.ttfr?.coldTtfrMs).toBeGreaterThanOrEqual(0);
   });
 
+  it('tools.contextPack is null for a backend without contextPack (fs)', async () => {
+    const qs = {
+      queries: [{ id: 'q1', kind: 'single' as const, query: 'content' }],
+      reads: { small: 'small.md', large: 'large.md' },
+      runs: 2,
+    };
+    const summary = await runBenchmark({ backend: adapter, querySet: qs });
+    expect(summary.tools.contextPack).toBeNull();
+  });
+
+  it('tools.contextPack carries the first search query and stats when supported', async () => {
+    const packText = JSON.stringify({ excerpts: ['packed'] });
+    const backend = {
+      name: 'fake-pack',
+      description: 'fake contextPack-capable backend',
+      search: adapter.search.bind(adapter),
+      read: adapter.read.bind(adapter),
+      write: adapter.write.bind(adapter),
+      list: adapter.list.bind(adapter),
+      contextPack: async () => ({
+        result: { excerpts: ['packed'] },
+        payloadBytes: Buffer.byteLength(packText, 'utf8'),
+        payloadText: packText,
+      }),
+    };
+    const qs = {
+      queries: [{ id: 'q1', kind: 'single' as const, query: 'content' }],
+      reads: { small: 'small.md', large: 'large.md' },
+      runs: 2,
+    };
+    const summary = await runBenchmark({ backend, querySet: qs });
+    expect(summary.tools.contextPack?.query).toBe('content');
+    expect(summary.tools.contextPack?.stats.runs).toBe(2);
+    expect(summary.tools.contextPack?.stats.payloadBytesMean).toBe(
+      Buffer.byteLength(packText, 'utf8'),
+    );
+  });
+
   it('summary.read is {small: null, large: null} when reads are null and no statsPath', async () => {
     const qs = {
       queries: [{ id: 'q1', kind: 'single' as const, query: 'content' }],

--- a/packages/harness/src/bench/runner.ts
+++ b/packages/harness/src/bench/runner.ts
@@ -8,6 +8,8 @@ export interface ToolBenchmarks {
   list: RunStats | null;
   /** list_tags — all tags sorted by count. */
   listTags: RunStats | null;
+  /** context_pack — one-call context assembly for the first search query. */
+  contextPack: { query: string; stats: RunStats } | null;
   /** outline_note — heading/block structure of the small read target. */
   outline: { path: string; stats: RunStats } | null;
   /** get_backlinks — reverse-link lookup for the small read target. */
@@ -111,7 +113,13 @@ export async function runBenchmark(opts: RunnerOptions): Promise<BenchmarkSummar
     : null;
 
   // ── Extended tool benchmarks ─────────────────────────────────────────────────
-  const tools = await runToolBenchmarks(backend, reads.small, querySet.runs, samplePeak);
+  const tools = await runToolBenchmarks(
+    backend,
+    reads.small,
+    querySet.queries[0]?.query ?? null,
+    querySet.runs,
+    samplePeak,
+  );
 
   return {
     snapshotDate: new Date().toISOString(),
@@ -134,6 +142,7 @@ export async function runBenchmark(opts: RunnerOptions): Promise<BenchmarkSummar
 async function runToolBenchmarks(
   backend: Backend,
   samplePath: string | null,
+  sampleQuery: string | null,
   runs: number,
   samplePeak: () => void,
 ): Promise<ToolBenchmarks> {
@@ -155,6 +164,13 @@ async function runToolBenchmarks(
 
   const listTagsFn = backend.listTags?.bind(backend);
   const listTags = listTagsFn ? await bench(() => listTagsFn()) : null;
+
+  // context_pack — one-call context assembly; needs a query string
+  const contextPackFn = backend.contextPack?.bind(backend);
+  const contextPack =
+    contextPackFn && sampleQuery
+      ? { query: sampleQuery, stats: await bench(() => contextPackFn(sampleQuery)) }
+      : null;
 
   // outline, getBacklinks, getLinks — all need a note path
   let outline: ToolBenchmarks['outline'] = null;
@@ -189,7 +205,7 @@ async function runToolBenchmarks(
   const getPeriodicNoteFn = backend.getPeriodicNote?.bind(backend);
   const getPeriodicNote = getPeriodicNoteFn ? await bench(() => getPeriodicNoteFn('daily')) : null;
 
-  return { list, listTags, outline, getBacklinks, getLinks, getPeriodicNote };
+  return { list, listTags, contextPack, outline, getBacklinks, getLinks, getPeriodicNote };
 }
 
 async function resolveReadPaths(

--- a/packages/harness/src/bench/scenarios-report.test.ts
+++ b/packages/harness/src/bench/scenarios-report.test.ts
@@ -1,0 +1,135 @@
+import { summarise } from '@seekstone/core/percentiles';
+import { describe, expect, it } from 'vitest';
+import type { ScenarioSummary, TaskResult } from './scenarios.js';
+import { renderScenarioComparisonMarkdown, renderScenarioMarkdown } from './scenarios-report.js';
+
+function taskResult(overrides: Partial<TaskResult> = {}): TaskResult {
+  return {
+    id: 'phlogiston-theory',
+    question: 'What was the phlogiston theory?',
+    strategy: 'context-pack',
+    steps: [{ op: 'context_pack', target: 'phlogiston', payloadBytes: 2048, payloadTokens: 500 }],
+    calls: 1,
+    totalPayloadBytes: 2048,
+    totalPayloadTokens: 500,
+    payloadStable: true,
+    latency: { coldMs: 4.2, warm: summarise([1.1, 1.2, 1.3, 1.4]), runs: 5 },
+    ...overrides,
+  };
+}
+
+function summary(label: string, tasks: TaskResult[]): ScenarioSummary {
+  return {
+    snapshotDate: '2026-08-04T00:00:00.000Z',
+    machine: { platform: 'darwin', arch: 'arm64', node: 'v22.0.0', cpus: 8 },
+    backend: { name: label.replace(/-multicall$/, ''), description: `${label} adapter` },
+    label,
+    runs: 5,
+    tasks,
+  };
+}
+
+describe('renderScenarioMarkdown', () => {
+  it('renders totals, calls, strategy and the encoder footnote', () => {
+    const md = renderScenarioMarkdown(summary('seekstone', [taskResult()]));
+    expect(md).toContain('# Scenarios — seekstone');
+    expect(md).toContain('| phlogiston-theory | context-pack | 1 | 2.0 KB | 500 |');
+    expect(md).toContain('Tokens (approx)');
+    expect(md).toContain('encoder-approximate');
+  });
+
+  it('renders a step-breakdown row per call', () => {
+    const md = renderScenarioMarkdown(
+      summary('fs', [
+        taskResult({
+          strategy: 'search-read',
+          steps: [
+            { op: 'search', target: 'phlogiston', payloadBytes: 512, payloadTokens: 100 },
+            {
+              op: 'read',
+              target: 'Encyclopedia/P/Phlogiston.md',
+              payloadBytes: 4096,
+              payloadTokens: 900,
+            },
+          ],
+          calls: 2,
+          totalPayloadBytes: 4608,
+          totalPayloadTokens: 1000,
+        }),
+      ]),
+    );
+    expect(md).toContain('| 1 | `search` | `phlogiston` |');
+    expect(md).toContain('| 2 | `read` | `Encyclopedia/P/Phlogiston.md` |');
+  });
+
+  it('calls out tasks whose payload was not byte-stable across runs', () => {
+    const md = renderScenarioMarkdown(summary('rest', [taskResult({ payloadStable: false })]));
+    expect(md).toContain('Payload not byte-stable across runs');
+    expect(md).toContain('`phlogiston-theory`');
+  });
+});
+
+describe('renderScenarioComparisonMarkdown', () => {
+  it('orders columns seekstone, seekstone-multicall, fs — unknowns last', () => {
+    const md = renderScenarioComparisonMarkdown([
+      summary('zzz-unknown', [taskResult()]),
+      summary('fs', [taskResult()]),
+      summary('seekstone-multicall', [taskResult()]),
+      summary('seekstone', [taskResult()]),
+    ]);
+    const headerLine = md.split('\n').find((l) => l.startsWith('| Task |')) as string;
+    expect(headerLine).toBe('| Task | seekstone | seekstone-multicall | fs | zzz-unknown |');
+  });
+
+  it('computes token multipliers against the seekstone baseline', () => {
+    const md = renderScenarioComparisonMarkdown([
+      summary('seekstone', [taskResult({ totalPayloadTokens: 500 })]),
+      summary('fs', [taskResult({ totalPayloadTokens: 5000 })]),
+    ]);
+    expect(md).toContain('## Context multiplier vs seekstone (tokens)');
+    expect(md).toContain('1.0×');
+    expect(md).toContain('10.0×');
+  });
+
+  it('renders — for tasks a backend has no result for', () => {
+    const md = renderScenarioComparisonMarkdown([
+      summary('seekstone', [taskResult()]),
+      summary('fs', [taskResult({ id: 'other-task' })]),
+    ]);
+    const row = md.split('\n').find((l) => l.startsWith('| phlogiston-theory |')) as string;
+    expect(row).toContain('—');
+  });
+
+  it('daggers zero-hit search-read tasks instead of pricing them as a win', () => {
+    const zeroHit = taskResult({
+      strategy: 'search-read',
+      steps: [{ op: 'search', target: 'phlogiston', payloadBytes: 56, payloadTokens: 17 }],
+      calls: 1,
+      totalPayloadBytes: 56,
+      totalPayloadTokens: 17,
+    });
+    const md = renderScenarioComparisonMarkdown([
+      summary('seekstone', [taskResult()]),
+      summary('obsidian-tc', [zeroHit]),
+    ]);
+    expect(md).toContain('17†');
+    expect(md).toContain('—†');
+    expect(md).toContain('retrieval failure');
+    // The single-backend report daggers it too.
+    expect(renderScenarioMarkdown(summary('obsidian-tc', [zeroHit]))).toContain(
+      'phlogiston-theory†',
+    );
+  });
+
+  it('marks the multicall column as an ablation in the adapter list', () => {
+    const md = renderScenarioComparisonMarkdown([
+      summary('seekstone', [taskResult()]),
+      summary('seekstone-multicall', [taskResult()]),
+    ]);
+    expect(md).toContain('ablation: context_pack disabled');
+  });
+
+  it('returns a stub for empty input', () => {
+    expect(renderScenarioComparisonMarkdown([])).toContain('No data');
+  });
+});

--- a/packages/harness/src/bench/scenarios-report.ts
+++ b/packages/harness/src/bench/scenarios-report.ts
@@ -1,0 +1,228 @@
+import type { ScenarioSummary, TaskResult } from './scenarios.js';
+
+/**
+ * Renderers for the tokens-per-task scenario benchmark (SHA-274).
+ *
+ * `renderScenarioMarkdown` is the per-backend report; the comparison renderer
+ * is the headline artifact — the "tokens per answered question" table meant
+ * for the README and the public leaderboard.
+ */
+
+const KB = 1024;
+const MB = 1024 * 1024;
+
+function fmtBytes(n: number): string {
+  if (n >= MB) return `${(n / MB).toFixed(2)} MB`;
+  if (n >= KB) return `${(n / KB).toFixed(1)} KB`;
+  return `${Math.round(n)} B`;
+}
+function fmtMs(n: number): string {
+  return `${n.toFixed(2)} ms`;
+}
+function fmtTokens(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+const ENCODER_FOOTNOTE =
+  '> Token counts are encoder-approximate: tiktoken `cl100k_base` (an OpenAI encoder) on the raw payload text; per-model tokenizers differ in absolute counts but the cross-adapter ratios hold. Steps without raw text fall back to bytes÷4.';
+
+const NO_HITS_FOOTNOTE =
+  '> † Search returned no hits — the task went unanswered. The payload is the cost of the failed attempt, not of an answer; a low number here is a retrieval failure, not a win.';
+
+/** A search-read sequence that never got to a read found nothing to answer with. */
+function noHits(t: TaskResult): boolean {
+  return t.strategy === 'search-read' && !t.steps.some((s) => s.op === 'read');
+}
+
+export function renderScenarioMarkdown(s: ScenarioSummary): string {
+  const out: string[] = [];
+  const push = (line = '') => out.push(line);
+
+  push(`# Scenarios — ${s.label}`);
+  push();
+  push(`- **Adapter:** ${s.backend.description}`);
+  push(`- **Snapshot:** ${s.snapshotDate}`);
+  push(`- **Runs per task:** ${s.runs} (cold = run 1; warm = runs 2..N)`);
+  push(
+    `- **Machine:** ${s.machine.platform}/${s.machine.arch}, Node ${s.machine.node}, ${s.machine.cpus} logical CPUs`,
+  );
+  push();
+  push(
+    'Each task is one question an agent must gather context to answer. Payload and tokens are summed across every call in the sequence — the context tax per answered question.',
+  );
+  push();
+
+  push('| Task | Strategy | Calls | Payload | Tokens (approx) | Cold | Warm p50 |');
+  push('| --- | --- | ---: | ---: | ---: | ---: | ---: |');
+  for (const t of s.tasks) {
+    const mark = noHits(t) ? '†' : '';
+    push(
+      `| ${t.id}${mark} | ${t.strategy} | ${t.calls} | ${fmtBytes(t.totalPayloadBytes)} | ${fmtTokens(t.totalPayloadTokens)} | ${fmtMs(t.latency.coldMs)} | ${fmtMs(t.latency.warm.median)} |`,
+    );
+  }
+  push();
+  if (s.tasks.some(noHits)) {
+    push(NO_HITS_FOOTNOTE);
+    push();
+  }
+  const unstable = s.tasks.filter((t) => !t.payloadStable);
+  if (unstable.length > 0) {
+    push(
+      `> **Payload not byte-stable across runs** for: ${unstable.map((t) => `\`${t.id}\``).join(', ')}. Totals above are from run 1.`,
+    );
+    push();
+  }
+  push(ENCODER_FOOTNOTE);
+  push();
+
+  push('## Step breakdown (run 1)');
+  push();
+  for (const t of s.tasks) {
+    push(`### ${t.id}`);
+    push();
+    push(`> ${t.question}`);
+    push();
+    push('| # | Call | Target | Payload | Tokens (approx) |');
+    push('| ---: | --- | --- | ---: | ---: |');
+    t.steps.forEach((step, i) => {
+      push(
+        `| ${i + 1} | \`${step.op}\` | \`${mdCellEscape(step.target)}\` | ${fmtBytes(step.payloadBytes)} | ${fmtTokens(step.payloadTokens)} |`,
+      );
+    });
+    push();
+  }
+
+  return out.join('\n');
+}
+
+export function renderScenarioComparisonMarkdown(summaries: ScenarioSummary[]): string {
+  const first = summaries[0];
+  if (!first) return '# Scenario Comparison\n\nNo data.\n';
+
+  // Stable label ordering: seekstone first, its ablation right after, then the
+  // filesystem-direct field, then the rest — same story-order as scaling.ts.
+  const order = [
+    'seekstone',
+    'seekstone-multicall',
+    'fs',
+    'mcpvault',
+    'obsidian-mcp-pro',
+    'obsidian-mcp',
+    'obsidian-mcp-rs',
+    'obsidian-tc',
+    'obsidian-tc-facade',
+    'rest',
+    'obsidian-mcp-server',
+    'mcp-obsidian',
+  ];
+  const sorted = [...summaries].sort((a, b) => {
+    const ia = order.indexOf(a.label);
+    const ib = order.indexOf(b.label);
+    return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+  });
+
+  const taskIds = [...new Set(sorted.flatMap((s) => s.tasks.map((t) => t.id)))];
+  const get = (s: ScenarioSummary, id: string): TaskResult | undefined =>
+    s.tasks.find((t) => t.id === id);
+
+  const L: string[] = [];
+  L.push('# Tokens per answered question — scenario comparison');
+  L.push('');
+  L.push(
+    `> Generated ${first.snapshotDate.slice(0, 10)} · ${first.runs} runs per task · ${first.machine.platform}/${first.machine.arch} · Node ${first.machine.node}`,
+  );
+  L.push('');
+  L.push(
+    'Total context an agent consumes to answer each question: one `context_pack` call on backends that support it, versus search → read ×K → backlinks everywhere else. Lower is better.',
+  );
+  L.push('');
+
+  const header = (lead: string) => {
+    L.push(`| ${lead} | ${sorted.map((s) => s.label).join(' | ')} |`);
+    L.push(`| --- | ${sorted.map(() => '---:').join(' | ')} |`);
+  };
+
+  const anyNoHits = sorted.some((s) => s.tasks.some(noHits));
+
+  L.push('## Tokens (approx) per task');
+  L.push('');
+  header('Task');
+  for (const id of taskIds) {
+    const cells = sorted.map((s) => {
+      const t = get(s, id);
+      return t ? `${fmtTokens(t.totalPayloadTokens)}${noHits(t) ? '†' : ''}` : '—';
+    });
+    L.push(`| ${id} | ${cells.join(' | ')} |`);
+  }
+  L.push('');
+  L.push(ENCODER_FOOTNOTE);
+  L.push('');
+  if (anyNoHits) {
+    L.push(NO_HITS_FOOTNOTE);
+    L.push('');
+  }
+
+  L.push('## Payload bytes per task');
+  L.push('');
+  header('Task');
+  for (const id of taskIds) {
+    const cells = sorted.map((s) => {
+      const t = get(s, id);
+      return t ? fmtBytes(t.totalPayloadBytes) : '—';
+    });
+    L.push(`| ${id} | ${cells.join(' | ')} |`);
+  }
+  L.push('');
+
+  L.push('## Calls per task');
+  L.push('');
+  header('Task');
+  for (const id of taskIds) {
+    const cells = sorted.map((s) => {
+      const t = get(s, id);
+      return t ? `${t.calls}` : '—';
+    });
+    L.push(`| ${id} | ${cells.join(' | ')} |`);
+  }
+  L.push('');
+
+  // ── Multiplier vs seekstone ────────────────────────────────────────────────
+  const baseline = sorted.find((s) => s.label === 'seekstone');
+  if (baseline) {
+    const others = sorted.filter((s) => s !== baseline);
+    if (others.length > 0) {
+      L.push('## Context multiplier vs seekstone (tokens)');
+      L.push('');
+      header('Task');
+      for (const id of taskIds) {
+        const base = get(baseline, id);
+        const cells = sorted.map((s) => {
+          if (s === baseline) return '1.0×';
+          const t = get(s, id);
+          if (!t || !base || base.totalPayloadTokens === 0) return '—';
+          // A no-hit run has no answer to price — a multiplier would read as a win.
+          if (noHits(t)) return '—†';
+          return `${(t.totalPayloadTokens / base.totalPayloadTokens).toFixed(1)}×`;
+        });
+        L.push(`| ${id} | ${cells.join(' | ')} |`);
+      }
+      L.push('');
+    }
+  }
+
+  L.push('## Adapters');
+  L.push('');
+  for (const s of sorted) {
+    const suffix = s.label.endsWith('-multicall')
+      ? ' — ablation: context_pack disabled, forced down the search→read path'
+      : '';
+    L.push(`- **${s.label}**: ${s.backend.description}${suffix}`);
+  }
+  L.push('');
+
+  return L.join('\n');
+}
+
+function mdCellEscape(s: string): string {
+  return s.replaceAll('|', '\\|');
+}

--- a/packages/harness/src/bench/scenarios.test.ts
+++ b/packages/harness/src/bench/scenarios.test.ts
@@ -1,0 +1,173 @@
+import { get_encoding } from 'tiktoken';
+import { describe, expect, it } from 'vitest';
+import type { Backend, BackendResponse, SearchHit } from './backend.js';
+import { runScenarios } from './scenarios.js';
+import type { TaskDef, TaskSet } from './tasks.js';
+
+const enc = get_encoding('cl100k_base');
+
+function resp<T>(result: T): BackendResponse<T> {
+  const text = JSON.stringify(result);
+  return { result, payloadBytes: Buffer.byteLength(text, 'utf8'), payloadText: text };
+}
+
+const hits: SearchHit[] = [
+  { path: 'A/alpha.md', score: 2 },
+  { path: 'B/beta.md', score: 1 },
+  { path: 'C/gamma.md', score: 0.5 },
+];
+
+/** Minimal multi-call backend: search/read/list only, like every competitor. */
+function multicallBackend(overrides: Partial<Backend> = {}): Backend {
+  return {
+    name: 'fake',
+    description: 'fake backend for scenario tests',
+    search: async () => resp(hits),
+    read: async (path: string) => resp(`content of ${path}`),
+    write: async () => ({ result: undefined, payloadBytes: 0 }),
+    list: async () => resp([]),
+    ...overrides,
+  };
+}
+
+function task(overrides: Partial<TaskDef> = {}): TaskDef {
+  return { id: 't1', question: 'What is alpha?', searchQuery: 'alpha', readTopK: 2, ...overrides };
+}
+
+function taskSet(tasks: TaskDef[], runs = 2): TaskSet {
+  return { tasks, runs };
+}
+
+describe('runScenarios', () => {
+  it('uses one context_pack call when the backend supports it', async () => {
+    const calls: Array<[string, number | undefined]> = [];
+    const backend = multicallBackend({
+      contextPack: async (query: string, budgetBytes?: number) => {
+        calls.push([query, budgetBytes]);
+        return resp({ excerpts: ['packed'] });
+      },
+    });
+    const summary = await runScenarios({
+      backend,
+      taskSet: taskSet([task({ budgetBytes: 4096 })]),
+    });
+    const t = summary.tasks[0];
+    expect(t?.strategy).toBe('context-pack');
+    expect(t?.calls).toBe(1);
+    expect(t?.steps.map((s) => s.op)).toEqual(['context_pack']);
+    expect(t?.steps[0]?.target).toBe('alpha');
+    expect(calls[0]).toEqual(['alpha', 4096]);
+    expect(summary.label).toBe('fake');
+  });
+
+  it('falls back to search → read ×K → get_backlinks without context_pack', async () => {
+    const backend = multicallBackend({
+      getBacklinks: async (path: string) => resp({ target: path, backlinks: [] }),
+    });
+    const summary = await runScenarios({ backend, taskSet: taskSet([task()]) });
+    const t = summary.tasks[0];
+    expect(t?.strategy).toBe('search-read');
+    expect(t?.steps.map((s) => s.op)).toEqual(['search', 'read', 'read', 'get_backlinks']);
+    expect(t?.steps.map((s) => s.target)).toEqual([
+      'alpha',
+      'A/alpha.md',
+      'B/beta.md',
+      'A/alpha.md',
+    ]);
+    expect(t?.calls).toBe(4);
+  });
+
+  it('sums payload bytes and tiktoken tokens across all steps', async () => {
+    const backend = multicallBackend();
+    const summary = await runScenarios({ backend, taskSet: taskSet([task()]) });
+    const t = summary.tasks[0];
+    const expectedBytes = [
+      JSON.stringify(hits),
+      JSON.stringify('content of A/alpha.md'),
+      JSON.stringify('content of B/beta.md'),
+    ].reduce((a, s) => a + Buffer.byteLength(s, 'utf8'), 0);
+    const expectedTokens = [
+      JSON.stringify(hits),
+      JSON.stringify('content of A/alpha.md'),
+      JSON.stringify('content of B/beta.md'),
+    ].reduce((a, s) => a + enc.encode(s).length, 0);
+    expect(t?.totalPayloadBytes).toBe(expectedBytes);
+    expect(t?.totalPayloadTokens).toBe(expectedTokens);
+  });
+
+  it('clamps reads to the available hits when fewer than readTopK', async () => {
+    const backend = multicallBackend({ search: async () => resp(hits.slice(0, 1)) });
+    const summary = await runScenarios({ backend, taskSet: taskSet([task({ readTopK: 5 })]) });
+    expect(summary.tasks[0]?.steps.map((s) => s.op)).toEqual(['search', 'read']);
+  });
+
+  it('records only the search step on zero hits (no reads, no backlinks)', async () => {
+    const backend = multicallBackend({
+      search: async () => resp([]),
+      getBacklinks: async (path: string) => resp({ target: path }),
+    });
+    const summary = await runScenarios({ backend, taskSet: taskSet([task()]) });
+    expect(summary.tasks[0]?.steps.map((s) => s.op)).toEqual(['search']);
+  });
+
+  it('skips get_backlinks when the task sets followBacklinks: false', async () => {
+    const backend = multicallBackend({
+      getBacklinks: async (path: string) => resp({ target: path }),
+    });
+    const summary = await runScenarios({
+      backend,
+      taskSet: taskSet([task({ followBacklinks: false })]),
+    });
+    expect(summary.tasks[0]?.steps.map((s) => s.op)).toEqual(['search', 'read', 'read']);
+  });
+
+  it('falls back to bytes÷4 tokens for steps without payloadText', async () => {
+    const backend = multicallBackend({
+      search: async () => ({ result: hits.slice(0, 1), payloadBytes: 100 }),
+      read: async () => ({ result: 'binary-ish', payloadBytes: 401 }),
+    });
+    const summary = await runScenarios({ backend, taskSet: taskSet([task()]) });
+    const t = summary.tasks[0];
+    expect(t?.steps[0]?.payloadTokens).toBe(25);
+    expect(t?.steps[1]?.payloadTokens).toBe(101);
+  });
+
+  it('forceMulticall pushes a context_pack backend down the search-read path and relabels it', async () => {
+    let packCalls = 0;
+    const backend = multicallBackend({
+      contextPack: async () => {
+        packCalls += 1;
+        return resp({});
+      },
+    });
+    const summary = await runScenarios({
+      backend,
+      taskSet: taskSet([task()]),
+      forceMulticall: true,
+    });
+    expect(summary.label).toBe('fake-multicall');
+    expect(summary.tasks[0]?.strategy).toBe('search-read');
+    expect(packCalls).toBe(0);
+  });
+
+  it('flags payloadStable=false when byte totals differ across runs', async () => {
+    let call = 0;
+    const backend = multicallBackend({
+      search: async () => {
+        call += 1;
+        return { result: [], payloadBytes: call * 100 };
+      },
+    });
+    const summary = await runScenarios({ backend, taskSet: taskSet([task()], 3) });
+    expect(summary.tasks[0]?.payloadStable).toBe(false);
+  });
+
+  it('reports cold/warm latency with the RunStats split (cold = run 1)', async () => {
+    const backend = multicallBackend();
+    const summary = await runScenarios({ backend, taskSet: taskSet([task()], 4) });
+    const t = summary.tasks[0];
+    expect(t?.latency.runs).toBe(4);
+    expect(t?.latency.coldMs).toBeGreaterThanOrEqual(0);
+    expect(t?.latency.warm.n).toBe(3);
+  });
+});

--- a/packages/harness/src/bench/scenarios.ts
+++ b/packages/harness/src/bench/scenarios.ts
@@ -1,0 +1,156 @@
+import { cpus } from 'node:os';
+import type { Distribution } from '@seekstone/core/percentiles';
+import { summarise } from '@seekstone/core/percentiles';
+import type { Backend, BackendResponse } from './backend.js';
+import type { TaskDef, TaskSet } from './tasks.js';
+import { countTokens, timed } from './timer.js';
+
+/**
+ * Task-level "tokens per answered question" benchmark (SHA-274).
+ *
+ * Where runner.ts measures single operations, this simulates the call
+ * sequence an agent actually makes to answer a question and sums the payload
+ * across it. Backends with context_pack answer in ONE call; everything else
+ * pays for search → read ×K → backlinks. The sum is the context tax per task.
+ */
+
+export type ScenarioStrategy = 'context-pack' | 'search-read';
+
+export interface TaskStep {
+  op: 'context_pack' | 'search' | 'read' | 'get_backlinks';
+  /** Query string (context_pack/search) or vault-relative note path. */
+  target: string;
+  payloadBytes: number;
+  payloadTokens: number;
+}
+
+export interface TaskResult {
+  id: string;
+  question: string;
+  strategy: ScenarioStrategy;
+  /** Step breakdown captured from run 1 (payload is deterministic per backend). */
+  steps: TaskStep[];
+  calls: number;
+  totalPayloadBytes: number;
+  totalPayloadTokens: number;
+  /** False when per-run byte totals differed — flags nondeterministic backends. */
+  payloadStable: boolean;
+  /** Whole-task wall time; cold = run 1, warm = runs 2..N (same split as RunStats). */
+  latency: { coldMs: number; warm: Distribution; runs: number };
+}
+
+export interface ScenarioSummary {
+  snapshotDate: string;
+  machine: { platform: string; arch: string; node: string; cpus: number };
+  backend: { name: string; description: string };
+  /** backend.name, or `${name}-multicall` for the forced-ablation run. */
+  label: string;
+  runs: number;
+  tasks: TaskResult[];
+}
+
+export interface ScenarioOptions {
+  backend: Backend;
+  taskSet: TaskSet;
+  /**
+   * Force the search-read path even when the backend supports context_pack.
+   * The ablation row proves the win comes from context_pack, not the adapter.
+   */
+  forceMulticall?: boolean;
+}
+
+export async function runScenarios(opts: ScenarioOptions): Promise<ScenarioSummary> {
+  const { backend, taskSet, forceMulticall = false } = opts;
+  const label = forceMulticall ? `${backend.name}-multicall` : backend.name;
+
+  const tasks: TaskResult[] = [];
+  for (const task of taskSet.tasks) {
+    const strategy: ScenarioStrategy =
+      !forceMulticall && backend.contextPack ? 'context-pack' : 'search-read';
+
+    const durations: number[] = [];
+    const byteTotals: number[] = [];
+    let firstSteps: TaskStep[] | null = null;
+    for (let i = 0; i < taskSet.runs; i++) {
+      const t = await timed(() => executeTask(backend, task, strategy));
+      durations.push(t.durationMs);
+      byteTotals.push(t.result.reduce((a, s) => a + s.payloadBytes, 0));
+      if (firstSteps === null) firstSteps = t.result;
+    }
+
+    const steps = firstSteps ?? [];
+    tasks.push({
+      id: task.id,
+      question: task.question,
+      strategy,
+      steps,
+      calls: steps.length,
+      totalPayloadBytes: steps.reduce((a, s) => a + s.payloadBytes, 0),
+      totalPayloadTokens: steps.reduce((a, s) => a + s.payloadTokens, 0),
+      payloadStable: byteTotals.every((b) => b === byteTotals[0]),
+      latency: {
+        coldMs: durations[0] ?? 0,
+        warm: summarise(durations.slice(1)),
+        runs: taskSet.runs,
+      },
+    });
+  }
+
+  return {
+    snapshotDate: new Date().toISOString(),
+    machine: {
+      platform: process.platform,
+      arch: process.arch,
+      node: process.version,
+      cpus: cpus().length,
+    },
+    backend: { name: backend.name, description: backend.description },
+    label,
+    runs: taskSet.runs,
+    tasks,
+  };
+}
+
+/** One pass over a task: the ordered calls an agent would make. */
+async function executeTask(
+  backend: Backend,
+  task: TaskDef,
+  strategy: ScenarioStrategy,
+): Promise<TaskStep[]> {
+  if (strategy === 'context-pack') {
+    const contextPackFn = backend.contextPack?.bind(backend);
+    if (!contextPackFn) {
+      throw new Error(`Backend ${backend.name} has no contextPack but strategy is context-pack.`);
+    }
+    const r = await contextPackFn(task.searchQuery, task.budgetBytes);
+    return [step('context_pack', task.searchQuery, r)];
+  }
+
+  const steps: TaskStep[] = [];
+  const search = await backend.search(task.searchQuery);
+  steps.push(step('search', task.searchQuery, search));
+
+  const hits = search.result.slice(0, task.readTopK);
+  for (const hit of hits) {
+    const r = await backend.read(hit.path);
+    steps.push(step('read', hit.path, r));
+  }
+
+  const getBacklinksFn = backend.getBacklinks?.bind(backend);
+  const topHit = hits[0];
+  if (getBacklinksFn && topHit && task.followBacklinks !== false) {
+    const r = await getBacklinksFn(topHit.path);
+    steps.push(step('get_backlinks', topHit.path, r));
+  }
+
+  return steps;
+}
+
+function step(op: TaskStep['op'], target: string, r: BackendResponse<unknown>): TaskStep {
+  return {
+    op,
+    target,
+    payloadBytes: r.payloadBytes,
+    payloadTokens: countTokens(r.payloadText, r.payloadBytes),
+  };
+}

--- a/packages/harness/src/bench/tasks.test.ts
+++ b/packages/harness/src/bench/tasks.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { loadTaskSet } from './tasks.js';
 
@@ -51,7 +52,8 @@ describe('loadTaskSet', () => {
   });
 
   it('parses the committed tasks.json', async () => {
-    const committed = new URL('../../queries/tasks.json', import.meta.url).pathname;
+    // fileURLToPath, not .pathname — the latter mangles Windows drive letters.
+    const committed = fileURLToPath(new URL('../../queries/tasks.json', import.meta.url));
     const ts = await loadTaskSet(committed);
     expect(ts.tasks.length).toBeGreaterThanOrEqual(3);
     for (const t of ts.tasks) {

--- a/packages/harness/src/bench/tasks.test.ts
+++ b/packages/harness/src/bench/tasks.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadTaskSet } from './tasks.js';
+
+async function writeTaskFile(content: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'seekstone-tasks-'));
+  const path = join(dir, 'tasks.json');
+  await writeFile(path, JSON.stringify(content));
+  return path;
+}
+
+const validTask = {
+  id: 't1',
+  question: 'What is X?',
+  searchQuery: 'x',
+  readTopK: 3,
+};
+
+describe('loadTaskSet', () => {
+  it('parses a valid task set and applies the runs default of 5', async () => {
+    const path = await writeTaskFile({ tasks: [validTask] });
+    const ts = await loadTaskSet(path);
+    expect(ts.tasks).toHaveLength(1);
+    expect(ts.tasks[0]?.id).toBe('t1');
+    expect(ts.runs).toBe(5);
+  });
+
+  it('honours an explicit runs value', async () => {
+    const path = await writeTaskFile({ tasks: [validTask], runs: 9 });
+    const ts = await loadTaskSet(path);
+    expect(ts.runs).toBe(9);
+  });
+
+  it('throws when the file has no tasks', async () => {
+    const path = await writeTaskFile({ tasks: [] });
+    await expect(loadTaskSet(path)).rejects.toThrow(/has no tasks/);
+  });
+
+  it('throws when a task is missing id/question/searchQuery', async () => {
+    const path = await writeTaskFile({ tasks: [{ id: 't1', readTopK: 3 }] });
+    await expect(loadTaskSet(path)).rejects.toThrow(/id, question and searchQuery/);
+  });
+
+  it('throws when readTopK is out of range (adapters cap search hits at 10)', async () => {
+    const path = await writeTaskFile({ tasks: [{ ...validTask, readTopK: 11 }] });
+    await expect(loadTaskSet(path)).rejects.toThrow(/between 1 and 10/);
+    const zero = await writeTaskFile({ tasks: [{ ...validTask, readTopK: 0 }] });
+    await expect(loadTaskSet(zero)).rejects.toThrow(/between 1 and 10/);
+  });
+
+  it('parses the committed tasks.json', async () => {
+    const committed = new URL('../../queries/tasks.json', import.meta.url).pathname;
+    const ts = await loadTaskSet(committed);
+    expect(ts.tasks.length).toBeGreaterThanOrEqual(3);
+    for (const t of ts.tasks) {
+      expect(t.question.length).toBeGreaterThan(0);
+      expect(t.searchQuery.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/harness/src/bench/tasks.ts
+++ b/packages/harness/src/bench/tasks.ts
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises';
+
+/**
+ * A task = one question an agent must gather context to answer. The scenario
+ * runner (scenarios.ts) picks the cheapest call sequence the backend supports:
+ * a single context_pack call, or search → read ×K → backlinks for backends
+ * without it. The task file is a methodology artifact like default.json —
+ * committed, edited per-vault, and re-run against the same set so results
+ * stay comparable across snapshots and adapters.
+ */
+export interface TaskDef {
+  id: string;
+  /** The human question — documentation and report label. */
+  question: string;
+  /** What an agent would feed to search / context_pack. */
+  searchQuery: string;
+  /** How many top hits the multi-call path reads in full. */
+  readTopK: number;
+  /** context_pack byte budget; the adapter default (2048) applies when omitted. */
+  budgetBytes?: number;
+  /** Follow up with get_backlinks on the top hit (multi-call path). Default true. */
+  followBacklinks?: boolean;
+  notes?: string;
+}
+
+export interface TaskSet {
+  tasks: TaskDef[];
+  runs: number;
+}
+
+/**
+ * Adapters cap search results (seekstone limit 10, fs slices to 10), so a
+ * readTopK beyond that would silently measure fewer reads than declared.
+ */
+const MAX_READ_TOP_K = 10;
+
+export async function loadTaskSet(path: string): Promise<TaskSet> {
+  const raw = await readFile(path, 'utf8');
+  const parsed = JSON.parse(raw) as Partial<TaskSet> & { runs?: number };
+  if (!Array.isArray(parsed.tasks) || parsed.tasks.length === 0) {
+    throw new Error(`Task file ${path} has no tasks.`);
+  }
+  for (const t of parsed.tasks) {
+    if (!t.id || !t.question || !t.searchQuery) {
+      throw new Error(`Task file ${path}: every task needs id, question and searchQuery.`);
+    }
+    if (!Number.isInteger(t.readTopK) || t.readTopK < 1 || t.readTopK > MAX_READ_TOP_K) {
+      throw new Error(
+        `Task ${t.id}: readTopK must be an integer between 1 and ${MAX_READ_TOP_K} (adapters cap search results at 10).`,
+      );
+    }
+  }
+  return {
+    tasks: parsed.tasks,
+    runs: parsed.runs ?? 5,
+  };
+}

--- a/packages/harness/src/bench/timer.test.ts
+++ b/packages/harness/src/bench/timer.test.ts
@@ -1,8 +1,24 @@
 import { get_encoding } from 'tiktoken';
 import { describe, expect, it } from 'vitest';
-import { runN, runNStream, timed } from './timer.js';
+import { countTokens, runN, runNStream, timed } from './timer.js';
 
 const enc = get_encoding('cl100k_base');
+
+describe('countTokens', () => {
+  it('uses tiktoken cl100k_base when text is provided', () => {
+    const text = 'Hello, this is a sample note with some content for token counting.';
+    expect(countTokens(text, Buffer.byteLength(text, 'utf8'))).toBe(enc.encode(text).length);
+  });
+
+  it('falls back to ceil(bytes / 4) when text is undefined', () => {
+    expect(countTokens(undefined, 512)).toBe(128);
+    expect(countTokens(undefined, 513)).toBe(129);
+  });
+
+  it('counts an empty string as 0 tokens rather than falling back', () => {
+    expect(countTokens('', 512)).toBe(0);
+  });
+});
 
 describe('timed', () => {
   it('returns the result of the fn unchanged', async () => {

--- a/packages/harness/src/bench/timer.ts
+++ b/packages/harness/src/bench/timer.ts
@@ -3,6 +3,15 @@ import { get_encoding } from 'tiktoken';
 
 const enc = get_encoding('cl100k_base');
 
+/**
+ * Token count for a payload: exact tiktoken cl100k_base when the raw text is
+ * available, else bytes÷4. Encoder-approximate — cl100k_base is an OpenAI
+ * encoder, so absolute counts differ per model but cross-adapter ratios hold.
+ */
+export function countTokens(text: string | undefined, bytes: number): number {
+  return text !== undefined ? enc.encode(text).length : Math.ceil(bytes / 4);
+}
+
 export interface Timing<T> {
   result: T;
   durationMs: number;
@@ -56,8 +65,7 @@ export async function runN<T>(
   const cold = durations[0] ?? 0;
   const warmRuns = durations.slice(1);
   const payloadMean = payloads.reduce((a, b) => a + b, 0) / Math.max(1, payloads.length);
-  const payloadTokensMean =
-    sampleText !== undefined ? enc.encode(sampleText).length : Math.ceil(payloadMean / 4);
+  const payloadTokensMean = countTokens(sampleText, payloadMean);
   return {
     coldMs: cold,
     warm: summarise(warmRuns),

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -20,6 +20,12 @@ import {
   runBenchmark,
 } from './bench/index.js';
 import { renderScalingMarkdown, type ScaleGroup } from './bench/scaling.js';
+import { runScenarios } from './bench/scenarios.js';
+import {
+  renderScenarioComparisonMarkdown,
+  renderScenarioMarkdown,
+} from './bench/scenarios-report.js';
+import { loadTaskSet } from './bench/tasks.js';
 import { fetchCorpus, loadCorpus } from './fixtures/corpus.js';
 import { generateVault } from './fixtures/generate.js';
 import { profileVault } from './profiler/index.js';
@@ -38,6 +44,7 @@ process.chdir(REPO_ROOT);
 // Anchor fixture defaults to this package, independent of the caller's cwd.
 const FIXTURES = fileURLToPath(new URL('../fixtures', import.meta.url));
 const DEFAULT_QUERIES = fileURLToPath(new URL('../queries/default.json', import.meta.url));
+const DEFAULT_TASKS = fileURLToPath(new URL('../queries/tasks.json', import.meta.url));
 
 const cli = cac('seekstone-harness');
 
@@ -97,6 +104,77 @@ cli
     } finally {
       await backend.close?.();
     }
+  });
+
+// ---------- scenarios ----------
+cli
+  .command('scenarios', 'Run the tokens-per-task scenario benchmark against a backend.')
+  .option('--backend <name>', 'Adapter name (see bench).', { default: 'seekstone' })
+  .option('--vault <path>', 'Vault root (or set SEEKSTONE_VAULT).')
+  .option('--tasks <file>', 'Task set JSON.', { default: DEFAULT_TASKS })
+  .option('--strategy <mode>', '"auto" (context_pack when supported) or "multicall" (ablation).', {
+    default: 'auto',
+  })
+  .option('--out <dir>', 'Output directory.', { default: 'reports' })
+  .option('--runs <n>', 'Override runs-per-task.')
+  .action(async (opts) => {
+    if (opts.strategy !== 'auto' && opts.strategy !== 'multicall') {
+      console.error(`Unknown --strategy: ${opts.strategy}. Known: auto, multicall.`);
+      process.exit(2);
+    }
+    const outDir = resolve(opts.out);
+    await mkdir(outDir, { recursive: true });
+    const taskSet = await loadTaskSet(resolve(opts.tasks));
+    if (opts.runs) taskSet.runs = Number(opts.runs);
+    const vaultRoot = opts.vault ?? process.env.SEEKSTONE_VAULT;
+    const backend = await buildBackend(opts.backend, vaultRoot);
+    try {
+      const summary = await runScenarios({
+        backend,
+        taskSet,
+        forceMulticall: opts.strategy === 'multicall',
+      });
+      await writeFile(
+        join(outDir, `scenarios-${summary.label}.json`),
+        JSON.stringify(summary, null, 2),
+      );
+      await writeFile(
+        join(outDir, `scenarios-${summary.label}.md`),
+        renderScenarioMarkdown(summary),
+      );
+      console.log(
+        `scenarios (${summary.label}): ${summary.tasks.length} tasks × ${taskSet.runs} runs.`,
+      );
+      console.log(`         wrote ${join(outDir, `scenarios-${summary.label}.json`)}`);
+      console.log(`         wrote ${join(outDir, `scenarios-${summary.label}.md`)}`);
+    } finally {
+      await backend.close?.();
+    }
+  });
+
+// ---------- scenarios-compare ----------
+cli
+  .command(
+    'scenarios-compare',
+    'Generate a cross-adapter tokens-per-task comparison from scenario JSON files.',
+  )
+  .option('--reports <files>', 'Comma-separated paths to scenarios-*.json files.')
+  .option('--out <dir>', 'Output directory.', { default: 'reports' })
+  .action(async (opts) => {
+    const paths = needArg(opts.reports as string, 'reports')
+      .split(',')
+      .map((p: string) => resolve(p.trim()));
+    const summaries = await Promise.all(
+      paths.map(async (p: string) => {
+        const raw = await readFile(p, 'utf8');
+        return JSON.parse(raw) as import('./bench/scenarios.js').ScenarioSummary;
+      }),
+    );
+    const outDir = resolve(opts.out);
+    await mkdir(outDir, { recursive: true });
+    const outPath = join(outDir, 'scenarios-comparison.md');
+    await writeFile(outPath, renderScenarioComparisonMarkdown(summaries));
+    console.log(`scenarios-compare: wrote ${outPath}`);
   });
 
 // ---------- safety ----------


### PR DESCRIPTION
Closes SHA-274 — the deferred half of SHA-256: a **task-level** context-tax metric instead of only per-op measurements.

## What

- **`scenarios` command**: each task in the committed `queries/tasks.json` (4 tasks against the seed-42 EB1911 fixture vault) is a question an agent must gather context to answer. The runner executes the cheapest sequence the backend supports — one `context_pack` call, or `search` → `read` ×K → `get_backlinks`, with reads following **each backend's own** hit ranking — and sums payload bytes + tiktoken tokens across the calls. Whole-task latency keeps the cold/warm split.
- **`--strategy multicall` ablation**: forces seekstone down the multi-call path (`seekstone-multicall` column), proving the win is `context_pack` itself, not the adapter.
- **`scenarios-compare` command**: the leaderboard-ready cross-adapter table (tokens / bytes / calls / multiplier vs seekstone).
- **Per-op `context_pack` wiring**: added to `ToolBenchmarks` so it also lands in standard benchmark/comparison tables (old committed JSONs render it as unsupported, no crash).
- **Honesty guards**: zero-hit search sequences are daggered as retrieval failures so a cheap miss can't read as a win; token counts are labeled encoder-approximate (`cl100k_base`); `payloadStable` flags nondeterministic backends.

## Headline numbers (committed baselines, 10k fixture vault)

| Task | seekstone | seekstone-multicall | fs | obsidian-mcp-rs | obsidian-tc |
| --- | ---: | ---: | ---: | ---: | ---: |
| phlogiston-theory | 551 | 106,523 | 106,612 | 3,861 | 7,410 |
| roman-empire-extent | 1,115 | 41,397 | 41,534 | 22,550 | 120,619 |
| church-architecture | 1,084 | 25,298 | 22,529 | 15,172 | 17† |
| rome-hub-navigation | 630 | 1,016 | 1,355 | 1,942 | 1,581 |

† zero hits — retrieval failure, not a win.

Payload totals verified byte-identical across repeat runs (deterministic for the committed vault).

## Notes

- obsidian-mcp-pro was run but **not** committed: its current npm release wraps search results in prose `[BEGIN UNTRUSTED VAULT CONTENT]` markers the adapter's JSON parser doesn't handle, so hits parse to zero. Will file a follow-up issue for the adapter.
- No changeset: harness-only change (changeset gate covers `packages/server/src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)