### PR TITLE
fix(server): stop folding long frontmatter scalars, which drops wikilinks from the link index

### DIFF
--- a/.changeset/smooth-jars-hammer.md
+++ b/.changeset/smooth-jars-hammer.md
@@ -1,0 +1,9 @@
+---
+'seekstone': patch
+---
+
+Stop folding long frontmatter scalars. `create_note` and `patch_frontmatter` passed no
+`lineWidth` to the YAML serializer, so values past 80 columns were wrapped across lines with a
+trailing `\`. The output is valid YAML and round-trips, but link extraction runs per line, so a
+wikilink split that way became invisible to the backlink index, `get_links` and `context_pack` —
+a patch touching one key could silently drop a link declared under another.

--- a/packages/server/src/tools/create_note.test.ts
+++ b/packages/server/src/tools/create_note.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { extractLinksWithLines } from '@seekstone/core/extract';
 import MiniSearch from 'minisearch';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ServerContext } from '../context.js';
@@ -55,6 +56,21 @@ describe('createNote', () => {
     expect(disk).toMatch(/^---\n/);
     expect(disk).toContain('title: My Note');
     expect(disk).toContain('Body here.');
+  });
+
+  it('does not fold a long frontmatter value, keeping a wikilink extractable', async () => {
+    const target =
+      'sources/rag-notes/a-capture-slug-long-enough-to-exceed-the-default-line-width-2026-01-01';
+    await createNote(ctx, {
+      path: 'long-fm.md',
+      content: '# Body\n',
+      frontmatter: { title: 'Long', sources: `[[${target}]]` },
+    });
+
+    const disk = await readFile(join(tmpDir, 'long-fm.md'), 'utf8');
+
+    expect(disk).not.toContain('\\\n');
+    expect(extractLinksWithLines(disk).map((l) => l.target)).toContain(target);
   });
 
   it('creates parent directories automatically', async () => {

--- a/packages/server/src/tools/create_note.ts
+++ b/packages/server/src/tools/create_note.ts
@@ -86,7 +86,7 @@ export async function createNote(
 
   let raw = '';
   if (input.frontmatter && Object.keys(input.frontmatter).length > 0) {
-    raw = `---\n${stringifyYaml(input.frontmatter)}---\n`;
+    raw = `---\n${stringifyYaml(input.frontmatter, { lineWidth: 0 })}---\n`;
   }
   raw += input.content ?? '';
 

--- a/packages/server/src/tools/patch_frontmatter.test.ts
+++ b/packages/server/src/tools/patch_frontmatter.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { extractLinksWithLines } from '@seekstone/core/extract';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import MiniSearch from 'minisearch';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -172,6 +173,25 @@ describe('patchFrontmatter', () => {
     expect(fm.data?.title).toBe('Created');
     // Original body preserved
     expect(written).toContain('# No Frontmatter');
+  });
+
+  it('does not fold a long value — a wikilink survives a patch to an unrelated key', async () => {
+    const target =
+      'sources/rag-notes/a-capture-slug-long-enough-to-exceed-the-default-line-width-2026-01-01';
+    const note = `---\ntitle: Long Sources\nupdated: 2026-01-01\nsources: ["[[${target}]]"]\n---\n# Body\n`;
+    await writeFile(join(vaultRoot, 'long-value.md'), note, 'utf8');
+    const ctx = buildCtx(vaultRoot, [
+      { id: 'long-value.md', title: 'Long Sources', body: '# Body\n', raw: note },
+    ]);
+
+    await patchFrontmatter(ctx, { path: 'long-value.md', patch: { updated: '2026-02-02' } });
+
+    const written = await readFile(join(vaultRoot, 'long-value.md'), 'utf8');
+
+    // A folded scalar is valid YAML that round-trips, so assert on the consumer that
+    // actually breaks: a wikilink split across lines matches no link-extraction regex.
+    expect(written).not.toContain('\\\n');
+    expect(extractLinksWithLines(written).map((l) => l.target)).toContain(target);
   });
 
   it('throws "Path outside vault" for path traversal', async () => {

--- a/packages/server/src/tools/patch_frontmatter.ts
+++ b/packages/server/src/tools/patch_frontmatter.ts
@@ -74,7 +74,7 @@ export async function patchFrontmatter(
         keysAdded.push(k);
       }
     }
-    newContent = `---\n${doc.toString()}---\n${original}`;
+    newContent = `---\n${doc.toString({ lineWidth: 0 })}---\n${original}`;
   } else {
     // Parse the existing FM block preserving source tokens.
     const opensWithCRLF = original.startsWith('---\r\n');
@@ -102,7 +102,7 @@ export async function patchFrontmatter(
 
     const head = opensWithCRLF ? '---\r\n' : '---\n';
     const tail = opensWithCRLF ? '---\r\n' : '---\n';
-    newContent = `${head}${doc.toString()}${tail}${fm.body}`;
+    newContent = `${head}${doc.toString({ lineWidth: 0 })}${tail}${fm.body}`;
   }
 
   await atomicWrite(absPath, newContent);


### PR DESCRIPTION
## Tl;dr

Obviously done with claude - This is to facilitate Karpathys Obsidian vault. For the vault, wikilinks in the frontmatter are very useful but they can't be added correctly right now.

## What & why

`create_note` and `patch_frontmatter` pass no `lineWidth` to the YAML serializer, so the `yaml` default of 80 applies and any longer frontmatter value is emitted folded across lines with a trailing `\`.

The folded output is **valid YAML and round-trips to the same string**, so this isn't a YAML correctness problem — every parser-level consumer is fine. It's a problem because link extraction runs per line and its patterns exclude newlines (`[^\]|#\n]{1,512}`), so a wikilink that folding splits matches *neither half*. It doesn't become a dangling link; it stops existing.

`extractLinksWithLines` is documented as extracting "from a raw note (including frontmatter)", and it feeds `index/backlinks.ts`, `get_links.ts` and `context_pack.ts` — so all three lose the link.

### Reproduction

`page.md`, with `sources:` in the quoted-flow-list form:

```yaml
---
title: page
updated: 2026-07-29
sources: ["[[sources/rag-notes/a-very-long-capture-slug-that-exceeds-eighty-columns-2026-07-29]]"]
---
```

Patch **only** `updated`:

```json
{"name":"patch_frontmatter","arguments":{"path":"page.md","patch":{"updated":"2026-08-05"}}}
```

The untouched `sources:` value comes back split mid-slug:

```yaml
sources:
  [
    "[[sources/rag-notes/a-very-long-capture-slug-that-exceeds-eighty-columns\
      -2026-07-29]]"
  ]
```

`get_backlinks` against that capture, same link, only the wrapping differs:

| `sources:` form | result |
| --- | --- |
| folded (what the server writes) | `total: 0`, `backlinks: []` |
| one line | `total: 1`, `backlinks: ["page.md"]` |

So the writer produces a file the reader in the same process no longer resolves. `create_note` folds the same way when given a long scalar.

This was found in a 78-page vault where it had silently removed the `sources:` link from four pages. Nothing surfaced at the time, because a missing link reports as nothing at all.

### The change

`{ lineWidth: 0 }` at the three sites that serialize frontmatter — one in `create_note`, two in `patch_frontmatter`. Parsed values are unaffected; the only difference is that a long frontmatter value stays on one line, which is what Obsidian itself writes.

I checked before choosing the default over an opt-in: no test asserts a folded value and no fixture is long enough to fold, so nothing in the repo depends on the current wrapping. Happy to rework this as a server-level config option instead if you'd prefer to gate it — just say so and I'll push that version.

### Not included, but worth flagging

The more robust fix is to make frontmatter link extraction YAML-aware (parse the block, walk string values) rather than regexing raw lines, which would tolerate folding from *any* writer, including hand-edited files. I left that out deliberately — it changes behaviour for three consumers at once and is your design call, not something to slip into a bug fix.

## How it was tested

- `npm test` — 66 files, 745 tests, all passing.
- `npm run lint` — clean (rc 0).
- `npx tsc -p packages/server/tsconfig.json --noEmit` — clean.
- Two regression tests added, one per affected tool. Both assert through `extractLinksWithLines` rather than string matching, so they fail for the reason that actually broke rather than on formatting.
- Verified the tests are load-bearing: with the source fix reverted and the tests kept, exactly those two fail; with it applied, all pass.

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Typecheck passes (`npx tsc -p packages/server/tsconfig.json --noEmit`)
- [x] Tests added/updated for the change
- [x] Added a changeset (patch) for the user-facing fix
- [x] No new network calls or telemetry in the server
