### PR TITLE
fix(server): separator-boundary vault containment via shared resolveVaultPath

### DIFF
--- a/.changeset/vault-path-boundary.md
+++ b/.changeset/vault-path-boundary.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Harden the vault sandbox: path containment now uses a single shared guard (`resolveVaultPath`) with a proper separator-boundary check, replacing 13 inline `startsWith` checks that accepted paths escaping into sibling directories whose names share the vault's prefix (e.g. vault `/home/u/vault` + path `../vault-backup/x.md`). The vault root is also normalized with `resolve()` at startup so a relative or trailing-slash `SEEKSTONE_VAULT` can't weaken the boundary, and absolute-path inputs are now contained instead of concatenated.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolve } from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -53,11 +54,15 @@ const log = createLogger();
 // on a stray unhandled rejection rather than crashing the user's session.
 installProcessGuards(log);
 
-const vaultRoot = process.env.SEEKSTONE_VAULT;
-if (!vaultRoot) {
+const rawVaultRoot = process.env.SEEKSTONE_VAULT;
+if (!rawVaultRoot) {
   log.error('SEEKSTONE_VAULT env var is required');
   process.exit(1);
 }
+// Normalize once so the containment guard (vault-path.ts) compares against a
+// canonical absolute path — a relative or trailing-slash SEEKSTONE_VAULT must
+// not weaken the prefix boundary.
+const vaultRoot = resolve(rawVaultRoot);
 
 const policy = parseWritePolicy(process.env);
 if (policy.readOnly) log.info('read-only mode', { env: 'SEEKSTONE_READ_ONLY' });

--- a/packages/server/src/tools/append_note.ts
+++ b/packages/server/src/tools/append_note.ts
@@ -6,6 +6,7 @@ import { atomicWrite } from '../atomic-write.js';
 import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { assertWritable } from '../policy.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const AppendNoteInput = z.object({
   path: z.string().describe('Vault-relative path to the note.'),
@@ -44,10 +45,7 @@ export async function appendNote(
   ctx: ServerContext,
   input: AppendNoteInput,
 ): Promise<AppendNoteResult> {
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
   assertWritable(ctx.policy, input.path);
 
   const original = await readFile(absPath, 'utf8');

--- a/packages/server/src/tools/append_note.ts
+++ b/packages/server/src/tools/append_note.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { z } from 'zod';
 import { atomicWrite } from '../atomic-write.js';

--- a/packages/server/src/tools/create_note.test.ts
+++ b/packages/server/src/tools/create_note.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { extractLinksWithLines } from '@seekstone/core/extract';
 import MiniSearch from 'minisearch';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -152,7 +152,7 @@ describe('createNote', () => {
   it('throws on sibling-directory prefix escape', async () => {
     // A path resolving to <vault>-backup/… passes a bare startsWith(vaultRoot)
     // check; the separator-boundary guard must reject it.
-    const sibling = `../${tmpDir.split('/').pop()}-backup/secret.md`;
+    const sibling = `../${basename(tmpDir)}-backup/secret.md`;
     await expect(createNote(ctx, { path: sibling, content: 'bad' })).rejects.toThrow(
       'Path outside vault',
     );

--- a/packages/server/src/tools/create_note.test.ts
+++ b/packages/server/src/tools/create_note.test.ts
@@ -149,6 +149,15 @@ describe('createNote', () => {
     );
   });
 
+  it('throws on sibling-directory prefix escape', async () => {
+    // A path resolving to <vault>-backup/… passes a bare startsWith(vaultRoot)
+    // check; the separator-boundary guard must reject it.
+    const sibling = `../${tmpDir.split('/').pop()}-backup/secret.md`;
+    await expect(createNote(ctx, { path: sibling, content: 'bad' })).rejects.toThrow(
+      'Path outside vault',
+    );
+  });
+
   it('respects write-path scoping', async () => {
     const scoped = { ...freshCtx(), policy: { readOnly: false, writeGlobs: ['journal/**'] } };
     await expect(

--- a/packages/server/src/tools/create_note.ts
+++ b/packages/server/src/tools/create_note.ts
@@ -7,6 +7,7 @@ import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { buildDoc, upsertDoc } from '../index/doc.js';
 import { assertWritable } from '../policy.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const CreateNoteInput = z
   .object({
@@ -51,10 +52,7 @@ export async function createNote(
   rawInput: CreateNoteInput,
 ): Promise<CreateNoteResult> {
   const input = CreateNoteInput.parse(rawInput);
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
   assertWritable(ctx.policy, input.path);
 
   if (!input.overwrite) {

--- a/packages/server/src/tools/create_note.ts
+++ b/packages/server/src/tools/create_note.ts
@@ -1,5 +1,5 @@
 import { access, mkdir, readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname } from 'node:path';
 import { stringify as stringifyYaml } from 'yaml';
 import { z } from 'zod';
 import { atomicWrite } from '../atomic-write.js';

--- a/packages/server/src/tools/delete_note.ts
+++ b/packages/server/src/tools/delete_note.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import type { ServerContext } from '../context.js';
 import { removeNoteBacklinks } from '../index/backlinks.js';
 import { assertWritable } from '../policy.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const DeleteNoteInput = z.object({
   path: z.string().describe('Vault-relative path of the note to delete.'),
@@ -44,10 +45,7 @@ export async function deleteNote(
   rawInput: DeleteNoteInput,
 ): Promise<DeleteNoteResult> {
   const input = DeleteNoteInput.parse(rawInput);
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
   // Policy applies to the note being deleted; the .trash/ destination is the
   // safety mechanism itself, not a user write.
   assertWritable(ctx.policy, input.path);

--- a/packages/server/src/tools/get_backlinks.ts
+++ b/packages/server/src/tools/get_backlinks.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import { z } from 'zod';
 import type { ServerContext } from '../context.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const GetBacklinksInput = z.object({
   path: z.string().describe('Vault-relative path to the target note.'),
@@ -34,10 +35,7 @@ export interface GetBacklinksResult {
 const EXCERPT_MAX = 200;
 
 export function getBacklinks(ctx: ServerContext, input: GetBacklinksInput): GetBacklinksResult {
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
 
   const includeContext = input.includeContext ?? true;
   const limit = input.limit ?? 50;

--- a/packages/server/src/tools/get_backlinks.ts
+++ b/packages/server/src/tools/get_backlinks.ts
@@ -1,4 +1,3 @@
-import { join } from 'node:path';
 import { z } from 'zod';
 import type { ServerContext } from '../context.js';
 import { resolveVaultPath } from '../vault-path.js';
@@ -35,7 +34,7 @@ export interface GetBacklinksResult {
 const EXCERPT_MAX = 200;
 
 export function getBacklinks(ctx: ServerContext, input: GetBacklinksInput): GetBacklinksResult {
-  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
+  resolveVaultPath(ctx.vaultRoot, input.path); // containment validation only
 
   const includeContext = input.includeContext ?? true;
   const limit = input.limit ?? 50;

--- a/packages/server/src/tools/get_links.ts
+++ b/packages/server/src/tools/get_links.ts
@@ -4,6 +4,7 @@ import { extractLinksWithLines } from '@seekstone/core/extract';
 import { z } from 'zod';
 import type { ServerContext } from '../context.js';
 import { resolveLink } from '../index/resolve.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const GetLinksInput = z.object({
   path: z.string().describe('Vault-relative path to the note.'),
@@ -25,10 +26,7 @@ export interface GetLinksResult {
 }
 
 export function getLinks(ctx: ServerContext, input: GetLinksInput): GetLinksResult {
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
   const note = ctx.notes.get(input.path);
   if (note === undefined) throw new Error(`Note not found: ${input.path}`);
 

--- a/packages/server/src/tools/get_links.ts
+++ b/packages/server/src/tools/get_links.ts
@@ -1,4 +1,3 @@
-import { join } from 'node:path';
 import type { LinkType } from '@seekstone/core/extract';
 import { extractLinksWithLines } from '@seekstone/core/extract';
 import { z } from 'zod';
@@ -26,7 +25,7 @@ export interface GetLinksResult {
 }
 
 export function getLinks(ctx: ServerContext, input: GetLinksInput): GetLinksResult {
-  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
+  resolveVaultPath(ctx.vaultRoot, input.path); // containment validation only
   const note = ctx.notes.get(input.path);
   if (note === undefined) throw new Error(`Note not found: ${input.path}`);
 

--- a/packages/server/src/tools/move_note.ts
+++ b/packages/server/src/tools/move_note.ts
@@ -7,6 +7,7 @@ import { addNoteBacklinks, removeNoteBacklinks } from '../index/backlinks.js';
 import { buildDoc, upsertDoc } from '../index/doc.js';
 import { assertWritable, isWritable } from '../policy.js';
 import { hasMarkdownLinkTo, rewriteNoteLinks } from './rewrite_links.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const MoveNoteInput = z.object({
   from: z.string().describe('Vault-relative path of the note to move.'),
@@ -42,11 +43,8 @@ export async function moveNote(
   // Parse here (not only in dispatch) so defaults like rewriteLinks apply to
   // direct callers too — same pattern as periodic_note.
   const input = MoveNoteInput.parse(rawInput);
-  const absFrom = join(ctx.vaultRoot, input.from);
-  const absTo = join(ctx.vaultRoot, input.to);
-
-  if (!absFrom.startsWith(ctx.vaultRoot)) throw new Error(`Path outside vault: ${input.from}`);
-  if (!absTo.startsWith(ctx.vaultRoot)) throw new Error(`Path outside vault: ${input.to}`);
+  const absFrom = resolveVaultPath(ctx.vaultRoot, input.from);
+  const absTo = resolveVaultPath(ctx.vaultRoot, input.to);
   assertWritable(ctx.policy, input.from);
   assertWritable(ctx.policy, input.to);
 

--- a/packages/server/src/tools/move_note.ts
+++ b/packages/server/src/tools/move_note.ts
@@ -6,8 +6,8 @@ import type { ServerContext } from '../context.js';
 import { addNoteBacklinks, removeNoteBacklinks } from '../index/backlinks.js';
 import { buildDoc, upsertDoc } from '../index/doc.js';
 import { assertWritable, isWritable } from '../policy.js';
-import { hasMarkdownLinkTo, rewriteNoteLinks } from './rewrite_links.js';
 import { resolveVaultPath } from '../vault-path.js';
+import { hasMarkdownLinkTo, rewriteNoteLinks } from './rewrite_links.js';
 
 export const MoveNoteInput = z.object({
   from: z.string().describe('Vault-relative path of the note to move.'),

--- a/packages/server/src/tools/outline_note.ts
+++ b/packages/server/src/tools/outline_note.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { buildOutline } from '@seekstone/core/outline';
 import { z } from 'zod';
 import type { ServerContext } from '../context.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const OutlineNoteInput = z.object({
   path: z.string().describe('Vault-relative path to the note.'),
@@ -18,10 +19,7 @@ export const OutlineNoteInput = z.object({
 export type OutlineNoteInput = z.infer<typeof OutlineNoteInput>;
 
 export async function outlineNote(ctx: ServerContext, input: OutlineNoteInput) {
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
 
   const raw = await readFile(absPath, 'utf8');
   return buildOutline(raw, {

--- a/packages/server/src/tools/outline_note.ts
+++ b/packages/server/src/tools/outline_note.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { buildOutline } from '@seekstone/core/outline';
 import { z } from 'zod';
 import type { ServerContext } from '../context.js';

--- a/packages/server/src/tools/patch_frontmatter.ts
+++ b/packages/server/src/tools/patch_frontmatter.ts
@@ -7,6 +7,7 @@ import { atomicWrite } from '../atomic-write.js';
 import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { assertWritable } from '../policy.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const PatchFrontmatterInput = z.object({
   path: z.string().describe('Vault-relative path to the note.'),
@@ -49,10 +50,7 @@ export async function patchFrontmatter(
   ctx: ServerContext,
   input: PatchFrontmatterInput,
 ): Promise<PatchFrontmatterResult> {
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
   assertWritable(ctx.policy, input.path);
 
   const original = await readFile(absPath, 'utf8');

--- a/packages/server/src/tools/patch_frontmatter.ts
+++ b/packages/server/src/tools/patch_frontmatter.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { parseDocument } from 'yaml';
 import { z } from 'zod';

--- a/packages/server/src/tools/patch_note.ts
+++ b/packages/server/src/tools/patch_note.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { buildOutline } from '@seekstone/core/outline';
 import { z } from 'zod';

--- a/packages/server/src/tools/patch_note.ts
+++ b/packages/server/src/tools/patch_note.ts
@@ -7,6 +7,7 @@ import { atomicWrite } from '../atomic-write.js';
 import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { assertWritable } from '../policy.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const PatchNoteInput = z.object({
   path: z.string().describe('Vault-relative path to the note.'),
@@ -63,10 +64,7 @@ export async function patchNote(
   ctx: ServerContext,
   input: PatchNoteInput,
 ): Promise<PatchNoteResult> {
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
   assertWritable(ctx.policy, input.path);
 
   const raw = await readFile(absPath, 'utf8');

--- a/packages/server/src/tools/periodic_note.ts
+++ b/packages/server/src/tools/periodic_note.ts
@@ -7,6 +7,7 @@ import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { buildDoc, upsertDoc } from '../index/doc.js';
 import { assertWritable } from '../policy.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 // ── Period type ───────────────────────────────────────────────────────────────
 
@@ -163,9 +164,7 @@ export async function getPeriodicNote(
   const date = input.date ? new Date(input.date) : new Date();
   const cfg = await resolveConfig(ctx.vaultRoot, input.period);
   const path = resolveNotePath(cfg, date);
-  const abs = join(ctx.vaultRoot, path);
-
-  if (!abs.startsWith(ctx.vaultRoot)) throw new Error(`Path outside vault: ${path}`);
+  const abs = resolveVaultPath(ctx.vaultRoot, path);
 
   let existed = false;
   try {
@@ -184,15 +183,13 @@ export async function getPeriodicNote(
   // Read template if configured.
   let body = '';
   if (cfg.template) {
-    const templateAbs = join(
-      ctx.vaultRoot,
-      cfg.template.endsWith('.md') ? cfg.template : `${cfg.template}.md`,
-    );
-    if (templateAbs.startsWith(ctx.vaultRoot)) {
-      try {
-        body = await readFile(templateAbs, 'utf8');
-      } catch {}
-    }
+    try {
+      const templateAbs = resolveVaultPath(
+        ctx.vaultRoot,
+        cfg.template.endsWith('.md') ? cfg.template : `${cfg.template}.md`,
+      );
+      body = await readFile(templateAbs, 'utf8');
+    } catch {}
   }
 
   await mkdir(dirname(abs), { recursive: true });
@@ -239,9 +236,7 @@ export async function appendPeriodicNote(
   const date = input.date ? new Date(input.date) : new Date();
   const cfg = await resolveConfig(ctx.vaultRoot, input.period);
   const path = resolveNotePath(cfg, date);
-  const abs = join(ctx.vaultRoot, path);
-
-  if (!abs.startsWith(ctx.vaultRoot)) throw new Error(`Path outside vault: ${path}`);
+  const abs = resolveVaultPath(ctx.vaultRoot, path);
   assertWritable(ctx.policy, path);
 
   let original = '';

--- a/packages/server/src/tools/read_note.test.ts
+++ b/packages/server/src/tools/read_note.test.ts
@@ -67,6 +67,11 @@ describe('readNote — whole note', () => {
     await expect(readNote(ctx, { path: '../etc/passwd' })).rejects.toThrow('Path outside vault');
   });
 
+  it('throws "Path outside vault" for sibling-directory prefix escape', async () => {
+    const sibling = `../${vaultRoot.split('/').pop()}-backup/secret.md`;
+    await expect(readNote(ctx, { path: sibling })).rejects.toThrow('Path outside vault');
+  });
+
   it('throws ENOENT for a non-existent file', async () => {
     await expect(readNote(ctx, { path: 'does-not-exist.md' })).rejects.toThrow(/ENOENT/);
   });

--- a/packages/server/src/tools/read_note.test.ts
+++ b/packages/server/src/tools/read_note.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import MiniSearch from 'minisearch';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ServerContext } from '../context.js';
@@ -68,7 +68,7 @@ describe('readNote — whole note', () => {
   });
 
   it('throws "Path outside vault" for sibling-directory prefix escape', async () => {
-    const sibling = `../${vaultRoot.split('/').pop()}-backup/secret.md`;
+    const sibling = `../${basename(vaultRoot)}-backup/secret.md`;
     await expect(readNote(ctx, { path: sibling })).rejects.toThrow('Path outside vault');
   });
 

--- a/packages/server/src/tools/read_note.ts
+++ b/packages/server/src/tools/read_note.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { buildOutline } from '@seekstone/core/outline';
 import { z } from 'zod';

--- a/packages/server/src/tools/read_note.ts
+++ b/packages/server/src/tools/read_note.ts
@@ -5,6 +5,7 @@ import { buildOutline } from '@seekstone/core/outline';
 import { z } from 'zod';
 import { contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const ReadNoteInput = z
   .object({
@@ -55,10 +56,7 @@ export interface ReadNoteResult {
 }
 
 export async function readNote(ctx: ServerContext, input: ReadNoteInput): Promise<ReadNoteResult> {
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
 
   const raw = await readFile(absPath, 'utf8');
   const noteBytes = Buffer.byteLength(raw, 'utf8');

--- a/packages/server/src/tools/replace_in_note.ts
+++ b/packages/server/src/tools/replace_in_note.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { z } from 'zod';
 import { atomicWrite } from '../atomic-write.js';

--- a/packages/server/src/tools/replace_in_note.ts
+++ b/packages/server/src/tools/replace_in_note.ts
@@ -6,6 +6,7 @@ import { atomicWrite } from '../atomic-write.js';
 import { assertHashMatch, contentHash } from '../content-hash.js';
 import type { ServerContext } from '../context.js';
 import { assertWritable } from '../policy.js';
+import { resolveVaultPath } from '../vault-path.js';
 
 export const ReplaceInNoteInput = z.object({
   path: z.string().describe('Vault-relative path to the note.'),
@@ -69,10 +70,7 @@ export async function replaceInNote(
   ctx: ServerContext,
   input: ReplaceInNoteInput,
 ): Promise<ReplaceInNoteResult> {
-  const absPath = join(ctx.vaultRoot, input.path);
-  if (!absPath.startsWith(ctx.vaultRoot)) {
-    throw new Error(`Path outside vault: ${input.path}`);
-  }
+  const absPath = resolveVaultPath(ctx.vaultRoot, input.path);
   assertWritable(ctx.policy, input.path);
 
   // Validate regex before any IO.

--- a/packages/server/src/vault-path.test.ts
+++ b/packages/server/src/vault-path.test.ts
@@ -1,8 +1,10 @@
-import { sep } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { resolveVaultPath } from './vault-path.js';
 
-const ROOT = ['', 'home', 'u', 'vault'].join(sep);
+// resolve() gives the root a drive letter on Windows, so comparisons inside
+// resolveVaultPath (which resolves its inputs) stay consistent cross-platform.
+const ROOT = resolve(sep, 'home', 'u', 'vault');
 
 describe('resolveVaultPath', () => {
   it('resolves a plain relative path inside the vault', () => {
@@ -32,7 +34,7 @@ describe('resolveVaultPath', () => {
   });
 
   it('rejects an absolute path outside the vault', () => {
-    expect(() => resolveVaultPath(ROOT, ['', 'etc', 'passwd'].join(sep))).toThrow(
+    expect(() => resolveVaultPath(ROOT, resolve(sep, 'etc', 'passwd'))).toThrow(
       'Path outside vault',
     );
   });

--- a/packages/server/src/vault-path.test.ts
+++ b/packages/server/src/vault-path.test.ts
@@ -1,0 +1,44 @@
+import { sep } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveVaultPath } from './vault-path.js';
+
+const ROOT = ['', 'home', 'u', 'vault'].join(sep);
+
+describe('resolveVaultPath', () => {
+  it('resolves a plain relative path inside the vault', () => {
+    expect(resolveVaultPath(ROOT, 'notes/a.md')).toBe([ROOT, 'notes', 'a.md'].join(sep));
+  });
+
+  it('allows the vault root itself', () => {
+    expect(resolveVaultPath(ROOT, '.')).toBe(ROOT);
+  });
+
+  it('normalizes internal ../ that stays inside the vault', () => {
+    expect(resolveVaultPath(ROOT, 'notes/../a.md')).toBe([ROOT, 'a.md'].join(sep));
+  });
+
+  it('rejects a plain parent escape', () => {
+    expect(() => resolveVaultPath(ROOT, '../escape.md')).toThrow('Path outside vault');
+  });
+
+  it('rejects the sibling-directory prefix escape (the startsWith gap)', () => {
+    // /home/u/vault + ../vault-backup/secret.md → /home/u/vault-backup/secret.md,
+    // which passes a bare startsWith('/home/u/vault') check.
+    expect(() => resolveVaultPath(ROOT, '../vault-backup/secret.md')).toThrow('Path outside vault');
+  });
+
+  it('rejects a deep traversal that lands in a prefix-sibling', () => {
+    expect(() => resolveVaultPath(ROOT, 'a/b/../../../vault2/x.md')).toThrow('Path outside vault');
+  });
+
+  it('rejects an absolute path outside the vault', () => {
+    expect(() => resolveVaultPath(ROOT, ['', 'etc', 'passwd'].join(sep))).toThrow(
+      'Path outside vault',
+    );
+  });
+
+  it('accepts an absolute path inside the vault', () => {
+    const inside = [ROOT, 'notes', 'a.md'].join(sep);
+    expect(resolveVaultPath(ROOT, inside)).toBe(inside);
+  });
+});

--- a/packages/server/src/vault-path.ts
+++ b/packages/server/src/vault-path.ts
@@ -1,0 +1,21 @@
+import { resolve, sep } from 'node:path';
+
+/**
+ * Resolve a vault-relative path to an absolute path, guaranteeing the result
+ * stays inside the vault. This is the single containment guard for every tool
+ * handler — the previous inline `join(...).startsWith(vaultRoot)` checks had
+ * no separator boundary, so with a vault at `/home/u/vault` the input
+ * `../vault-backup/x.md` resolved to `/home/u/vault-backup/x.md` and passed.
+ *
+ * `resolve` (not `join`) also normalizes an absolute `input` instead of
+ * concatenating it, so absolute-path inputs are contained too.
+ *
+ * @throws Error `Path outside vault: <input>` when the resolved path escapes.
+ */
+export function resolveVaultPath(vaultRoot: string, inputPath: string): string {
+  const abs = resolve(vaultRoot, inputPath);
+  if (abs !== vaultRoot && !abs.startsWith(vaultRoot + sep)) {
+    throw new Error(`Path outside vault: ${inputPath}`);
+  }
+  return abs;
+}


### PR DESCRIPTION
Found during tonight's documentation audit: SECURITY.md and WRITE-SAFETY.md claim no tool can read or write outside `SEEKSTONE_VAULT`, but the guard enforcing it was a bare `startsWith` prefix check with no separator boundary.

**Escape (reproduced):** vault at `/home/u/vault`, input `../vault-backup/secret.md` → `join` yields `/home/u/vault-backup/secret.md`, which `startsWith('/home/u/vault')` accepts. Any sibling directory whose name extends the vault dirname was reachable, for reads and writes. Existing tests only covered the trivial `../escape.md` case, which the prefix check happens to catch.

**Fix:**
- New `src/vault-path.ts` — `resolveVaultPath(vaultRoot, path)`: `resolve`-based (also contains absolute-path inputs instead of concatenating them), rejects unless the result is the root itself or begins with `root + sep`.
- Replaces all **13** inline checks across the 12 tool handlers (periodic notes had two, plus its template read which previously used the same unbounded prefix test).
- `index.ts` normalizes `SEEKSTONE_VAULT` with `resolve()` at startup so a relative or trailing-slash root can't weaken the comparison.
- One guard means a future tool can't forget the check — same rationale as the shared `assertWritable` in the write policy.

**Tests:** new `vault-path.test.ts` (8 cases: sibling-prefix escape, deep traversal into a prefix-sibling, absolute in/out, internal `../` normalization, root itself); sibling-escape integration cases added to `create_note` and `read_note` suites. Full server suite: 419 passing.

Changeset: patch. Docs follow-up: the audit-sweep PR updates SECURITY.md/WRITE-SAFETY.md to reference the shared guard.