### PR TITLE
docs: full accuracy sweep + docs-sync CI guard

### DIFF
--- a/.changeset/docs-audit-sweep.md
+++ b/.changeset/docs-audit-sweep.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Documentation accuracy sweep: npm description now says 18 tools; `replace_in_note` is correctly documented as replacing all occurrences by default (literal/regex, whole-word, `limit`, dry-run); compare-and-swap docs name the six participating edit tools; `SEEKSTONE_LOG_MAX_SIZE` added to the configuration tables; SECURITY.md rewritten for recoverable deletes, the full 8-tool write surface, read-only mode, and write scoping; llms.txt and REGISTRIES.md updated to current benchmark claims. No code changes.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: seekstone version
       description: "Output of `npx seekstone --version` or the version in your config. Run the latest if you can."
-      placeholder: "0.1.0"
+      placeholder: "0.12.1"
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: node scripts/check-registries-tools.mjs
 
+      # Guard: docs must not drift from the code — tool counts across every doc
+      # surface, retired marketing claims (575× etc.), and the env-var tables
+      # are all checked against dispatch.ts / server source. Runs once (Linux).
+      - name: docs sync
+        if: matrix.os == 'ubuntu-latest'
+        run: node scripts/check-docs-sync.mjs
+
       # Coverage gate runs once (Linux) — thresholds live in the server's
       # vitest config and fail the build if logic coverage regresses.
       - name: Coverage gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,20 +38,22 @@ The **server** has a real build — `npm run build -w seekstone` bundles it (and
 
 `packages/harness/fixtures/vault/` is a **committed 10,000-note synthetic vault** generated from the public-domain 1911 Encyclopædia Britannica (Project Gutenberg). It's the canonical, reproducible, personal-data-free benchmark target — use it instead of a personal vault. The generator (`src/fixtures/`, deterministic, seed 42) + pinned corpus manifest are committed; the raw corpus text under `fixtures/corpus/raw/` is gitignored and re-fetched on demand. `src/fixtures/profile-fixture.test.ts` snapshots the vault's content-derived profile so the target can't silently drift. See `packages/harness/README.md`. Freshness stats are N/A for the fixture (mtime = checkout time).
 
-## Required env vars
+## Required env vars (harness)
 
 - `SEEKSTONE_VAULT` — absolute path to the Obsidian vault.
 - `SEEKSTONE_REST_API_KEY` — required when invoking the `rest` backend; from the Local REST API plugin settings tab.
 - `SEEKSTONE_REST_URL` — defaults to `https://127.0.0.1:27124`. The plugin ships a self-signed cert; the adapter accepts it via an isolated `undici.Agent`, never by setting `NODE_TLS_REJECT_UNAUTHORIZED`.
 
+The **server** reads its own set (`SEEKSTONE_VAULT`, `SEEKSTONE_READ_ONLY`, `SEEKSTONE_WRITE_PATHS`, `SEEKSTONE_LOG_LEVEL`, `SEEKSTONE_LOG_FILE`, `SEEKSTONE_LOG_MAX_SIZE`, `SEEKSTONE_WATCH_POLL`) — documented in the README's Configuration table. Write behavior to know before editing tools: deletes are recoverable (`.trash/`), edits support `prevHash` compare-and-swap, moves rewrite inbound links, and every write is policy-gated + atomic (see `docs/ARCHITECTURE.md` §2).
+
 ## Architecture
 
 For the full picture — package graph, the server's five layers, the end-to-end request flow, and the harness — see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) (Mermaid diagrams). Keep it in sync when you add a layer, tool, or adapter. The summary below covers the harness specifically.
 
-The harness is three modules behind one CLI, all sharing the same `Backend` abstraction so the eventual filesystem-direct server slots in without rewriting consumers.
+The harness is three modules behind one CLI, all sharing the same `Backend` abstraction the shipped filesystem-direct server plugs into (the in-process `seekstone` adapter).
 
 ### Backend interface (`packages/harness/src/bench/backend.ts`)
-One small contract: `search`, `read`, `write`, `list`. Every adapter returns `{ result, payloadBytes }` so payload size — the headline metric — is captured at the boundary. The MCP server is being designed to expose exactly this surface, which is why it's tiny on purpose.
+A small required core — `search`, `read`, `write`, `list` — plus optional extended tool methods (`listTags`, `contextPack`, `outline`, `getBacklinks`, `getLinks`, `getPeriodicNote`) and optional write-safety methods (`deleteNote`, `createNote`, `readWithHash`, `casWrite`) that drive the behavioral safety ops. Every adapter returns `{ result, payloadBytes }` so payload size — the headline metric — is captured at the boundary. The shipped server exposes this surface (18 tools; the `seekstone` adapter calls its tool functions in-process).
 
 ### Profiler (`packages/harness/src/profiler/`)
 Walks the vault with `fast-glob`, classifies each file (`note` / `image` / `pdf` / `excalidraw` / `canvas` / …), reads each note, and aggregates. Two things are subtle and worth knowing before editing:
@@ -73,7 +75,7 @@ Three guard rails, in this order, and they all matter:
 2. **`runSafety`** re-asserts copy ≠ original before doing anything.
 3. The **REST adapter writes to whatever vault Obsidian is open on** — so the workflow is two-phase: first invocation copies the vault and prints the path; you point Obsidian at the copy; second invocation runs with `--copy-vault-root`.
 
-Three ops per sampled note: `identity` (byte equality), `body-append` (FM untouched, body == original + marker), `fm-edit` (body untouched, existing FM key order preserved). `fm-edit` uses `yaml.parseDocument` because that's the only way to preserve comments / quote style / key order — anything that route-trips through `parseYaml` + `stringify` will fail the test, by design.
+Eight ops per sampled backend — five byte-faithful: `identity` (byte equality), `body-append` (FM untouched, body == original + marker), `fm-edit` (body untouched, existing FM key order preserved), `patch-note`, `replace-in-note`; and three behavioral (`safety/behavioral-ops.ts`): `recoverable-delete` (lands in `.trash/`, byte-identical), `create-no-clobber`, `cas-conflict` (stale `prevHash` must be refused). `fm-edit` uses `yaml.parseDocument` because that's the only way to preserve comments / quote style / key order — anything that round-trips through `parseYaml` + `stringify` will fail the test, by design.
 
 ## Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,11 @@ npx vitest run packages/server/src/tools/search.test.ts
 npx vitest run -t 'parses a typical frontmatter'
 ```
 
-Before opening a PR, make sure **`npm test`, `npm run lint`, and the typechecks all pass** — CI runs them on macOS, Linux, and Windows and will block a merge otherwise.
+Before opening a PR, make sure **`npm test`, `npm run lint`, and the typechecks all pass** — CI runs them on macOS, Linux, and Windows and will block a merge otherwise. The Linux leg additionally blocks on: protocol conformance (`npm run conformance`), the write-safety baseline (`node scripts/check-safety-baseline.mjs`), per-package coverage gates (server, harness, and core thresholds), `server.json` and docs-sync guards, and a **changeset check** — a PR touching `packages/server/src/` or `package.json` without a changeset fails CI (`npx changeset` to add one).
 
 ## Conventions
 
-- **Tests ship with the change.** Add or update co-located `*.test.ts` files for any code you touch. We aim to keep the server's logic modules well covered (CI enforces a coverage threshold).
+- **Tests ship with the change.** Add or update co-located `*.test.ts` files for any code you touch. We aim to keep the logic modules well covered (CI enforces coverage thresholds for the server, harness, and core packages).
 - **Formatting is biome.** Run `npm run format` before committing and **stage all the files it changes**, not just the ones you edited.
 - **Line endings are LF** (enforced via `.gitattributes`).
 - **Imports use `.js` extensions** even for TypeScript sources — that's what NodeNext + tsx + tsc agree on.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@
 
 It reads your vault **directly from disk** rather than routing through the Obsidian Local REST API plugin, and holds a warm full-text index in-process. The practical difference is twofold:
 
-- **Speed.** Searches return in **single-digit milliseconds** warm — up to **~250× faster** than every other Obsidian MCP server we benchmarked, because there's no subprocess to spawn and no HTTP round-trip per query.
+- **Speed.** Searches return in **single-digit milliseconds** warm — up to **~440× faster** than every other Obsidian MCP server we benchmarked, because there's no subprocess to spawn and no HTTP round-trip per query.
 - **Context.** A broad search that returns **tens of megabytes** and millions of tokens via a REST-proxy server returns **~2 KB** via Seekstone — up to a **~47,000× reduction** that only widens as your vault grows.
 
-Search comes in two modes: ranked **full-text search** (fuzzy, prefix, phrase), and **structured metadata queries** — `query_notes` filters by frontmatter properties (`status`, `due`, `type`, …), tags, folder, modified time, and size, answering questions like *"which draft notes changed this week?"* in a few hundred bytes instead of a search-and-read loop.
+Search comes in two modes: ranked **full-text search** (fuzzy and prefix matching), and **structured metadata queries** — `query_notes` filters by frontmatter properties (`status`, `due`, `type`, …), tags, folder, modified time, and size, answering questions like *"which draft notes changed this week?"* in a few hundred bytes instead of a search-and-read loop.
 
 Claude can search and read your entire note library, in milliseconds, without burning most of its context window on a single tool call.
 
@@ -291,7 +291,7 @@ Claude never sees your full vault at once — it searches and reads selectively,
 
 | Tool | Description |
 |---|---|
-| `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy, prefix, and phrase queries. |
+| `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy and prefix matching. |
 | `query_notes` | Structured metadata query. Filter by frontmatter key/value predicates (`eq`, `ne`, `contains`, `exists`, `missing`, `gt`/`gte`/`lt`/`lte`), tag, folder, modified time, and size; sort and select the fields you need. Returns compact rows (path + title by default), not note content. |
 | `context_pack` | Answer-ready context for a natural-language question in one call, hard-capped at a byte budget (default 2 KB): ranked excerpts, linked neighbor notes with one-line summaries, and follow-up source paths — replaces a search → read → get_backlinks round-trip loop. |
 | `read_note` | Read the full content of a note by vault-relative path. Supports returning a single section, block, or line range. |
@@ -312,10 +312,10 @@ Claude never sees your full vault at once — it searches and reads selectively,
 | `append_note` | Append text to a note body without touching frontmatter. |
 | `patch_frontmatter` | Set, update, or delete frontmatter keys without reordering existing keys or changing quote style. |
 | `patch_note` | Insert text immediately after a heading without touching frontmatter. |
-| `replace_in_note` | Replace the first occurrence of a word or phrase in the note body. |
+| `replace_in_note` | Find and replace text in the note body — literal or regex, case sensitivity, whole-word matching, optional `limit` (replaces **all** occurrences by default), and a dry-run preview. |
 | `append_periodic_note` | Append to today's periodic note, creating it from a template if it doesn't yet exist. |
 
-Every edit tool supports optional **compare-and-swap**: pass the `contentHash` you got from `read_note` as `prevHash` and the write fails cleanly if the note changed underneath you, instead of silently discarding the concurrent edit.
+The content-editing tools (`append_note`, `patch_note`, `patch_frontmatter`, `replace_in_note`, `append_periodic_note`, and `create_note` with `overwrite: true`) support optional **compare-and-swap**: pass the `contentHash` you got from `read_note` as `prevHash` and the write fails cleanly if the note changed underneath you, instead of silently discarding the concurrent edit.
 
 **Fast *and* complete.** Seekstone is the only Obsidian MCP server in our benchmark set to implement `list_tags`, `outline_note`, `get_backlinks`, and `get_links` — every other tested server supports only search, read, list, and write. Three more capabilities set it apart:
 
@@ -332,6 +332,7 @@ Every edit tool supports optional **compare-and-swap**: pass the `contentHash` y
 | `SEEKSTONE_VAULT` | Yes | Absolute path to your Obsidian vault. |
 | `SEEKSTONE_LOG_LEVEL` | No | `error` \| `warn` \| `info` (default) \| `debug`. |
 | `SEEKSTONE_LOG_FILE` | No | Absolute path; when set, JSON-line logs are appended here (size-rotated). |
+| `SEEKSTONE_LOG_MAX_SIZE` | No | Log-rotation threshold for `SEEKSTONE_LOG_FILE` (e.g. `10mb`; default 5 MB). |
 | `SEEKSTONE_WATCH_POLL` | No | Set to `1` to stat-poll for changes instead of native OS events — slower but reliable on network drives, WSL, and some containers. |
 | `SEEKSTONE_READ_ONLY` | No | Set to `1` to run read-only: the 8 write tools are unregistered from the tool list entirely (and rejected if called anyway), so the session provably cannot modify your vault. |
 | `SEEKSTONE_WRITE_PATHS` | No | Comma-separated vault-relative globs (e.g. `journal/**,inbox/*.md`). Writes are permitted only under matching paths; the rest of the vault stays read-only. |
@@ -416,7 +417,7 @@ The server has a real build (tsup → `dist/`) and is published to npm. The harn
 
 ### The measurement harness
 
-The harness exists to reproduce the benchmark numbers that motivated the filesystem-direct design. It needs the Local REST API plugin for the `rest` backend.
+The harness exists to reproduce the benchmark numbers that motivated the filesystem-direct design. The default reproduction path (`fs`/`seekstone` backends against the committed synthetic vault) needs nothing extra; only the REST-backed backends (`rest`, `mcp-obsidian`, `obsidian-mcp-server`) need Obsidian running with the Local REST API plugin.
 
 ```bash
 export SEEKSTONE_VAULT="/absolute/path/to/your/vault"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,12 +16,14 @@ Please include the version, your environment (OS, Node version), and steps to re
 
 Seekstone is designed to be conservative with your data. The published server:
 
-- **Reads and writes only under `SEEKSTONE_VAULT`.** It does not touch files outside the vault directory you configure (the one optional exception is a log file, only if you set `SEEKSTONE_LOG_FILE`).
+- **Reads and writes only under `SEEKSTONE_VAULT`.** Every tool handler resolves its path through a shared containment guard with a proper directory-boundary check. It does not touch files outside the vault directory you configure (the one optional exception: if you set `SEEKSTONE_LOG_FILE`, the log file and its single size-rotation sibling `<file>.1` are written at that path).
 - **Makes no outbound network connections and collects no telemetry.** Indexing and search run entirely on your machine.
-- **Only modifies your vault through explicit tool calls** (`create_note`, `delete_note`, `move_note`, `append_note`, `patch_frontmatter`). It never makes background edits.
+- **Only modifies your vault through explicit tool calls** — the 8 write tools: `create_note`, `delete_note`, `move_note`, `append_note`, `patch_note`, `patch_frontmatter`, `replace_in_note`, `append_periodic_note`. One read tool has a documented write side effect: `get_periodic_note` creates the periodic note when `createIfMissing` is set (neutralized in read-only mode). It never makes background edits.
+- **Can be locked down further.** `SEEKSTONE_READ_ONLY=1` runs the server read-only — the 8 write tools are removed from the advertised tool list entirely and rejected at dispatch if called anyway. `SEEKSTONE_WRITE_PATHS` (comma-separated vault-relative globs, e.g. `journal/**,inbox/*.md`) restricts writes to matching paths while the rest of the vault stays read-only. Both are enforced at the dispatch layer plus a shared per-handler check, so a new tool cannot forget them.
+- **Guards against lost updates.** Every read returns a `contentHash`; edit tools accept an optional `prevHash` and fail with a structured `hash_conflict` error instead of silently overwriting a concurrent change (compare-and-swap).
 - **Preserves file fidelity on writes.** Frontmatter edits keep key order, quote style, and comments; body appends leave the frontmatter region byte-identical. Writes are atomic (write-to-temp then rename).
 
-`delete_note` permanently removes a file and cannot be undone — treat it accordingly.
+`delete_note` moves the note to the vault's `.trash/` folder by default (Obsidian-compatible — restore by moving it back). Pass `permanent: true` for an unrecoverable delete. The full, tested write-safety guarantees are documented in [docs/WRITE-SAFETY.md](docs/WRITE-SAFETY.md).
 
 ## Logs and privacy
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,7 @@ flowchart TD
   never published**, so the server's build inlines it (see below).
 - **`seekstone`** (`packages/server`) — the product. The only runtime npm
   dependencies are `@modelcontextprotocol/sdk`, `chokidar`, `fast-glob`,
-  `minisearch`, `yaml`, and `zod`. `tsup` bundles `src/index.ts` **plus the
+  `minisearch`, `picomatch`, `yaml`, and `zod`. `tsup` bundles `src/index.ts` **plus the
   `@seekstone/core` workspace package** into a single self-contained
   `dist/index.js` (ESM, `#!/usr/bin/env node` shebang); the npm deps stay
   external and install normally. This is why `@seekstone/core` is a *devDep*
@@ -65,25 +65,29 @@ flowchart TD
         init["init.ts<br/>setup wizard"]
         guards["process-guards.ts"]
         log["log.ts<br/>structured logger"]
+        pol["policy.ts<br/>parseWritePolicy: SEEKSTONE_READ_ONLY<br/>SEEKSTONE_WRITE_PATHS globs"]
+        tl["tool-list.ts<br/>ALL_TOOLS schemas · visibleTools(policy)"]
     end
 
     subgraph idx["② Index layer — index/"]
         build["build.ts<br/>buildIndex(vaultRoot)"]
-        doc["doc.ts · excerpt.ts<br/>resolve.ts · types.ts"]
+        doc["doc.ts · excerpt.ts · resolve.ts<br/>backlinks.ts · types.ts"]
     end
 
-    ctx["③ ServerContext (context.ts)<br/>vaultRoot · index (MiniSearch)<br/>notes Map · backlinks Map"]
+    ctx["③ ServerContext (context.ts)<br/>vaultRoot · index (MiniSearch)<br/>notes Map · backlinks Map · policy"]
 
     watch["④ Watcher — watcher.ts<br/>chokidar → incremental re-index"]
 
     subgraph disp["⑤ Dispatch — dispatch.ts"]
-        dispatcher["dispatch(): timing · logging · errors<br/>HANDLED_TOOLS (16) → run() switch"]
+        dispatcher["dispatch(): timing · logging · errors<br/>read-only / write-policy gate (WRITE_TOOLS)<br/>HANDLED_TOOLS (18) → run() switch"]
     end
 
-    subgraph tools["Tools layer — tools/ (16)"]
-        reads["READ-ONLY<br/>search · read_note · list_notes<br/>list_tags · outline_note<br/>get_backlinks · get_links · get_periodic_note"]
+    subgraph tools["Tools layer — tools/ (18)"]
+        reads["READ-ONLY<br/>search · query_notes · context_pack<br/>read_note · list_notes · list_tags<br/>outline_note · get_backlinks · get_links<br/>get_periodic_note"]
         writes["WRITES (filesystem-direct)<br/>create_note · delete_note · move_note<br/>append_note · patch_note · patch_frontmatter<br/>replace_in_note · append_periodic_note"]
     end
+
+    prims["Write primitives (shared by every write tool)<br/>vault-path.ts resolveVaultPath · policy.ts assertWritable<br/>atomic-write.ts (temp-file+rename) · content-hash.ts (CAS)<br/>tools/rewrite_links.ts (link-aware moves)"]
 
     vault[("Obsidian vault<br/>(filesystem)")]
     core2["@seekstone/core<br/>frontmatter · extract · outline · walk"]
@@ -97,7 +101,8 @@ flowchart TD
     dispatcher --> reads
     dispatcher --> writes
     reads --> ctx
-    writes --> vault
+    writes --> prims
+    prims --> vault
     writes -. uses .-> core2
     reads -. read body .-> vault
     build -. walk .-> vault
@@ -108,31 +113,43 @@ flowchart TD
 
 1. **Bootstrap (`index.ts`)** — the executable entry. Handles `version` / `help`
    / `init` CLI intents (which print and exit before any server starts), then
-   for an MCP session: requires `SEEKSTONE_VAULT`, installs process guards
-   (a stray unhandled rejection must not kill a long-lived stdio session),
-   builds the index, constructs the `ServerContext`, starts the watcher, and
-   wires the `@modelcontextprotocol/sdk` `Server` to a `StdioServerTransport`
-   with `ListTools` + `CallTool` handlers.
+   for an MCP session: requires `SEEKSTONE_VAULT`, parses the write policy
+   (`policy.ts` — `SEEKSTONE_READ_ONLY`, `SEEKSTONE_WRITE_PATHS`), installs
+   process guards (a stray unhandled rejection must not kill a long-lived stdio
+   session), builds the index, constructs the `ServerContext`, starts the
+   watcher, and wires the `@modelcontextprotocol/sdk` `Server` to a
+   `StdioServerTransport` with `ListTools` + `CallTool` handlers. `ListTools`
+   answers from `tool-list.ts` (`visibleTools(policy)` — in read-only mode the
+   8 write tools are unregistered entirely, not just rejected).
 2. **Index layer (`index/`)** — `buildIndex(vaultRoot)` walks the vault, parses
    each note, and returns a `MiniSearch` full-text index, a `notes` map
    (path → `IndexedNote`), and a `backlinks` reverse-link map. This is the
    in-memory model every read tool queries.
 3. **`ServerContext` (`context.ts`)** — the single shared state bag:
-   `{ vaultRoot, index, notes, backlinks }`. No globals; it's threaded into every
-   tool call.
+   `{ vaultRoot, index, notes, backlinks, policy }`. No globals; it's threaded
+   into every tool call.
 4. **Watcher (`watcher.ts`)** — chokidar watches the vault and incrementally
    updates `index` / `notes` / `backlinks` so the in-memory model never goes
    stale during a session.
 5. **Dispatch (`dispatch.ts`)** — the routing seam. `dispatch()` wraps the
    per-tool `run()` switch with `performance.now()` timing, structured logging
    (content/query args are debug-only — never logged at info), payload-byte
-   measurement, and uniform error-to-`isError` handling. `HANDLED_TOOLS` is the
-   16-name source of truth, kept in sync with the `ListTools` schema.
+   measurement, and uniform error-to-`isError` handling. It is also the write
+   **policy enforcement seam**: calls to any of the 8 `WRITE_TOOLS` are rejected
+   in read-only mode, and `get_periodic_note`'s `createIfMissing` side effect is
+   neutralized there too. `HANDLED_TOOLS` is the 18-name source of truth, kept
+   in sync with the `ListTools` schemas in `tool-list.ts`.
 
 The **tools** themselves are thin: read tools answer from `ServerContext`
 (and read note bodies straight off disk when needed); write tools mutate the
-vault filesystem directly, using `@seekstone/core` to preserve frontmatter
-byte-for-byte.
+vault filesystem through a shared set of write primitives — path containment
+(`vault-path.ts`), a second per-handler `assertWritable` policy check
+(`policy.ts`), optional compare-and-swap via `prevHash` (`content-hash.ts`),
+and a crash-safe temp-file+rename write (`atomic-write.ts`) — using
+`@seekstone/core` to preserve frontmatter byte-for-byte. `delete_note` moves
+notes to the vault's `.trash/` folder rather than unlinking (unless
+`permanent: true`), and `move_note` rewrites inbound links via
+`tools/rewrite_links.ts`.
 
 ---
 
@@ -158,7 +175,9 @@ sequenceDiagram
         T->>Ctx: query index / notes / backlinks
         T-->>FS: read note body (only if needed)
     else write tool (append_note, patch_note, …)
-        T->>FS: write bytes directly (frontmatter preserved)
+        D->>D: policy gate (read-only → reject)
+        T->>T: resolveVaultPath · assertWritable<br/>prevHash CAS check (if given)
+        T->>FS: atomic temp-file + rename<br/>(frontmatter preserved)
     end
     T-->>D: ToolResult { content }
     D->>D: log tool ok { durationMs, resultBytes }
@@ -166,10 +185,10 @@ sequenceDiagram
     SDK-->>Client: CallToolResult
 ```
 
-`ListToolsRequest` is answered directly from the bootstrap's static schema list
-(the 18 tools). On error, `dispatch()` catches and returns
-`{ isError: true, content: [...] }` rather than throwing — the session stays
-alive.
+`ListToolsRequest` is answered from `tool-list.ts` (`visibleTools(ctx.policy)`)
+— all 18 tools normally, only the 10 read tools in read-only mode. On error,
+`dispatch()` catches and returns `{ isError: true, content: [...] }` rather
+than throwing — the session stays alive.
 
 ---
 
@@ -185,7 +204,7 @@ the boundary** as the headline "context tax" metric.
 flowchart TD
     cli["CLI — cli.ts (cac)<br/>profile · bench · scenarios · safety · compare<br/>scenarios-compare · scale-render · gen-vault · fetch-corpus"]
 
-    backend["Backend contract — bench/backend.ts<br/>search · read · write · list (+ optional tools)<br/>every method → BackendResponse{ result, payloadBytes }"]
+    backend["Backend contract — bench/backend.ts<br/>search · read · write · list<br/>+ optional tool methods (incl. contextPack)<br/>+ optional write-safety ops (delete/create/CAS)<br/>every method → BackendResponse{ result, payloadBytes }"]
 
     subgraph inproc["In-process adapters"]
         fs["fs<br/>standalone MiniSearch"]
@@ -197,9 +216,9 @@ flowchart TD
     end
 
     subgraph modules["Three measurement modules"]
-        profiler["profiler/<br/>walk · classify · aggregate → VaultStats"]
+        profiler["profiler/<br/>walk · aggregate → VaultStats"]
         bench["bench/<br/>runN cold/warm → BenchmarkSummary<br/>scenarios (tokens-per-task) → ScenarioSummary<br/>report · compare · scaling · timer"]
-        safety["safety/<br/>copyVault → runSafety ops → SafetySummary<br/>identity · body-append · fm-edit · patch · replace"]
+        safety["safety/<br/>copyVault → runSafety ops → SafetySummary<br/>byte ops: identity · body-append · fm-edit<br/>patch-note · replace-in-note<br/>behavioral ops: recoverable-delete<br/>create-no-clobber · cas-conflict"]
     end
 
     fixtures["fixtures/<br/>EB1911 corpus → 10k-note synthetic vault<br/>generate · prng · tags · parse-volume · corpus"]
@@ -220,10 +239,12 @@ flowchart TD
     seek -. imports .-> bench
 ```
 
-- **`Backend` contract** (`bench/backend.ts`) — intentionally tiny:
+- **`Backend` contract** (`bench/backend.ts`) — a tiny required core:
   `search`, `read`, `write`, `list`, plus optional extended tools
-  (`listTags`, `outline`, `getBacklinks`, `getLinks`, `getPeriodicNote`,
-  `searchStream`, `close`). Every call returns
+  (`listTags`, `contextPack`, `outline`, `getBacklinks`, `getLinks`,
+  `getPeriodicNote`, `searchStream`, `close`) and optional write-safety
+  methods (`deleteNote`, `createNote`, `readWithHash`, `casWrite`) that drive
+  the behavioral safety matrix. Every call returns
   `BackendResponse<T> = { result, payloadBytes, payloadText? }`, so the raw
   bytes a backend served are recorded at the boundary.
 - **Adapters** split into **in-process** (`fs`, `seekstone` — zero IPC, the most
@@ -235,8 +256,10 @@ flowchart TD
   **warm** (runs 2..N) so a cheap warm number can't hide a brutal cold start,
   and renders per-adapter + cross-adapter (`compare`) + multi-scale (`scaling`)
   reports.
-- **safety** copies the vault to a scratch dir and round-trips write ops,
-  proving frontmatter stays byte-identical.
+- **safety** copies the vault to a scratch dir and runs eight op kinds: five
+  byte-faithful round-trips (proving frontmatter stays byte-identical) plus
+  three behavioral ops proving recoverable deletes, no-clobber creates, and
+  compare-and-swap conflict detection.
 - **fixtures** generate the committed, personal-data-free 10k-note synthetic
   vault from the public-domain 1911 Encyclopædia Britannica (deterministic,
   seed 42 — hence the custom `prng`, since `Math.random()` is banned harness-wide).
@@ -257,7 +280,7 @@ flowchart LR
         direction TB
         s1["in-process MCP server"]
         s2["in-memory index (MiniSearch)<br/>+ direct file reads"]
-        s3["slim payload<br/>~200-char ranked excerpts,<br/>not whole notes"]
+        s3["slim payload<br/>~120-char ranked excerpts,<br/>not whole notes"]
         s1 --> s2 --> s3
     end
 
@@ -298,7 +321,7 @@ are the receipts.
 
 | Tool | Kind | Purpose |
 | --- | --- | --- |
-| `search` | read | Ranked full-text search; returns ~200-char excerpts, not full notes |
+| `search` | read | Ranked full-text search; returns ~120-char excerpts (tunable), not full notes |
 | `query_notes` | read | Structured metadata query: frontmatter predicates + mtime/size/tag/folder filters; compact rows, no note content |
 | `context_pack` | read | Byte-budgeted context pack for a question: ranked excerpts + link-neighborhood summaries + follow-up sources in one call |
 | `read_note` | read | Read a note (with optional outline/frontmatter metadata) |
@@ -309,8 +332,8 @@ are the receipts.
 | `get_links` | read | Outgoing wikilinks/embeds of a note |
 | `get_periodic_note` | read | Resolve today's / a given date's periodic note |
 | `create_note` | write | Create a new note |
-| `delete_note` | write | Delete a note |
-| `move_note` | write | Move/rename a note |
+| `delete_note` | write | Move a note to `.trash/` (recoverable); `permanent: true` unlinks |
+| `move_note` | write | Move/rename a note, rewriting inbound links in other notes |
 | `append_note` | write | Append to a note body |
 | `patch_note` | write | Targeted body edit by heading/block |
 | `patch_frontmatter` | write | Edit frontmatter, preserving key order/comments |
@@ -318,5 +341,6 @@ are the receipts.
 | `append_periodic_note` | write | Append to today's / a given date's periodic note |
 
 The list is mirrored in `dispatch.ts` (`HANDLED_TOOLS`) and the `ListTools`
-schema in `index.ts`; `docs/REGISTRIES.md` carries the same count and a CI guard
-keeps them in sync.
+schemas in `tool-list.ts`; `docs/REGISTRIES.md` carries the same count and CI
+guards (`check-registries-tools.mjs`, `check-docs-sync.mjs`) keep the counts in
+sync across docs.

--- a/docs/CLIENT-TESTING.md
+++ b/docs/CLIENT-TESTING.md
@@ -8,6 +8,7 @@ How Seekstone backs the claim "works with any MCP client" (positioning decision 
 |---|---|---|
 | Protocol conformance | `npm run conformance` — boots the built server over stdio with the MCP SDK reference client; asserts the initialize handshake, the exact `HANDLED_TOOLS` surface, and a `search` + `append_note` round-trip against a scratch vault | Every CI run (Linux leg) and as a release gate |
 | Config writers | Unit tests per `seekstone init --client <name>` target (`packages/server/src/init.test.ts`) — exact file format and path per client | Every `npm test` |
+| Write-safety baseline | `node scripts/check-safety-baseline.mjs` — re-runs the harness safety suite and diffs against the committed golden report, gating client-visible write behavior | Every CI run (Linux leg) and as a release gate |
 | Real-client E2E | `scripts/claude-code-e2e.sh` — packs the current build, attaches it to headless Claude Code via `--mcp-config`, and asserts a model-driven `search` retrieves seeded vault content | Manual, before releases that change tool schemas |
 | GUI client checklist | The table below | Manual, when tool schemas or install docs change |
 
@@ -27,7 +28,7 @@ Record each pass here (newest first):
 |---|---|---|---|---|
 | _(add rows as runs happen)_ | | | | |
 
-Clients to cover as their install docs ship (SHA-61 children): Claude Desktop, Claude Code (scripted — see above), Cursor (SHA-230), VS Code / Copilot (SHA-62), JetBrains AI Assistant (SHA-67), Windsurf.
+Shipped first-class `init --client` targets: **Claude Desktop, Claude Code (scripted — see above), Cursor, VS Code / Copilot** (`init.ts` — `desktop | code | cursor | vscode`, each with one-click install paths in the README). Still uncovered: JetBrains AI Assistant (SHA-67), Windsurf (generic manual-config block only).
 
 ## Non-clients
 

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -12,7 +12,7 @@ Seekstone is published as [`seekstone`](https://www.npmjs.com/package/seekstone)
 
 - **Name:** Seekstone
 - **Tagline:** An Obsidian MCP server — filesystem-direct, low context-tax.
-- **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (~575× smaller payloads in benchmarks). 18 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
+- **Description:** Seekstone reads your Obsidian vault directly from disk instead of routing through the Local REST API plugin, so Claude can search and edit notes without burning its context window on a single tool call (up to ~47,000× smaller payloads in reproducible multi-vault benchmarks). 18 tools over stdio; no Obsidian app or plugin required; macOS/Linux/Windows; no network, no telemetry.
 - **Install:** `npx -y seekstone`; env `SEEKSTONE_VAULT=/path/to/vault`
 - **Repo:** https://github.com/shaqmughal/seekstone
 - **npm:** https://www.npmjs.com/package/seekstone
@@ -23,14 +23,14 @@ Seekstone is published as [`seekstone`](https://www.npmjs.com/package/seekstone)
 
 ## 1. Official MCP registry
 
-`server.json` lists the `seekstone` npm package. After each release, re-publish to update the version:
+`server.json` lists the `seekstone` npm package. **Publishing is automated:** `release.yml` installs `mcp-publisher`, authenticates with `login github-oidc`, and re-publishes on every npm release; the version is synced by `scripts/sync-server-json.mjs` (run by `version-packages` and CI-guarded). The manual flow below is a fallback only:
 
 ```bash
 # Install the publisher CLI (macOS/Linux):
 curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
 # (or: brew install mcp-publisher)
 
-mcp-publisher login github   # device-code auth (one-time per session)
+mcp-publisher login github   # device-code auth (manual fallback; CI uses `login github-oidc`)
 mcp-publisher publish        # reads server.json, validates against mcpName in published package
 ```
 
@@ -62,6 +62,6 @@ The entry originally used `obsidian-mcp-seekstone`; that name is now deprecated 
 
 ## Keeping listings current
 
-- **Official registry:** bump the version in `server.json` and re-run `mcp-publisher publish` after each release. The `version` field should always match the current `seekstone` npm version.
+- **Official registry:** automated — `release.yml` re-publishes on every release, and `sync-server-json.mjs` keeps the `server.json` version matching npm (guarded in CI). No manual action needed.
 - **Glama:** tracks the repo automatically — no action needed on release.
 - **awesome-mcp-servers:** static PR; only needs updating if the description or install command changes.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,9 +18,9 @@ Re-running a release for an already-published version is a no-op, so the workflo
 
 ## Gates (must pass before publish)
 
-The `Release` workflow runs typecheck → `npm test` → `npm run lint` → **`npm run smoke`** → **`npm run conformance`** before the publish step. `smoke` packs the tarball, installs it into a throwaway project, and boots the `seekstone` bin to confirm `npx seekstone` works for a real user. `conformance` drives the built server with the MCP SDK reference client — handshake, exact tool surface, and a search + append round-trip — so a protocol regression can't ship (see `docs/CLIENT-TESTING.md`). A failure at any gate blocks the publish.
+The `Release` workflow runs typecheck → `npm test` → `npm run lint` → **`npm run smoke`** → **`npm run conformance`** → **write-safety baseline** (`node scripts/check-safety-baseline.mjs`, which re-runs the harness safety suite against the committed golden report — a write-behavior regression blocks the publish) before the publish step. `smoke` packs the tarball, installs it into a throwaway project, and boots the `seekstone` bin to confirm `npx seekstone` works for a real user. `conformance` drives the built server with the MCP SDK reference client — handshake, exact tool surface, and a search + append round-trip — so a protocol regression can't ship (see `docs/CLIENT-TESTING.md`). A failure at any gate blocks the publish.
 
-CI (the `CI` workflow) additionally enforces a **coverage gate** on the server's logic modules (thresholds in `packages/server/vitest.config.ts`).
+CI (the `CI` workflow) additionally enforces, on the Linux leg: **three coverage gates** (server, harness, and core — thresholds in each package's `vitest.config.ts`), the same write-safety baseline, protocol conformance, `server.json` version sync (`sync-server-json.mjs --check`), the `docs/REGISTRIES.md` tool-list guard (`check-registries-tools.mjs`), the docs-sync guard (`check-docs-sync.mjs`), and a **changeset check** that fails any PR touching `packages/server/src/` or `package.json` without a changeset.
 
 **Manual gate for tool-schema changes:** `scripts/claude-code-e2e.sh` runs a real headless Claude Code session against the packed tarball and asserts a model-driven `search` retrieves seeded vault content. Run it before releases that change tool names or input schemas (needs an authenticated `claude` CLI; spends a few tokens).
 
@@ -40,6 +40,7 @@ The default `GITHUB_TOKEN` can't be used to open the "Version Packages" PR: push
 4. Add two repo secrets (Settings → Secrets and variables → Actions):
    - `APP_ID` — the App's numeric ID (shown at the top of the App's settings page).
    - `APP_PRIVATE_KEY` — the full contents of the downloaded `.pem`, including the `-----BEGIN/END-----` lines.
+   - `VERCEL_DEPLOY_HOOK_URL` (optional) — when set, a successful publish triggers a seekstone.dev rebuild so the site's displayed version stays current.
 
 Once both secrets exist, releases are hands-off. If the App is ever uninstalled or the secrets are removed, the `Mint release-bot token` step fails fast at the top of the job.
 
@@ -53,6 +54,10 @@ The workflow publishes via **OIDC trusted publishing**: no npm token is stored, 
 
 Once configured, the publish step authenticates automatically — there is no `NODE_AUTH_TOKEN`. The old `NPM_TOKEN` secret is no longer used (deleted 2026-06-27).
 
+## Post-publish: automated pipeline
+
+On a successful publish (`published == 'true'`), `release.yml` also runs, in order: builds the **MCPB bundle** (`seekstone.mcpb`), generates a **SLSA build-provenance attestation** for it, uploads both to the **GitHub Release** (`seekstone.mcpb` + `seekstone.mcpb.intoto.jsonl`), re-publishes to the **official MCP Registry** (`mcp-publisher login github-oidc && mcp-publisher publish`), and fires the **seekstone.dev Vercel rebuild hook** (if `VERCEL_DEPLOY_HOOK_URL` is set). None of these need manual action.
+
 ## Post-publish: Glama (manual)
 
 After every npm publish you need to create a new release on the Glama listing manually:
@@ -61,7 +66,7 @@ After every npm publish you need to create a new release on the Glama listing ma
 2. Click **"Create Release"** (or the equivalent button in the admin UI).
 3. Verify the new version appears on <https://glama.ai/mcp/servers/shaqmughal/seekstone>.
 
-**Why this isn't automated yet:** Glama has no public REST API or documented webhook for programmatic release creation (investigated in SHA-85, June 2026). The build spec uses `"pinnedCommit": null`, so the build itself always pulls the latest commit — only the release creation step is missing. If Glama adds an API or webhook in the future, the step would slot into `release.yml` after the MCPB upload:
+**Why this isn't automated yet:** Glama has no public REST API or documented webhook for programmatic release creation (investigated in SHA-85, June 2026). Glama tracks the repository itself (our committed `glama.json` holds only the maintainer list), so the build follows the latest commit — only the release creation step is missing. If Glama adds an API or webhook in the future, the step would slot into `release.yml` after the MCPB upload:
 
 ```yaml
 - name: Trigger Glama release

--- a/docs/WRITE-SAFETY.md
+++ b/docs/WRITE-SAFETY.md
@@ -46,23 +46,28 @@ path and refuses anything that escapes the vault root; traversal attempts
 Body-editing tools (`append_note`, `patch_note`, `replace_in_note`) never touch
 the frontmatter region — not re-serialized, not re-quoted, not re-ordered:
 byte-identical. `patch_frontmatter` edits values through a CST-preserving YAML
-parser, so untouched keys keep their order, quotes, and comments.
+parser, so untouched keys keep their order, quotes, and comments (and since
+0.12.1, serialization passes `lineWidth: 0`, so long values are never re-folded
+across lines).
 
 - Enforced by: byte-offset frontmatter handling (`parseFrontmatter` reports
   `bodyStart` as an offset) plus post-write re-read verification in
   `patch_note`/`replace_in_note`.
-- Proven by: the harness `identity`, `body-append`, `fm-edit`, `patch-note`,
-  and `replace-in-note` ops ([`ops.ts`](../packages/harness/src/safety/ops.ts))
-  — byte-region equality assertions on the re-read file.
+- Proven by: the harness `identity`, `body-append`, `patch-note`, and
+  `replace-in-note` ops ([`ops.ts`](../packages/harness/src/safety/ops.ts)) —
+  byte-region equality assertions on the re-read file. The `fm-edit` op asserts
+  body-untouched plus key-order preservation (not full byte equality of the
+  frontmatter region, since the edited key's line legitimately changes).
 
 ### 4. Atomic writes — no torn files
 
 Every write goes through one shared temp-file-plus-rename helper
 ([`atomic-write.ts`](../packages/server/src/atomic-write.ts)). A crash
 mid-write leaves either the old content or the new content on disk, never a
-truncated file. (`move_note`'s file relocation is an atomic rename; its link
-rewrites in referencing notes are each individually atomic. This is per-file
-crash-safety, not a multi-file transaction.)
+truncated file. (`move_note`'s file relocation and `delete_note`'s move-to-`.trash/` are
+atomic renames rather than temp-file writes; `move_note`'s link rewrites in
+referencing notes are each individually atomic. This is per-file crash-safety,
+not a multi-file transaction.)
 
 - Proven by: [`atomic-write.test.ts`](../packages/server/src/atomic-write.test.ts)
   and every write-tool test asserting exact post-write bytes.
@@ -92,9 +97,10 @@ reports where it went. `permanent: true` is the explicit opt-out.
 `read_note` returns a `contentHash` (sha-256 of the note's disk bytes). Edit
 tools accept `prevHash` and refuse to write — with a structured
 `hash_conflict` error carrying the current hash — when the note changed since
-it was read, so a concurrent edit is never silently discarded. Every mutating
-result returns the new hash, so chained edits need no re-reads. This is
-conflict **detection**, not locking.
+it was read, so a concurrent edit is never silently discarded. Every
+content-editing result returns the new hash, so chained edits need no re-reads
+(`move_note` and `delete_note` don't participate in hash chaining — re-read
+after them). This is conflict **detection**, not locking.
 
 - Enforced by: [`content-hash.ts`](../packages/server/src/content-hash.ts),
   checked immediately after the disk read in every edit tool.
@@ -144,8 +150,8 @@ whole-note updates are simply unavailable; its partial-edit tools were not
 driven by this suite. — n/a = the server does not expose the capability
 (no delete / create / CAS surface in its tools). **obsidian-mcp**
 (StevenStavrakis) is absent because its synchronous startup indexing does not
-complete within 5 minutes on the 10k-note vault — the same reason it is
-excluded from the scaling benchmark. REST-proxy servers need a live Obsidian
+complete within this suite's 5-minute init budget on the 10k-note vault. (It
+does appear in the scaling benchmark, whose per-run patience is higher.) REST-proxy servers need a live Obsidian
 session and are not part of this headless table.</sup>
 
 **obsidian-tc** (the governance platform) is absent for a structural reason:

--- a/docs/launch-assets/tools-overview-ph.gen.py
+++ b/docs/launch-assets/tools-overview-ph.gen.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Generate the PH "what you get" card (1270x760) as HTML.
 
-Tool list source: README.md tools tables (17 tools: 9 read + 8 write).
+Tool list source: README.md tools tables (18 tools: 9 read + 8 write).
 Brand tokens: seekstone.dev src/styles/ds/colors.css.
 
 Usage: python3 tools-overview-ph.gen.py, then render the HTML it prints
@@ -86,7 +86,7 @@ html = f"""<!DOCTYPE html>
 </style></head>
 <body>
   <div class="wordmark"><div class="gem"></div><div class="name">seekstone</div></div>
-  <h1>17 tools. No plugin. Nothing running.</h1>
+  <h1>18 tools. No plugin. Nothing running.</h1>
   <div class="sub">Filesystem-direct MCP server for your Obsidian vault — works with Obsidian closed</div>
   <div class="install">
     <div class="cmd">npx -y seekstone init</div>

--- a/llms.txt
+++ b/llms.txt
@@ -16,7 +16,7 @@ A user can paste this prompt into any coding agent (Claude Code, Cursor, Windsur
 
 ## Why filesystem-direct?
 
-Routing through the Obsidian Local REST API plugin returns ~1.75 MB (~459,000 tokens) for a typical search. Seekstone returns ~2 KB (~580 tokens) for the same query — a ~800× reduction. Claude can search an entire vault without burning its context window on a single tool call.
+Most Obsidian MCP servers return full note content for every search hit. Benchmarked across committed 1,000/5,000/10,000-note synthetic vaults against 7 other servers (open-source harness, reproducible): Seekstone returns ~2 KB per search and stays flat as the vault grows, while REST-proxy servers grow with the vault — up to 95 MB per query at 10k notes, and a single broad query peaked at ~370 MB / ~98M tokens in one tool call. That is up to a ~47,000× context-tax reduction. Warm search latency is 6.2 ms at 10k notes — the fastest alternative measured is ~6× slower, the REST-proxy generation ~70–250× slower. Full results: https://seekstone.dev/benchmarks
 
 ## How to install (Claude Desktop)
 
@@ -64,12 +64,12 @@ Read:
 
 Write:
 - `create_note` — create a note with optional frontmatter and body
-- `delete_note` — permanently delete a note
+- `delete_note` — move a note to the vault's `.trash/` folder (recoverable, Obsidian-compatible); `permanent: true` for an unrecoverable delete
 - `move_note` — move or rename a note, rewriting wikilinks and markdown links in other notes that point at it (link-aware; `rewriteLinks: false` to opt out)
 - `append_note` — append text to a note body without touching frontmatter
 - `patch_frontmatter` — set, update, or delete frontmatter keys while preserving key order and quote style
 - `patch_note` — insert text immediately after a heading
-- `replace_in_note` — replace the first occurrence of a word or phrase in the note body
+- `replace_in_note` — find and replace text in the note body (literal or regex, whole-word, case sensitivity, optional limit — replaces all occurrences by default, dry-run preview)
 - `append_periodic_note` — append to today's periodic note, creating it from a template if needed
 
 ## Requirements

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "smoke": "node scripts/smoke-install.mjs",
     "conformance": "node scripts/mcp-conformance.mjs",
     "check:registries": "node scripts/check-registries-tools.mjs",
+    "check:docs": "node scripts/check-docs-sync.mjs",
     "version-packages": "changeset version && node scripts/sync-server-json.mjs && biome format --write .",
     "release": "changeset publish"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "description": "Shared vault primitives — walk, frontmatter, extract, percentiles. Used by both harness and server.",
+  "description": "Shared vault primitives — walk, frontmatter, extract, outline, percentiles, pmap.",
   "exports": {
     "./walk": "./src/walk.ts",
     "./frontmatter": "./src/frontmatter.ts",

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -152,8 +152,13 @@ present and lists anything still missing under "Not yet captured."
 | `bench`   | Runs the query set against a `--backend` (`fs`, `rest`, …), capturing latency **and payload bytes/tokens** | `benchmark-<backend>.{json,md}` |
 | `scenarios` | Tokens-per-task: runs each task in `queries/tasks.json` as the call sequence an agent would make (one `context_pack` call where supported, else search → read ×K → backlinks) and sums payload across it | `scenarios-<label>.{json,md}` |
 | `scenarios-compare` | Cross-adapter tokens-per-task table from scenario JSONs | `scenarios-comparison.md` |
-| `safety`  | Byte-faithful write round-trip suite (operates on a vault **copy**) | `safety-<backend>.{json,md}` |
+| `safety`  | Write-safety suite (operates on a vault **copy**): five byte-faithful round-trip ops plus three behavioral ops — recoverable-delete, create-no-clobber, cas-conflict | `safety-<backend>.{json,md}` |
 | `compare` | Cross-adapter comparison from benchmark JSONs | `comparison.md` |
+| `gen-vault` | Regenerates the committed synthetic vault from the corpus (deterministic, `--seed 42`, `--count 10000`) | `fixtures/vault/` |
+| `fetch-corpus` | Downloads the PG EB1911 corpus into `fixtures/corpus/raw/` (gitignored) | corpus text |
+| `scale-render` | Renders the multi-scale (1k/5k/10k) comparison report from per-size benchmark JSONs | `benchmark-scaling.md` |
+
+`bench` and `scenarios` accept `--runs <n>` (default 20) — the run count behind the cold/warm split quoted in the reports. Each subprocess adapter's launch command can be overridden with `SEEKSTONE_<NAME>_CMD` (e.g. `SEEKSTONE_MCPVAULT_CMD`), matching the `SEEKSTONE_<NAME>_*` env convention.
 
 ### Tokens per task (`scenarios`)
 

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Profiler + benchmark harness for an Obsidian vault. Measures vault shape; benchmarks pluggable adapters (Obsidian Local REST API today, filesystem-direct next); verifies byte-faithful YAML round-trip.",
+  "description": "Measurement harness for Obsidian MCP access: vault profiler, cold/warm benchmark runner with pluggable adapters (filesystem-direct, REST, and 7 competing MCP servers), tokens-per-task scenario suite, and write-safety verification.",
   "bin": {
     "seekstone-harness": "./src/cli.ts"
   },

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -110,7 +110,7 @@ Other MCP clients (Windsurf, Cline, …) take the Option 3 JSON block in their o
 
 | Tool | Description |
 |---|---|
-| `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy, prefix, and phrase queries. |
+| `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy and prefix matching. |
 | `query_notes` | Structured metadata query. Filter by frontmatter key/value predicates (`eq`, `ne`, `contains`, `exists`, `missing`, `gt`/`gte`/`lt`/`lte`), tag, folder, modified time, and size; sort and select the fields you need. Returns compact rows, not note content. |
 | `context_pack` | Answer-ready context for a natural-language question in one call, hard-capped at a byte budget (default 2 KB): ranked excerpts, linked neighbor notes with one-line summaries, and follow-up source paths — replaces a search → read → get_backlinks round-trip loop. |
 | `read_note` | Read the full content of a note by vault-relative path. Supports returning a single section, block, or line range. |
@@ -131,10 +131,10 @@ Other MCP clients (Windsurf, Cline, …) take the Option 3 JSON block in their o
 | `append_note` | Append to a note body without touching frontmatter. |
 | `patch_frontmatter` | Set/update/delete frontmatter keys without reordering existing keys or changing quote style. |
 | `patch_note` | Insert text immediately after a heading without touching frontmatter. |
-| `replace_in_note` | Replace the first occurrence of a word or phrase in the note body. |
+| `replace_in_note` | Find and replace text in the note body — literal or regex, whole-word, case sensitivity, optional `limit` (replaces **all** occurrences by default), dry-run preview. |
 | `append_periodic_note` | Append to today's periodic note, creating it from a template if it doesn't yet exist. |
 
-Every edit tool supports optional **compare-and-swap**: pass the `contentHash` you got from `read_note` as `prevHash` and the write fails cleanly if the note changed underneath you, instead of silently discarding the concurrent edit.
+The content-editing tools (`append_note`, `patch_note`, `patch_frontmatter`, `replace_in_note`, `append_periodic_note`, and `create_note` with `overwrite: true`) support optional **compare-and-swap**: pass the `contentHash` you got from `read_note` as `prevHash` and the write fails cleanly if the note changed underneath you, instead of silently discarding the concurrent edit.
 
 ---
 
@@ -146,6 +146,7 @@ Every edit tool supports optional **compare-and-swap**: pass the `contentHash` y
 | `SEEKSTONE_LOG_LEVEL` | no | `error` \| `warn` \| `info` (default) \| `debug`. |
 | `SEEKSTONE_LOG_FILE` | no | Absolute path; when set, JSON-line logs are appended here (size-rotated). |
 | `SEEKSTONE_WATCH_POLL` | no | Set to `1` to stat-poll for changes instead of native OS events — reliable on network drives, WSL, containers. |
+| `SEEKSTONE_LOG_MAX_SIZE` | no | Log-rotation threshold for `SEEKSTONE_LOG_FILE` (e.g. `10mb`; default 5 MB). |
 | `SEEKSTONE_READ_ONLY` | no | Set to `1` to run read-only: the 8 write tools are unregistered entirely (and rejected if called anyway), so the session provably cannot modify your vault. |
 | `SEEKSTONE_WRITE_PATHS` | no | Comma-separated vault-relative globs (e.g. `journal/**,inbox/*.md`). Writes are permitted only under matching paths; the rest of the vault stays read-only. |
 

--- a/packages/server/manifest.json
+++ b/packages/server/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.4",
   "name": "seekstone",
-  "version": "0.5.0",
+  "version": "0.12.1",
   "description": "Obsidian MCP server — filesystem-direct vault access, low context-tax.",
   "author": {
     "name": "Shaq Mughal",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.1",
   "mcpName": "io.github.shaqmughal/seekstone",
   "type": "module",
-  "description": "The Obsidian MCP server that needs no plugin, no running Obsidian app — and doesn't blow your context window. Filesystem-direct: single-digit-ms search, ~2 KB payloads, 17 tools.",
+  "description": "The Obsidian MCP server that needs no plugin, no running Obsidian app — and doesn't blow your context window. Filesystem-direct: single-digit-ms search, ~2 KB payloads, 18 tools.",
   "keywords": [
     "obsidian",
     "obsidian-mcp",

--- a/scripts/check-docs-sync.mjs
+++ b/scripts/check-docs-sync.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Docs-sync guard — fails CI when documentation drifts from the code.
+ *
+ * Three checks, all derived from source-of-truth code, never from other docs:
+ *
+ *  1. Tool counts. Every "<N> tools" phrase in the marketing/doc surfaces must
+ *     equal HANDLED_TOOLS.length in dispatch.ts, and every "<N> read/write
+ *     tools" split must match the WRITE_TOOLS partition.
+ *  2. Retired claims. Numbers the messaging doc has retired (575×, the old
+ *     1.75 MB / 459k-token measurement, ~800×) must not appear in any current
+ *     doc surface. CHANGELOGs and .changeset are exempt (they record history).
+ *  3. Env vars. Every SEEKSTONE_* variable the server reads must be documented
+ *     in both READMEs' configuration tables.
+ *
+ * Born from the 2026-08 audit that found the npm README shipping a claim
+ * retired a month earlier (SHA-276) plus "16 tools" surviving in
+ * ARCHITECTURE.md — every one of those would have been caught here.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = new URL('..', import.meta.url).pathname;
+const read = (p) => readFileSync(join(root, p), 'utf8');
+const errors = [];
+
+// ---------- source of truth: dispatch.ts ----------
+const dispatch = read('packages/server/src/dispatch.ts');
+const handled = dispatch.match(/HANDLED_TOOLS = \[([\s\S]*?)\]/);
+if (!handled) throw new Error('cannot locate HANDLED_TOOLS in dispatch.ts');
+const toolCount = [...handled[1].matchAll(/'[^']+'/g)].length;
+const writeTools = dispatch.match(/WRITE_TOOLS[^=]*= new Set\(\[([\s\S]*?)\]\)/);
+if (!writeTools) throw new Error('cannot locate WRITE_TOOLS in dispatch.ts');
+const writeCount = [...writeTools[1].matchAll(/'[^']+'/g)].length;
+const readCount = toolCount - writeCount;
+
+// ---------- check 1: tool counts ----------
+const COUNT_SURFACES = [
+  'README.md',
+  'packages/server/README.md',
+  'packages/server/package.json',
+  'docs/ARCHITECTURE.md',
+  'docs/CLIENT-TESTING.md',
+  'docs/REGISTRIES.md',
+  'llms.txt',
+  'SECURITY.md',
+  'CLAUDE.md',
+];
+for (const file of COUNT_SURFACES) {
+  const text = read(file);
+  for (const m of text.matchAll(/(\d+)[  ](?:tools|read tools|write tools)/g)) {
+    const n = Number(m[1]);
+    const kind = m[0].includes('read')
+      ? { expect: readCount, label: 'read tools' }
+      : m[0].includes('write')
+        ? { expect: writeCount, label: 'write tools' }
+        : { expect: toolCount, label: 'tools' };
+    if (n !== kind.expect) {
+      const line = text.slice(0, m.index).split('\n').length;
+      errors.push(`${file}:${line} says "${m[0]}" but the server has ${kind.expect} ${kind.label}`);
+    }
+  }
+}
+
+// ---------- check 2: retired claims ----------
+const RETIRED = [/575\s*[×x]/, /1\.75\s*MB/, /459,?000/, /~?800×/];
+const RETIRED_SURFACES = [
+  'README.md',
+  'packages/server/README.md',
+  'packages/harness/README.md',
+  'packages/server/package.json',
+  'packages/server/manifest.json',
+  'llms.txt',
+  'SECURITY.md',
+  'CLAUDE.md',
+  ...readdirSync(join(root, 'docs'))
+    .filter((f) => f.endsWith('.md') && statSync(join(root, 'docs', f)).isFile())
+    .map((f) => `docs/${f}`),
+];
+for (const file of RETIRED_SURFACES) {
+  const text = read(file);
+  for (const re of RETIRED) {
+    const m = text.match(re);
+    if (m) {
+      const line = text.slice(0, m.index).split('\n').length;
+      errors.push(`${file}:${line} contains retired claim "${m[0]}" — see the messaging doc`);
+    }
+  }
+}
+
+// ---------- check 3: env vars documented ----------
+const serverSrc = join(root, 'packages/server/src');
+const vars = new Set();
+const walk = (dir) => {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walk(p);
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      for (const m of readFileSync(p, 'utf8').matchAll(/env\.(SEEKSTONE_[A-Z_]+)/g)) {
+        vars.add(m[1]);
+      }
+    }
+  }
+};
+walk(serverSrc);
+for (const file of ['README.md', 'packages/server/README.md']) {
+  const text = read(file);
+  for (const v of vars) {
+    if (!text.includes(v)) errors.push(`${file} is missing env var ${v} from its config table`);
+  }
+}
+
+// ---------- verdict ----------
+if (errors.length > 0) {
+  console.error(`docs-sync guard: ${errors.length} problem(s)\n`);
+  for (const e of errors) console.error(`  ✗ ${e}`);
+  process.exit(1);
+}
+console.log(
+  `docs-sync guard: ${COUNT_SURFACES.length + RETIRED_SURFACES.length} surfaces clean ` +
+    `(${toolCount} tools = ${readCount} read + ${writeCount} write; ${vars.size} env vars documented)`,
+);

--- a/scripts/check-docs-sync.mjs
+++ b/scripts/check-docs-sync.mjs
@@ -17,7 +17,7 @@
  * retired a month earlier (SHA-276) plus "16 tools" surviving in
  * ARCHITECTURE.md — every one of those would have been caught here.
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 const root = new URL('..', import.meta.url).pathname;
@@ -48,7 +48,7 @@ const COUNT_SURFACES = [
 ];
 for (const file of COUNT_SURFACES) {
   const text = read(file);
-  for (const m of text.matchAll(/(\d+)[  ](?:tools|read tools|write tools)/g)) {
+  for (const m of text.matchAll(/(\d+)[ {2}](?:tools|read tools|write tools)/g)) {
     const n = Number(m[1]);
     const kind = m[0].includes('read')
       ? { expect: readCount, label: 'read tools' }


### PR DESCRIPTION
Result of tonight's four-agent documentation audit (tracked alongside #237). Two parts:

## 1. Fix everything confirmed stale

**Critical (external-facing):** llms.txt was still serving the retired ~1.75 MB / ~459k-token / ~800× claims to answer engines; `docs/REGISTRIES.md`'s canonical copy-paste block still said 575×; the npm `package.json` description said 17 tools; both READMEs called `replace_in_note` "first occurrence" when it replaces **all** occurrences by default.

**Major:** ARCHITECTURE.md predated the entire write-safety generation (16 tools, no policy/CAS/atomic/trash/rewrite-links/tool-list modules, no read-only flow); SECURITY.md claimed deletes are unrecoverable and listed 5 of 8 write tools; RELEASING.md omitted the write-safety publish gate and the whole automated post-publish pipeline; CLAUDE.md described a pre-server world.

**Minor:** CAS scoped to its six real tools, phrase-search claim removed, ~250× → ~440×, `SEEKSTONE_LOG_MAX_SIZE` documented, CLIENT-TESTING roster, CONTRIBUTING CI gates, harness README command table + `--runs` + `SEEKSTONE_<NAME>_CMD`, WRITE-SAFETY wording (delete-rename caveat, fm-edit proof described accurately, obsidian-mcp footnote), manifest version, template placeholder.

Every fix traces to a file:line finding verified against source; the audit's full report is in SHA-278's description (Linear).

## 2. Keep it from drifting again

New `scripts/check-docs-sync.mjs` (npm run check:docs), wired into CI next to the REGISTRIES guard:
- every "N tools" / "N read tools" / "N write tools" phrase across 9 doc surfaces must equal the `HANDLED_TOOLS` / `WRITE_TOOLS` partition in `dispatch.ts`
- retired claims (575×, 1.75 MB, 459k, ~800×) are banned across all doc surfaces including llms.txt and docs/*
- every `SEEKSTONE_*` env var the server reads must appear in both README config tables

Each of tonight's critical findings would have been caught by this guard.

**Merge order:** after #237 (SECURITY.md's containment wording describes the shared guard #237 introduces). Changeset: patch (npm description + README ship with the package).