### PR TITLE
fix(core): YAML-aware frontmatter link extraction

### DIFF
--- a/.changeset/yaml-aware-frontmatter-links.md
+++ b/.changeset/yaml-aware-frontmatter-links.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+YAML-aware frontmatter link extraction: wikilinks split across lines by scalar folding (hand edits, other tools, or files written by pre-0.12.1 versions) now extract correctly into the backlink index, `get_links`, and `context_pack`. The frontmatter block is parsed as YAML and its string values walked, instead of regexing raw lines; malformed frontmatter falls back to the previous per-line behavior. Links inside multi-line scalars are attributed to the line where the scalar begins, and YAML keys are no longer scanned for links.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6466,7 +6466,7 @@
     },
     "packages/server": {
       "name": "seekstone",
-      "version": "0.12.0",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/packages/core/src/extract.test.ts
+++ b/packages/core/src/extract.test.ts
@@ -69,6 +69,131 @@ describe('extractLinksWithLines', () => {
   });
 });
 
+describe('extractLinksWithLines — frontmatter', () => {
+  it('extracts single-line frontmatter links with their line number', () => {
+    const raw = ['---', 'related: "[[Note A]]"', 'banner: "![[cover.png]]"', '---', 'Body.'].join(
+      '\n',
+    );
+    const links = extractLinksWithLines(raw);
+    expect(links).toEqual([
+      {
+        raw: '[[Note A]]',
+        target: 'Note A',
+        fragment: null,
+        alias: null,
+        linkType: 'wikilink',
+        line: 2,
+      },
+      {
+        raw: '![[cover.png]]',
+        target: 'cover.png',
+        fragment: null,
+        alias: null,
+        linkType: 'embed',
+        line: 3,
+      },
+    ]);
+  });
+
+  it('heals a wikilink split across lines by scalar folding', () => {
+    // yaml's default 80-col folding (pre-0.12.1 seekstone, other writers)
+    // turns a long value into a multi-line plain scalar; parsing folds the
+    // newline back into a space, restoring the link.
+    const raw = [
+      '---',
+      'source: this sentence references [[Some Extremely Long',
+      '  Note Name That Got Folded]] mid-link',
+      '---',
+      'Body with [[Inline Link]].',
+    ].join('\n');
+    const links = extractLinksWithLines(raw);
+    expect(links).toHaveLength(2);
+    expect(links[0]).toEqual({
+      raw: '[[Some Extremely Long Note Name That Got Folded]]',
+      target: 'Some Extremely Long Note Name That Got Folded',
+      fragment: null,
+      alias: null,
+      linkType: 'wikilink',
+      line: 2, // attributed to the line where the scalar begins
+    });
+    expect(links[1]?.target).toBe('Inline Link');
+    expect(links[1]?.line).toBe(5);
+  });
+
+  it('heals folded links inside list items and keeps aliases/fragments', () => {
+    const raw = [
+      '---',
+      'refs:',
+      '  - "[[First Note#Some',
+      '    Heading|display]]"',
+      '  - "[[Second]]"',
+      '---',
+      '',
+    ].join('\n');
+    const links = extractLinksWithLines(raw);
+    expect(links).toHaveLength(2);
+    expect(links[0]).toMatchObject({
+      target: 'First Note',
+      fragment: 'Some Heading',
+      alias: 'display',
+      line: 3,
+    });
+    expect(links[1]).toMatchObject({ target: 'Second', line: 5 });
+  });
+
+  it('offsets body line numbers past the frontmatter block', () => {
+    const raw = ['---', 'title: T', 'tags: [x]', '---', '', 'See [[Target]].'].join('\n');
+    const links = extractLinksWithLines(raw);
+    expect(links).toEqual([
+      {
+        raw: '[[Target]]',
+        target: 'Target',
+        fragment: null,
+        alias: null,
+        linkType: 'wikilink',
+        line: 6,
+      },
+    ]);
+  });
+
+  it('does not treat YAML keys as links', () => {
+    const raw = ['---', '"[[Not A Link]]": value', '---', ''].join('\n');
+    expect(extractLinksWithLines(raw)).toHaveLength(0);
+  });
+
+  it('falls back to per-line regex when frontmatter is malformed', () => {
+    const raw = ['---', 'bad: [unclosed', 'related: "[[Still Found]]"', '---', ''].join('\n');
+    const links = extractLinksWithLines(raw);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ target: 'Still Found', line: 3 });
+  });
+
+  it('handles CRLF frontmatter', () => {
+    const raw = '---\r\nrelated: "[[Windows Note]]"\r\n---\r\nBody [[After]].';
+    const links = extractLinksWithLines(raw);
+    expect(links).toHaveLength(2);
+    expect(links[0]).toMatchObject({ target: 'Windows Note', line: 2 });
+    expect(links[1]).toMatchObject({ target: 'After', line: 4 });
+  });
+
+  it('extracts per-line inside literal block scalars, attributed to the scalar start', () => {
+    const raw = ['---', 'notes: |', '  first [[Block Link]]', '  second line', '---', ''].join(
+      '\n',
+    );
+    const links = extractLinksWithLines(raw);
+    expect(links).toHaveLength(1);
+    // Attribution rule: multi-line scalars report the line the scalar begins on.
+    expect(links[0]).toMatchObject({ target: 'Block Link', line: 2 });
+  });
+
+  it('treats an unterminated frontmatter block as body (regex per line)', () => {
+    const raw = ['---', 'related: "[[Found Anyway]]"', 'no closing delimiter'].join('\n');
+    const links = extractLinksWithLines(raw);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ target: 'Found Anyway', line: 2 });
+  });
+});
+
 describe('extractUrls', () => {
   it('strips trailing punctuation', () => {
     expect(extractUrls('See https://example.com/foo, and (https://x.io/bar).')).toEqual([

--- a/packages/core/src/extract.ts
+++ b/packages/core/src/extract.ts
@@ -1,12 +1,16 @@
 /**
- * Link / URL / tag extractors. These run on note *bodies* (post-frontmatter)
- * so frontmatter values don't double-count as inline content.
+ * Link / URL / tag extractors. Most run on note *bodies* (post-frontmatter)
+ * so frontmatter values don't double-count as inline content;
+ * `extractLinksWithLines` takes the full raw note and handles the
+ * frontmatter block YAML-aware.
  *
  * Heuristics here intentionally lean toward "what Obsidian sees" rather than
  * full CommonMark parsing — we're profiling shape, not rendering. The regexes
  * are deliberately tolerant of code-fence content; counts are reported with
  * that caveat in the README.
  */
+import { parseDocument, visit } from 'yaml';
+import { parseFrontmatter } from './frontmatter.js';
 
 export interface Wikilink {
   /** Raw target before `#` and `|`. May include path segments. */
@@ -29,38 +33,109 @@ const LINK_WITH_LINES_RE =
 export type LinkType = 'wikilink' | 'embed';
 
 export interface LinkRecord {
-  /** Full raw match, e.g. "[[Note Name|alias]]" or "![[embed.png]]". */
+  /**
+   * Full raw match, e.g. "[[Note Name|alias]]" or "![[embed.png]]". For links
+   * found inside folded frontmatter scalars this is the *parsed* (unfolded)
+   * text, which may differ from the source bytes.
+   */
   raw: string;
   /** Raw target before `#` and `|`. */
   target: string;
   fragment: string | null;
   alias: string | null;
   linkType: LinkType;
-  /** 1-indexed line number in the source file. */
+  /**
+   * 1-indexed line number in the source file. Links inside multi-line
+   * frontmatter scalars are attributed to the line where the scalar begins.
+   */
   line: number;
 }
 
 /**
  * Extract all wikilinks and embeds from a raw note (including frontmatter),
  * annotating each with its 1-indexed line number.
+ *
+ * The frontmatter block is parsed as YAML and its string values walked, so
+ * links split across lines by scalar folding (yaml's default 80-col wrap —
+ * hand edits, other tools, or pre-0.12.1 seekstone) still extract: folding
+ * turns the newline back into a space on parse. Malformed frontmatter falls
+ * back to per-line regex over the block, matching the body treatment.
  */
 export function extractLinksWithLines(raw: string): LinkRecord[] {
-  const out: LinkRecord[] = [];
-  const lines = raw.split('\n');
-  for (const [lineIdx, lineText] of lines.entries()) {
-    for (const m of lineText.matchAll(LINK_WITH_LINES_RE)) {
-      const prefix = m[1] ?? '';
-      out.push({
-        raw: m[0] ?? '',
-        target: (m[2] ?? '').trim(),
-        fragment: m[3] ? m[3].slice(1).trim() : null,
-        alias: m[4] ? m[4].slice(1).trim() : null,
-        linkType: prefix.startsWith('!') ? 'embed' : 'wikilink',
-        line: lineIdx + 1,
-      });
-    }
-  }
+  const fm = parseFrontmatter(raw);
+  // bodyStart 0 covers both "no frontmatter" and "unterminated frontmatter"
+  // (where the whole file is treated as body).
+  if (!fm.present || fm.bodyStart === 0) return linksFromLines(raw, 1);
+
+  const fmRegion = raw.slice(0, fm.bodyStart);
+  const out = frontmatterLinks(fmRegion, fm.malformed);
+  const bodyFirstLine = countNewlines(fmRegion) + 1;
+  linksFromLinesInto(out, fm.body, bodyFirstLine);
   return out;
+}
+
+function linksFromLines(text: string, firstLine: number): LinkRecord[] {
+  const out: LinkRecord[] = [];
+  linksFromLinesInto(out, text, firstLine);
+  return out;
+}
+
+function linksFromLinesInto(out: LinkRecord[], text: string, firstLine: number): void {
+  const lines = text.split('\n');
+  for (const [lineIdx, lineText] of lines.entries()) {
+    matchLinksInto(out, lineText, firstLine + lineIdx);
+  }
+}
+
+function matchLinksInto(out: LinkRecord[], text: string, line: number): void {
+  for (const m of text.matchAll(LINK_WITH_LINES_RE)) {
+    const prefix = m[1] ?? '';
+    out.push({
+      raw: m[0] ?? '',
+      target: (m[2] ?? '').trim(),
+      fragment: m[3] ? m[3].slice(1).trim() : null,
+      alias: m[4] ? m[4].slice(1).trim() : null,
+      linkType: prefix.startsWith('!') ? 'embed' : 'wikilink',
+      line,
+    });
+  }
+}
+
+/**
+ * Walk the frontmatter block's string values via the YAML AST. `fmRegion` is
+ * the full block including both `---` delimiter lines. Keys are skipped —
+ * Obsidian doesn't treat property names as links.
+ */
+function frontmatterLinks(fmRegion: string, malformed: boolean): LinkRecord[] {
+  if (malformed) return linksFromLines(fmRegion, 1);
+
+  // Strip the delimiters: yaml content starts after the opening `---` line and
+  // ends before the closing `---` line (parseDocument would read a bare `---`
+  // as a document marker).
+  const yamlStart = fmRegion.indexOf('\n') + 1;
+  const closeLen = fmRegion.endsWith('---\r\n') ? 5 : 4;
+  const yamlText = fmRegion.slice(yamlStart, fmRegion.length - closeLen);
+
+  const doc = parseDocument(yamlText);
+  if (doc.errors.length > 0) return linksFromLines(fmRegion, 1);
+
+  const out: LinkRecord[] = [];
+  visit(doc, {
+    Scalar(key, node) {
+      if (key === 'key') return;
+      if (typeof node.value !== 'string' || node.range == null) return;
+      // Opening `---` is line 1, so yamlText's first line is file line 2.
+      const line = 2 + countNewlines(yamlText.slice(0, node.range[0]));
+      matchLinksInto(out, node.value, line);
+    },
+  });
+  return out;
+}
+
+function countNewlines(text: string): number {
+  let n = 0;
+  for (let i = text.indexOf('\n'); i !== -1; i = text.indexOf('\n', i + 1)) n++;
+  return n;
 }
 const URL_RE = /https?:\/\/[^\s<>"')]+/g;
 // Obsidian inline tag: must start with letter or underscore, then word chars, /, -.

--- a/packages/server/src/index/build.test.ts
+++ b/packages/server/src/index/build.test.ts
@@ -131,4 +131,33 @@ describe('buildIndex', () => {
     expect(note?.tags).toContain('alpha');
     expect(note?.tags).toContain('beta');
   });
+
+  it('backlinks index picks up frontmatter wikilinks split across lines by folding', async () => {
+    // A wikilink folded across lines (yaml's default 80-col wrap — other
+    // writers, or files written by pre-0.12.1 seekstone) must still resolve
+    // into the backlink index.
+    const foldedVault = await mkdtemp(join(tmpdir(), 'seekstone-folded-fm-'));
+    try {
+      const folded = [
+        '---',
+        'source: long sentence that references [[Target Note With A',
+        '  Rather Long Name]] across a fold',
+        '---',
+        'Body.',
+        '',
+      ].join('\n');
+      await writeFile(join(foldedVault, 'linker.md'), folded, 'utf8');
+      await writeFile(
+        join(foldedVault, 'Target Note With A Rather Long Name.md'),
+        '# Target\n',
+        'utf8',
+      );
+
+      const { backlinks } = await buildIndex(foldedVault);
+      const refs = backlinks.get('Target Note With A Rather Long Name.md');
+      expect(refs).toEqual([{ path: 'linker.md', line: 2, linkType: 'wikilink' }]);
+    } finally {
+      await rm(foldedVault, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the reader-side half of the folded-frontmatter-link problem ([SHA-277](https://linear.app/shaqster/issue/SHA-277/yaml-aware-frontmatter-link-extraction-regex-misses-foldedmulti-line), follow-up to #233 which fixed the writer side).

`extractLinksWithLines` regexed raw lines with newline-excluding patterns, so a wikilink split across lines by YAML scalar folding — hand edits, other tools, or files written by pre-0.12.1 versions — extracted as nothing: silently absent from the backlink index, `get_links`, and `context_pack`.

## Approach

- The frontmatter block is parsed as YAML (`parseDocument`) and its string scalar values are walked for links. Parsing folds the newline back into a space, restoring the split link.
- The body keeps the existing per-line regex, now with correct line offsets past the frontmatter block.
- Malformed frontmatter falls back to the previous per-line regex over the block, so behavior degrades gracefully instead of dropping the region.

## Design decisions

- **Line attribution:** links inside multi-line scalars report the line the scalar begins on (documented on `LinkRecord`). Single-line values — the overwhelmingly common case — keep exact lines, same as before.
- **Keys are skipped:** Obsidian doesn't treat property names as links (previously a link-shaped key would have been extracted).
- **`LinkRecord.raw` for healed links** is the parsed (unfolded) text, which may differ from the source bytes; also documented on the interface.
- YAML comments in frontmatter are no longer scanned (they aren't values).

## Tests

- 9 new core cases: folded plain scalar heals, folded quoted scalar in a list (alias + fragment preserved), single-line values, embeds, body line offsets, key skipping, malformed fallback, CRLF, literal block scalars, unterminated frontmatter.
- 1 server integration test: a folded frontmatter wikilink now lands in the backlink index built by `buildIndex`.
- Full suite green: 63 core + 284 harness + 420 server + 6 root; `tsc --noEmit` clean on core and server; biome clean; docs-sync gate clean.

Includes a changeset (patch) and a one-line `package-lock.json` version sync (0.12.0 → 0.12.2 was stale).