### PR TITLE
fix(server): advertise MCP safety annotations

### DIFF
--- a/.changeset/calm-stones-listen.md
+++ b/.changeset/calm-stones-listen.md
@@ -1,0 +1,5 @@
+---
+'seekstone': patch
+---
+
+Advertise explicit MCP safety annotations for every tool so clients can distinguish read-only, additive, destructive, idempotent, and closed-world operations.

--- a/packages/server/src/tool-list.test.ts
+++ b/packages/server/src/tool-list.test.ts
@@ -12,6 +12,61 @@ describe('ALL_TOOLS', () => {
     const names = new Set(ALL_TOOLS.map((t) => t.name));
     for (const w of WRITE_TOOLS) expect(names.has(w)).toBe(true);
   });
+  it('advertises conservative safety annotations for every tool', () => {
+    const annotations = Object.fromEntries(ALL_TOOLS.map((tool) => [tool.name, tool.annotations]));
+
+    for (const name of [
+      'search',
+      'query_notes',
+      'context_pack',
+      'read_note',
+      'list_notes',
+      'list_tags',
+      'outline_note',
+      'get_backlinks',
+      'get_links',
+    ]) {
+      expect(annotations[name]).toEqual({ readOnlyHint: true, openWorldHint: false });
+    }
+
+    for (const name of ['append_note', 'append_periodic_note']) {
+      expect(annotations[name]).toEqual({
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      });
+    }
+
+    for (const name of [
+      'create_note',
+      'delete_note',
+      'move_note',
+      'rename_heading',
+      'patch_note',
+      'replace_in_note',
+    ]) {
+      expect(annotations[name]).toEqual({
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      });
+    }
+
+    expect(annotations.patch_frontmatter).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(annotations.get_periodic_note).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+  });
 });
 
 describe('visibleTools', () => {

--- a/packages/server/src/tool-list.ts
+++ b/packages/server/src/tool-list.ts
@@ -1,5 +1,32 @@
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { WRITE_TOOLS } from './dispatch.js';
 import type { WritePolicy } from './policy.js';
+
+const READ_ONLY_ANNOTATIONS = {
+  readOnlyHint: true,
+  openWorldHint: false,
+} as const satisfies ToolAnnotations;
+
+const ADDITIVE_WRITE_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: false,
+} as const satisfies ToolAnnotations;
+
+const DESTRUCTIVE_WRITE_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: false,
+} as const satisfies ToolAnnotations;
+
+const IDEMPOTENT_DESTRUCTIVE_WRITE_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const satisfies ToolAnnotations;
 
 /**
  * The full tool list served to MCP clients, extracted verbatim from the
@@ -9,6 +36,7 @@ import type { WritePolicy } from './policy.js';
 export const ALL_TOOLS = [
   {
     name: 'search',
+    annotations: READ_ONLY_ANNOTATIONS,
     description:
       'Full-text search across the vault. Returns ranked excerpts (~200 chars) — not full notes — to minimise context usage. Supports fuzzy matching and prefix search.',
     inputSchema: {
@@ -24,6 +52,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'query_notes',
+    annotations: READ_ONLY_ANNOTATIONS,
     description:
       'Structured metadata query — filter notes by frontmatter key/value predicates, tag, folder, modified time, and size. Returns compact rows (path + title by default; opt into more via select), not note content. Use this instead of search when filtering by properties rather than text.',
     inputSchema: {
@@ -84,6 +113,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'context_pack',
+    annotations: READ_ONLY_ANNOTATIONS,
     description:
       'Assemble everything needed to ANSWER a natural-language question in one call, under a strict byte budget (default 2048): ranked excerpts, linked neighbor notes (backlinks/outlinks) with one-line summaries, and follow-up source paths. Use search to locate notes and query_notes for metadata filters; use context_pack when you want answer-ready context without multiple round-trips. Empty excerpts with confidence "none" or "low" means the vault lacks coverage — do not infer content.',
     inputSchema: {
@@ -100,6 +130,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'read_note',
+    annotations: READ_ONLY_ANNOTATIONS,
     description:
       'Read a note or a span of it — by heading section, block reference, or line range. Returns structured JSON with the content, bytes returned, total note size, and a contentHash to pass as prevHash to edit tools for compare-and-swap. Use search or outline_note first to find the right path and section names.',
     inputSchema: {
@@ -141,6 +172,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'list_notes',
+    annotations: READ_ONLY_ANNOTATIONS,
     description: 'List notes, optionally filtered by folder prefix or tag.',
     inputSchema: {
       type: 'object',
@@ -154,6 +186,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'list_tags',
+    annotations: READ_ONLY_ANNOTATIONS,
     description:
       'List all tags in the vault with usage counts. Supports substring filtering, minimum count threshold, and sort order. Nested tags (e.g. area/work) include a parent field.',
     inputSchema: {
@@ -179,6 +212,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'create_note',
+    annotations: DESTRUCTIVE_WRITE_ANNOTATIONS,
     description:
       'Create a new note at a vault-relative path. Optionally sets frontmatter and body content. Parent directories are created automatically. Fails if the note already exists unless overwrite is true (prevHash may guard the overwrite).',
     inputSchema: {
@@ -209,6 +243,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'delete_note',
+    annotations: DESTRUCTIVE_WRITE_ANNOTATIONS,
     description:
       'Delete a note. By default it is moved to the vault .trash/ folder (recoverable by moving it back); pass permanent: true to remove it outright.',
     inputSchema: {
@@ -225,6 +260,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'move_note',
+    annotations: DESTRUCTIVE_WRITE_ANNOTATIONS,
     description:
       'Move or rename a note to a new vault-relative path, rewriting wikilinks and markdown links in other notes that point at it so nothing breaks (links inside fenced code blocks are left alone). Parent directories at the destination are created automatically. Fails if the destination already exists unless overwrite is true.',
     inputSchema: {
@@ -247,6 +283,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'rename_heading',
+    annotations: DESTRUCTIVE_WRITE_ANNOTATIONS,
     description:
       'Rename a heading in a note and rewrite every [[note#heading]] wikilink and embed across the vault so references keep working — aliases preserved, fenced code blocks left alone. Served from the warm backlink index, no vault scan. Heading matching is case-insensitive; with duplicate headings the first match wins, mirroring Obsidian link resolution.',
     inputSchema: {
@@ -277,6 +314,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'append_note',
+    annotations: ADDITIVE_WRITE_ANNOTATIONS,
     description:
       'Append text to a note body without touching the frontmatter. Safe for meeting notes, daily logs, and append-only workflows.',
     inputSchema: {
@@ -295,6 +333,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'patch_frontmatter',
+    annotations: IDEMPOTENT_DESTRUCTIVE_WRITE_ANNOTATIONS,
     description:
       'Set, update, or delete frontmatter keys without reordering existing keys or changing quote style. Pass null as a value to delete a key.',
     inputSchema: {
@@ -317,6 +356,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'outline_note',
+    annotations: READ_ONLY_ANNOTATIONS,
     description:
       "Return a note's structure — heading tree with offsets, block-reference anchors, and frontmatter key list — without returning any prose. Use this before section reads or patches to discover what sections exist at a fraction of the cost of reading the full note.",
     inputSchema: {
@@ -337,6 +377,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'patch_note',
+    annotations: DESTRUCTIVE_WRITE_ANNOTATIONS,
     description:
       'Surgically edit a section of a note — targeted by heading or block reference — without rewriting the whole file. Operations: append (add after section), prepend (add after heading line), replace (swap section content). Frontmatter is never touched.',
     inputSchema: {
@@ -371,6 +412,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'get_backlinks',
+    annotations: READ_ONLY_ANNOTATIONS,
     description:
       'Return every note that links to the target note, with the source line and an optional excerpt. Results come from the pre-built reverse-link index so this is a fast, pure index lookup. Sort order: source path ascending.',
     inputSchema: {
@@ -391,6 +433,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'get_links',
+    annotations: READ_ONLY_ANNOTATIONS,
     description:
       'Return all outgoing wikilinks and embeds from a note. Each link is marked resolved (with target path) or unresolved. Duplicate targets are de-duplicated; results sorted by line number.',
     inputSchema: {
@@ -403,6 +446,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'replace_in_note',
+    annotations: DESTRUCTIVE_WRITE_ANNOTATIONS,
     description:
       'Find and replace text within a note body. Supports literal and regex search, case sensitivity, whole-word matching, and a replacement limit. Frontmatter is never touched. Use dryRun to preview matches before writing.',
     inputSchema: {
@@ -445,6 +489,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'get_periodic_note',
+    annotations: ADDITIVE_WRITE_ANNOTATIONS,
     description:
       'Get the path and existence status of a periodic note (daily, weekly, monthly, quarterly, or yearly) for a given date. Reads folder/format config from .obsidian/daily-notes.json (daily) or the periodic-notes plugin data.json. Optionally creates the note from the configured template if it is missing.',
     inputSchema: {
@@ -470,6 +515,7 @@ export const ALL_TOOLS = [
   },
   {
     name: 'append_periodic_note',
+    annotations: ADDITIVE_WRITE_ANNOTATIONS,
     description:
       'Append text to a periodic note (daily, weekly, monthly, quarterly, or yearly). Preserves existing frontmatter exactly. Creates the note first (from template if configured) when createIfMissing is true (default).',
     inputSchema: {

--- a/scripts/mcp-conformance.mjs
+++ b/scripts/mcp-conformance.mjs
@@ -8,6 +8,7 @@
 // Asserts:
 //   1. initialize handshake succeeds and identifies as `seekstone`
 //   2. tools/list matches HANDLED_TOOLS exactly (no drops, no strays)
+//      and every tool advertises explicit safety annotations
 //   3. tools/call round-trips: `search` finds seeded content, `append_note`
 //      writes it to disk with the frontmatter byte-identical
 //
@@ -85,6 +86,17 @@ try {
   check(
     tools.every((t) => t.description && t.inputSchema?.type === 'object'),
     'tools/list: every tool has a description and an object input schema',
+  );
+  check(
+    tools.every(
+      (t) =>
+        typeof t.annotations?.readOnlyHint === 'boolean' &&
+        typeof t.annotations?.openWorldHint === 'boolean' &&
+        (t.annotations.readOnlyHint ||
+          (typeof t.annotations.destructiveHint === 'boolean' &&
+            typeof t.annotations.idempotentHint === 'boolean')),
+    ),
+    'tools/list: every tool has explicit safety annotations',
   );
 
   // 3a. Read round-trip. The index builds at startup; retry briefly in case


### PR DESCRIPTION
## TL;DR

Adds MCP-standard `ToolAnnotations` to all 19 existing Seekstone tools so clients do not have to apply pessimistic defaults to known local-vault operations. This is metadata only: tool behavior, schemas, permissions, and vault writes remain unchanged. I found the gap while using Seekstone from Codex and ChatGPT through an MCP gateway; thanks for the great work by the way!

## What & why

Seekstone currently advertises all 19 MCP tools without `ToolAnnotations`. MCP defines conservative defaults for omitted annotations: tools are treated as write-capable, potentially destructive, non-idempotent, and open-world. Clients can therefore present safe local operations such as `search`, `read_note`, and `append_note` with stronger warnings or confirmation behavior than their real effects warrant.

I encountered this while using Seekstone as a local Obsidian backend for Codex and ChatGPT through a Streamable HTTP MCP gateway. ChatGPT displayed `append_note` as **PUBLIC WRITE**, **OPEN WORLD**, and **DESTRUCTIVE**, then stopped attempted note writes before they reached the gateway. Gateway logs confirmed that its own policy allowed Seekstone tools; missing backend annotations were the metadata gap.

This PR adds explicit, conservative MCP safety annotations to every existing tool. It changes metadata only: no tool names, input schemas, handlers, write policy, or vault behavior change.

I used Codex Sol extensively to trace the behavior across Seekstone, the gateway, and the client; implement the annotations and tests; run validation; and draft this description. I set the scope, made the classification decisions, and reviewed the resulting diff.

## Classification basis

This classification comes from the MCP [`ToolAnnotations`](https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations) contract, not from a ChatGPT-specific API. MCP defines these fields as client-facing hints: `readOnlyHint` says whether a tool can modify its environment, `destructiveHint` distinguishes destructive updates from additive ones, `idempotentHint` says whether repeating a call with the same arguments has further effects, and `openWorldHint` says whether a tool may interact with entities outside a closed domain. Omitted fields receive conservative defaults.

The mapping is based on each Seekstone tool's accepted inputs and possible handler effects, not only its common path. A mixed-mode tool receives the classification of its most consequential permitted path. This is why the mapping is valid even when a caller does not exercise the write or overwrite option:

- Pure retrieval tools advertise `readOnlyHint: true`.
- Every tool advertises `openWorldHint: false` because Seekstone operates only on the configured local vault and makes no network calls.
- `append_note` and `append_periodic_note` advertise additive, non-idempotent writes.
- Tools that can overwrite, remove, replace, rename, or rewrite content remain destructive.
- `patch_frontmatter` is destructive because it can replace or delete values, but idempotent for repeated identical patches.
- Mixed-mode tools stay conservative: `create_note` remains destructive because `overwrite: true` exists, and `get_periodic_note` remains write-capable because `createIfMissing: true` can create a note.

These hints are advisory, not authorization. Claude Desktop, Claude Code, and other MCP clients may retain separate permission settings, while Seekstone still enforces `SEEKSTONE_READ_ONLY` and `SEEKSTONE_WRITE_PATHS`. For remote clients reached through a transparent gateway, annotations survive `tools/list` proxying and describe Seekstone's actual local-vault behavior without requiring client-specific handling.

## How it was tested

- Live interoperability smoke test through ChatGPT and the deployed Levitate gateway — against the patched Seekstone build, ChatGPT created a temporary note, read back its exact content, and deleted it through Seekstone's recoverable trash behavior. Levitate logs confirmed a successful OAuth refresh and that the create/read calls reached the gateway and were allowed. Combined with the earlier pre-gateway block, this is strong before/after evidence consistent with the annotations correcting pessimistic client treatment, though not a controlled A/B proof of client-side policy behavior.
- `npm test` — 69 test files passed; 781 tests passed and 8 existing harness tests skipped.
- `npm run lint` — clean; Biome reported only the existing schema-version informational message.
- `npm run format` — no fixes needed.
- `npx tsc -p packages/server/tsconfig.json --noEmit` — clean.
- `npm run build -w seekstone` — publishable bundle built successfully.
- `npm run conformance` — serialized `tools/list` exposed all 19 tools with explicit safety annotations; search and append round-trips passed against a scratch vault.
- `npm run check:docs` — all 23 documentation surfaces remained synchronized.

## Not included

MCP tool descriptors can also advertise an `outputSchema`. Adding one correctly would require designing stable result objects and returning matching `structuredContent` while preserving current text `content` for existing clients. That is useful interoperability work, but separate from safety annotations and intentionally excluded to keep this PR reviewable.

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Typecheck passes (`npx tsc -p packages/server/tsconfig.json --noEmit`)
- [x] Tests added/updated for the change
- [x] Added a patch changeset
- [x] No new network calls or telemetry in the server
