### PR TITLE
fix(ci): migrate release.yml to changesets/action v2 input names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,10 @@ jobs:
         id: changesets
         uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          version: npm run version-packages
-          publish: npm run release
-          commit: 'chore: version packages'
-          title: 'chore: version packages'
+          version-script: npm run version-packages
+          publish-script: npm run release
+          commit-message: 'chore: version packages'
+          pr-title: 'chore: version packages'
         env:
           # The App token is the API token changesets uses to open the "Version
           # Packages" PR, so its author is the App bot rather than github-actions[bot].


### PR DESCRIPTION
## Why

PR #252 bumped `changesets/action` from v1.9.0 to v2.1.0, which renamed its inputs. Every Release run on main since that merge has failed fast with:

> This version of the Changesets action is designed to work with Changesets CLI v3…

and, after #250 landed CLI v3:

> The following inputs have been renamed…

## What

Renames the four inputs in `.github/workflows/release.yml`:

| v1 | v2 |
|---|---|
| `version` | `version-script` |
| `publish` | `publish-script` |
| `commit` | `commit-message` |
| `title` | `pr-title` |

No behavior change otherwise: the `published` output used by the downstream MCPB/attestation/release steps is unchanged in v2, CLI v3 is already in the lockfile (#250), and `.changeset/config.json` needs no migration (no `prettier` key). No changeset needed — workflow-only change, nothing published to npm is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpTR72k1xtJLUm36BqQYtN