### PR TITLE
fix(ci): pass App token via changesets/action v2 github-token input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,13 +103,15 @@ jobs:
           publish-script: npm run release
           commit-message: 'chore: version packages'
           pr-title: 'chore: version packages'
-        env:
           # The App token is the API token changesets uses to open the "Version
           # Packages" PR, so its author is the App bot rather than github-actions[bot].
           # This pairs with the same token on the checkout step above: authoring the PR
           # via the App is not enough on its own — the branch must also be PUSHED with it
-          # (see that comment) for the required pull_request CI to fire.
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # (see that comment) for the required pull_request CI to fire. Since action
+          # v2 the token goes through this input; a GITHUB_TOKEN env var that differs
+          # from it is a hard error.
+          github-token: ${{ steps.app-token.outputs.token }}
+        env:
           NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Build MCP Bundle


### PR DESCRIPTION
Follow-up to #254. changesets/action v2 hard-errors when the `GITHUB_TOKEN` env var is set and differs from its `github-token` input:

> The GITHUB_TOKEN environment variable is set and does not match the "github-token" input.

This moves the App token from `env.GITHUB_TOKEN` to the `github-token` input (v2's supported path — same token, same semantics: PR authored and branch pushed as the App bot so required CI fires on the version PR). `NPM_CONFIG_PROVENANCE` stays in `env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpTR72k1xtJLUm36BqQYtN