### PR TITLE
fix(deps): bump transitive nanoid to 3.3.18 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4593,9 +4593,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -6110,7 +6110,7 @@
     },
     "packages/server": {
       "name": "seekstone",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",


### PR DESCRIPTION
Resolves Scorecard code-scanning alert #28 (Vulnerabilities, high).

- `nanoid@3.3.17` → `3.3.18` — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8): custom generators can loop indefinitely when size is zero.
- Dev-only transitive dep (`tsup → postcss → nanoid`); not shipped in the published bundle, so no changeset.
- Also syncs the lockfile's `packages/server` entry to 0.13.1 (left stale by the Version Packages merge).

Verified: `npm ls nanoid` shows 3.3.18 only; build + full test suite green (787 tests).

Linear: SHA-301