### PR TITLE
fix(ci): drop unpinned npm self-upgrade from release workflow (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,20 @@ jobs:
       # automatic OIDC trusted publishing handle auth against the default registry.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
-      # OIDC trusted publishing requires npm >= 11.5.1.
-      - name: Upgrade npm
-        run: npm install -g npm@11.16.0
+      # OIDC trusted publishing requires npm >= 11.5.1. Node 24 has bundled a
+      # qualifying npm since 24.7.0, so no global npm upgrade is needed — but
+      # fail fast if a runner ever resolves an older toolchain, because the
+      # publish would otherwise fail late (or worse, unauthenticated → E404).
+      - name: Assert npm supports OIDC trusted publishing
+        run: |
+          v="$(npm --version)"
+          if [ "$(printf '%s\n' 11.5.1 "$v" | sort -V | head -1)" != "11.5.1" ]; then
+            echo "::error::npm $v < 11.5.1 — too old for OIDC trusted publishing"
+            exit 1
+          fi
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Resolves Scorecard code-scanning alert #24 (Pinned-Dependencies, medium) on `release.yml`.

- `setup-node` → `node-version: '24'` (LTS). Latest 24.x bundles npm 11.17.0; every 24.x since 24.7.0 bundles ≥ 11.5.1, the OIDC trusted-publishing minimum.
- Deletes the `npm install -g npm@11.16.0` step — the unpinned command disappears rather than being suppressed.
- Adds a fail-fast assertion that bundled npm ≥ 11.5.1, so a runner resolving an older toolchain fails loudly at setup instead of late in publish (or unauthenticated → E404).
- Root + server `engines` are `>=22`, changesets v3 requires `^22.11 || ^24 || >=26` — Node 24 satisfies both.

Note: the publish path itself only fully exercises on the next real release; the version assertion is the guard for that.

Linear: SHA-302