### PR TITLE
test(core): add fast-check property tests for frontmatter + extractors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@changesets/cli": "^3.0.0",
         "@types/node": "^26.2.0",
         "@vitest/coverage-v8": "^4.1.10",
+        "fast-check": "^4.9.0",
         "tsup": "^8.3.5",
         "tsx": "^4.23.12",
         "typescript": "^7.0.2",
@@ -3491,6 +3492,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4876,6 +4900,23 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -6110,7 +6151,7 @@
     },
     "packages/server": {
       "name": "seekstone",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@changesets/cli": "^3.0.0",
     "@types/node": "^26.2.0",
     "@vitest/coverage-v8": "^4.1.10",
+    "fast-check": "^4.9.0",
     "tsup": "^8.3.5",
     "tsx": "^4.23.12",
     "typescript": "^7.0.2",

--- a/packages/core/src/extract.property.test.ts
+++ b/packages/core/src/extract.property.test.ts
@@ -1,0 +1,189 @@
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import {
+  extractInlineTags,
+  extractLinksWithLines,
+  extractUrls,
+  extractWikilinks,
+  frontmatterTags,
+} from './extract.js';
+
+// Fixed seed keeps CI deterministic (repo convention — same reason the
+// fixture vault pins seed 42). Bump numRuns locally when hunting.
+fc.configureGlobal({ seed: 42, numRuns: 200 });
+
+/** Wikilink target: anything the WIKILINK_RE target group accepts, minus `[`
+ * so a generated target can't open a nested match at a shifted position. */
+const linkTarget = fc
+  .string({ minLength: 1, maxLength: 60 })
+  .filter((s) => !/[[\]|#\n]/.test(s) && s.trim().length > 0);
+
+/** Filler that can never form or terminate a wikilink. */
+const filler = fc.string({ maxLength: 40 }).filter((s) => !/[[\]\n]/.test(s));
+
+describe('extractWikilinks properties', () => {
+  it('is total and never yields a delimiter inside a field', () => {
+    fc.assert(
+      fc.property(fc.string({ unit: 'binary' }), (body) => {
+        for (const link of extractWikilinks(body)) {
+          expect(link.target).not.toMatch(/[\]|#\n]/);
+          if (link.fragment !== null) expect(link.fragment).not.toMatch(/[\]|\n]/);
+          if (link.alias !== null) expect(link.alias).not.toMatch(/[\]\n]/);
+        }
+      }),
+    );
+  });
+
+  it('extracts constructed links in order with correct fields', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            target: linkTarget,
+            fragment: fc.option(linkTarget),
+            alias: fc.option(linkTarget),
+            pad: filler,
+          }),
+          { minLength: 1, maxLength: 10 },
+        ),
+        (specs) => {
+          const body = specs
+            .map(
+              (s) =>
+                `${s.pad}[[${s.target}${s.fragment ? `#${s.fragment}` : ''}${
+                  s.alias ? `|${s.alias}` : ''
+                }]]`,
+            )
+            .join(' and ');
+          const links = extractWikilinks(body);
+          expect(links.map((l) => l.target)).toEqual(specs.map((s) => s.target.trim()));
+          expect(links.map((l) => l.fragment)).toEqual(
+            specs.map((s) => (s.fragment ? s.fragment.trim() : null)),
+          );
+          expect(links.map((l) => l.alias)).toEqual(
+            specs.map((s) => (s.alias ? s.alias.trim() : null)),
+          );
+        },
+      ),
+    );
+  });
+});
+
+describe('extractLinksWithLines properties', () => {
+  it('reports 1-indexed line numbers within the file', () => {
+    fc.assert(
+      fc.property(
+        fc.array(filler, { maxLength: 20 }),
+        linkTarget,
+        fc.nat({ max: 20 }),
+        (lines, target, at) => {
+          const insertAt = Math.min(at, lines.length);
+          const withLink = [...lines];
+          withLink.splice(insertAt, 0, `see [[${target}]] here`);
+          const records = extractLinksWithLines(withLink.join('\n'));
+          expect(records).toHaveLength(1);
+          expect(records[0]?.target).toBe(target.trim());
+          expect(records[0]?.line).toBe(insertAt + 1);
+          expect(records[0]?.linkType).toBe('wikilink');
+        },
+      ),
+    );
+  });
+
+  it('is total on arbitrary input and lines stay in range', () => {
+    fc.assert(
+      fc.property(fc.string({ unit: 'binary' }), (raw) => {
+        const lineCount = raw.split('\n').length;
+        for (const record of extractLinksWithLines(raw)) {
+          expect(record.line).toBeGreaterThanOrEqual(1);
+          expect(record.line).toBeLessThanOrEqual(lineCount);
+        }
+      }),
+    );
+  });
+});
+
+describe('extractUrls properties', () => {
+  it('never returns a URL with trailing punctuation and only http(s) schemes', () => {
+    fc.assert(
+      fc.property(fc.string({ unit: 'binary' }), (body) => {
+        for (const url of extractUrls(body)) {
+          expect(url).toMatch(/^https?:\/\//);
+          expect(url).not.toMatch(/[.,;:!?)]$/);
+        }
+      }),
+    );
+  });
+});
+
+describe('extractInlineTags properties', () => {
+  it('only yields tags Obsidian would accept', () => {
+    fc.assert(
+      fc.property(fc.string({ unit: 'binary' }), (body) => {
+        for (const tag of extractInlineTags(body)) {
+          expect(tag).toMatch(/^[A-Za-z_][\w/-]*$/);
+        }
+      }),
+    );
+  });
+});
+
+describe('frontmatterTags properties', () => {
+  const tagValue = fc
+    .string({ minLength: 1, maxLength: 20 })
+    .filter((s) => !/[\s,]/.test(s) && !s.startsWith('#'));
+
+  it('strips a single leading # from list-form tags', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.tuple(fc.boolean(), tagValue).map(([hash, t]) => (hash ? `#${t}` : t)),
+          { maxLength: 8 },
+        ),
+        (tags) => {
+          expect(frontmatterTags({ tags })).toEqual(tags.map((t) => t.replace(/^#/, '')));
+        },
+      ),
+    );
+  });
+
+  it('splits string-form tags on whitespace/commas with no empty results', () => {
+    fc.assert(
+      fc.property(
+        fc.array(tagValue, { minLength: 1, maxLength: 8 }),
+        fc.constantFrom(' ', ', ', ',', '  '),
+        (tags, sep) => {
+          expect(frontmatterTags({ tags: tags.join(sep) })).toEqual(tags);
+        },
+      ),
+    );
+  });
+});
+
+// Regression guards for the polynomial-ReDoS findings fixed in code-scanning
+// alerts #25/#26 — the exact adversarial shapes CodeQL flagged, at a size
+// that ran for minutes pre-fix. Wall-clock bound is deliberately generous so
+// slow CI runners can't flake it; a backtracking regression blows past it by
+// orders of magnitude.
+describe('ReDoS regression (bounded runtime on adversarial input)', () => {
+  const BUDGET_MS = 2000;
+
+  it.each([
+    ['unclosed openers', '[['.repeat(25_000)],
+    ['openers with quote-hash tail', '[["#'.repeat(12_500)],
+    ['embed bangs', `${'!'.repeat(25_000)}[[x]]`],
+    ['opener then bang flood', `[[${'!'.repeat(50_000)}`],
+  ])('extractors stay fast on %s', (_name, body) => {
+    const start = performance.now();
+    extractWikilinks(body);
+    extractLinksWithLines(body);
+    expect(performance.now() - start).toBeLessThan(BUDGET_MS);
+  });
+
+  it('extractUrls stays fast on punctuation floods', () => {
+    const body = `https://example.com/${'.'.repeat(50_000)}`;
+    const start = performance.now();
+    extractUrls(body);
+    expect(performance.now() - start).toBeLessThan(BUDGET_MS);
+  });
+});

--- a/packages/core/src/frontmatter.property.test.ts
+++ b/packages/core/src/frontmatter.property.test.ts
@@ -1,0 +1,88 @@
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { stringify as stringifyYaml } from 'yaml';
+import { parseFrontmatter } from './frontmatter.js';
+
+// Fixed seed keeps CI deterministic (repo convention — same reason the
+// fixture vault pins seed 42). Bump numRuns locally when hunting.
+fc.configureGlobal({ seed: 42, numRuns: 200 });
+
+/** Plain string→string mapping with yaml-friendly keys; values are arbitrary
+ * unicode so quoting, escaping, and scalar folding all get exercised. */
+const fmObject = fc.dictionary(fc.stringMatching(/^[a-z][a-zA-Z0-9_-]{0,15}$/), fc.string(), {
+  minKeys: 1,
+  maxKeys: 8,
+});
+
+/** A note built from a known frontmatter object and a known body. */
+const constructedNote = fc.tuple(fmObject, fc.string()).map(([data, body]) => ({
+  data,
+  body,
+  text: `---\n${stringifyYaml(data)}---\n${body}`,
+}));
+
+describe('parseFrontmatter properties', () => {
+  it('is total and self-consistent on arbitrary input', () => {
+    fc.assert(
+      fc.property(fc.string({ unit: 'binary' }), (text) => {
+        const r = parseFrontmatter(text);
+        // bodyStart 0 always means "the whole file is the body".
+        if (r.bodyStart === 0) expect(r.body).toBe(text);
+        // Otherwise the offset must reconstruct the input exactly — this is
+        // the invariant byte-faithful writers depend on.
+        else expect(text.slice(0, r.bodyStart) + r.body).toBe(text);
+        if (!r.present) {
+          expect(r.data).toBeNull();
+          expect(r.malformed).toBe(false);
+          expect(r.bodyStart).toBe(0);
+        }
+        expect(r.keys).toEqual(r.data ? Object.keys(r.data) : []);
+        if (r.data !== null) expect(r.malformed).toBe(false);
+      }),
+    );
+  });
+
+  it('round-trips a constructed frontmatter block', () => {
+    fc.assert(
+      fc.property(constructedNote, ({ data, body, text }) => {
+        const r = parseFrontmatter(text);
+        expect(r.present).toBe(true);
+        expect(r.malformed).toBe(false);
+        expect(r.data).toEqual(data);
+        expect(r.body).toBe(body);
+        expect(text.slice(r.bodyStart)).toBe(body);
+      }),
+    );
+  });
+
+  it('keeps the frontmatter region stable under body append (write-safety contract)', () => {
+    fc.assert(
+      fc.property(constructedNote, fc.string({ minLength: 1 }), ({ text }, marker) => {
+        const before = parseFrontmatter(text);
+        const after = parseFrontmatter(text + marker);
+        expect(after.bodyStart).toBe(before.bodyStart);
+        expect((text + marker).slice(0, after.bodyStart)).toBe(text.slice(0, before.bodyStart));
+        expect(after.body).toBe(before.body + marker);
+        expect(after.keys).toEqual(before.keys);
+      }),
+    );
+  });
+
+  it('treats an unterminated block as malformed with the whole file as body', () => {
+    fc.assert(
+      fc.property(
+        fc
+          .string()
+          .filter((s) => !`\n${s}`.includes('\n---\n') && !`\r\n${s}`.includes('\r\n---\r\n')),
+        (rest) => {
+          const text = `---\n${rest}`;
+          const r = parseFrontmatter(text);
+          expect(r.present).toBe(true);
+          expect(r.malformed).toBe(true);
+          expect(r.bodyStart).toBe(0);
+          expect(r.body).toBe(text);
+        },
+      ),
+    );
+  });
+});


### PR DESCRIPTION
Adds property-based tests (fast-check) for `packages/core` — 17 new tests, all running under the existing vitest setup with a fixed seed (42) so CI stays deterministic.

**What's covered**
- `parseFrontmatter`: the reconstruction invariant (`text.slice(0, bodyStart) + body === text`) that byte-faithful writers depend on; yaml round-trip of constructed frontmatter blocks; frontmatter-region stability under body append (the write-safety contract); unterminated-block handling; totality on arbitrary unicode input.
- Extractors: delimiter invariants on arbitrary input, ordered extraction of constructed `[[target#fragment|alias]]` links, 1-indexed line attribution in `extractLinksWithLines`, URL trailing-punctuation stripping, inline-tag validity, `frontmatterTags` list/string forms.
- ReDoS regression guards: the exact adversarial input shapes from the fixed CodeQL polynomial-ReDoS findings (alerts #25/#26), pinned to a generous wall-clock budget so a backtracking regression fails loudly without flaking slow runners.

**Why**
Beyond the direct coverage, this satisfies the OpenSSF Scorecard Fuzzing check (code-scanning alert #21) — Scorecard recognizes fast-check property testing as a fuzzing integration.

Dev-only dependency; no changeset (nothing published changes).

Linear: SHA-303