### PR TITLE
test(server): extend watcher nudge mitigation to the create-shape tests still flaking on CI

### DIFF
--- a/packages/server/src/watcher.test.ts
+++ b/packages/server/src/watcher.test.ts
@@ -74,12 +74,27 @@ afterEach(async () => {
 // starving the event loop.
 describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
   it('indexes a new .md file created after startup', async () => {
+    // Create-after-ready shape: under usePolling this is the only event kind
+    // that needs a parent-dir rescan, so it gets the nudge mitigation and the
+    // rawEvents diagnostics (SHA-242 gave them to the nested/spaced tests;
+    // this one kept flaking on CI without them — SHA-275).
     const ctx = freshCtx(tmpDir);
-    const { stop, ready } = startWatcher(ctx, undefined, { usePolling: true });
+    const rawEvents: string[] = [];
+    const { stop, ready } = startWatcher(ctx, undefined, {
+      usePolling: true,
+      onRawEvent: (event, abs, rel) => rawEvents.push(`${event} abs=${abs} rel=${rel}`),
+    });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await writeFile(join(tmpDir, 'watch-new.md'), 'watcher_unique_abc', 'utf8');
-      await waitFor(() => ctx.notes.has('watch-new.md'));
+      try {
+        await waitFor(() => ctx.notes.has('watch-new.md'), { nudge: dirNudger(tmpDir) });
+      } catch {
+        throw new Error(
+          `waitFor timeout — diagnostics:\n  platform=${process.platform} sep=${JSON.stringify(sep)}\n  vaultRoot=${tmpDir}\n  ctx.notes keys=[${[...ctx.notes.keys()].join(', ')}]\n  rawEvents(${rawEvents.length}):\n    ${rawEvents.join('\n    ') || '(none)'}`,
+        );
+      }
       expect(ctx.index.search('watcher_unique_abc').some((h) => h.id === 'watch-new.md')).toBe(
         true,
       );
@@ -199,13 +214,28 @@ describe.skipIf(process.env.SEEKSTONE_COVERAGE === '1')('startWatcher', () => {
       info: noop,
       debug: (msg: string, fields?: Record<string, unknown>) => events.push({ msg, fields }),
     };
-    const { stop, ready } = startWatcher(ctx, log, { usePolling: true });
+    // Same create-after-ready shape as the first test, observed through the
+    // logger instead of ctx.notes — needs the same nudge + diagnostics
+    // (SHA-275; nudge files are non-.md so they never produce 'index updated').
+    const rawEvents: string[] = [];
+    const { stop, ready } = startWatcher(ctx, log, {
+      usePolling: true,
+      onRawEvent: (event, abs, rel) => rawEvents.push(`${event} abs=${abs} rel=${rel}`),
+    });
     try {
       await ready;
+      await new Promise((r) => setImmediate(r));
       await writeFile(join(tmpDir, 'watch-log.md'), 'logged_body_qrs', 'utf8');
-      await waitFor(() =>
-        events.some((e) => e.msg === 'index updated' && e.fields?.path === 'watch-log.md'),
-      );
+      try {
+        await waitFor(
+          () => events.some((e) => e.msg === 'index updated' && e.fields?.path === 'watch-log.md'),
+          { nudge: dirNudger(tmpDir) },
+        );
+      } catch {
+        throw new Error(
+          `waitFor timeout — diagnostics:\n  platform=${process.platform} sep=${JSON.stringify(sep)}\n  vaultRoot=${tmpDir}\n  ctx.notes keys=[${[...ctx.notes.keys()].join(', ')}]\n  rawEvents(${rawEvents.length}):\n    ${rawEvents.join('\n    ') || '(none)'}`,
+        );
+      }
       expect(ctx.notes.has('watch-log.md')).toBe(true);
       expect(
         events.some((e) => e.msg === 'index updated' && e.fields?.path === 'watch-log.md'),


### PR DESCRIPTION
Fixes the SHA-275 flake: three 60s `waitFor` timeouts over ~2 weeks (Windows + Ubuntu PR CI, and one blocking the 0.13.1 release publish gate).

**Diagnosis**

The two flaking tests — `indexes a new .md file created after startup` and `logs index updates through an injected logger` — are exactly the two **create-after-ready** tests that the SHA-242/#188 mitigation skipped. #188 established the failure mode: under `usePolling`, creation is the only event shape that requires chokidar to rescan the parent directory, and a single dir-mtime transition can slip past a poll tick and stay invisible forever. Consistent with that: the two tests #188 nudged (nested folder, spaced vault) stopped flaking, and the modify/delete tests never flake because the target file is already stat-polled. The suite forces `usePolling: true` on every OS, which is why Ubuntu hits it too — this was never Windows-specific.

**Fix**

Apply the established treatment to both tests:
- `dirNudger` nudges (a fresh non-.md sibling every ~2s creates a new directory transition for the rescan to catch; non-.md means the nudge can never satisfy either wait condition itself)
- the `rawEvents` diagnostics block, so a future timeout reports what chokidar actually emitted instead of a bare `waitFor timeout`

A genuine event-silencing regression (like the SHA-144 8.3-path bug) still fails loudly: nudges change the directory, but a silenced watcher delivers nothing.

No retries, per the #188 convention. Verified: 15/15 stress runs of the watcher suite locally + full test suite green.

Linear: SHA-275