### PR TITLE
SHA-307: ship semantic search — mode on search, vector cache, watcher re-embeds

### DIFF
--- a/.changeset/semantic-search-mode.md
+++ b/.changeset/semantic-search-mode.md
@@ -1,0 +1,5 @@
+---
+"seekstone": minor
+---
+
+Local semantic search, opt-in and fully offline. With `SEEKSTONE_SEMANTIC=1`, the `search` tool gains `mode: "semantic"` (meaning-based search — a description like "instrument that measures wind speed" finds the Anemometer note even when no words match) and `mode: "hybrid"` (exact-title lookups stay lexical, everything else goes semantic). Powered by an in-process Model2Vec embedding model downloaded once via the new `seekstone fetch-model` subcommand — the running server never touches the network, keeping the zero-network guarantee intact. The vault embeds in the background at boot and is cached per-vault (keyed by content hash) so restarts are instant; the file watcher re-embeds changed notes incrementally. Semantic hits return the same lean ranked-excerpt payloads, with excerpts drawn from the matching passage rather than the note head. On the 10k-note benchmark vault, semantic mode answers description-style queries at 70% hit@5 vs lexical's 30%, at ~14 ms warm.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ The **server** has a real build — `npm run build -w seekstone` bundles it (and
 - `SEEKSTONE_REST_API_KEY` — required when invoking the `rest` backend; from the Local REST API plugin settings tab.
 - `SEEKSTONE_REST_URL` — defaults to `https://127.0.0.1:27124`. The plugin ships a self-signed cert; the adapter accepts it via an isolated `undici.Agent`, never by setting `NODE_TLS_REJECT_UNAUTHORIZED`.
 
-The **server** reads its own set (`SEEKSTONE_VAULT`, `SEEKSTONE_READ_ONLY`, `SEEKSTONE_WRITE_PATHS`, `SEEKSTONE_LOG_LEVEL`, `SEEKSTONE_LOG_FILE`, `SEEKSTONE_LOG_MAX_SIZE`, `SEEKSTONE_WATCH_POLL`) — documented in the README's Configuration table. Write behavior to know before editing tools: deletes are recoverable (`.trash/`), edits support `prevHash` compare-and-swap, moves rewrite inbound links, and every write is policy-gated + atomic (see `docs/ARCHITECTURE.md` §2).
+The **server** reads its own set (`SEEKSTONE_VAULT`, `SEEKSTONE_READ_ONLY`, `SEEKSTONE_WRITE_PATHS`, `SEEKSTONE_LOG_LEVEL`, `SEEKSTONE_LOG_FILE`, `SEEKSTONE_LOG_MAX_SIZE`, `SEEKSTONE_WATCH_POLL`, `SEEKSTONE_SEMANTIC`, `SEEKSTONE_MODEL_PATH`, `SEEKSTONE_CACHE_DIR`) — documented in the README's Configuration table. Write behavior to know before editing tools: deletes are recoverable (`.trash/`), edits support `prevHash` compare-and-swap, moves rewrite inbound links, and every write is policy-gated + atomic (see `docs/ARCHITECTURE.md` §2).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ It reads your vault **directly from disk** rather than routing through the Obsid
 - **Speed.** Searches return in **single-digit milliseconds** warm — up to **~440× faster** than every other Obsidian MCP server we benchmarked, because there's no subprocess to spawn and no HTTP round-trip per query.
 - **Context.** A broad search that returns **tens of megabytes** and millions of tokens via a REST-proxy server returns **~2 KB** via Seekstone — up to a **~47,000× reduction** that only widens as your vault grows.
 
-Search comes in two modes: ranked **full-text search** (fuzzy and prefix matching), and **structured metadata queries** — `query_notes` filters by frontmatter properties (`status`, `due`, `type`, …), tags, folder, modified time, and size, answering questions like *"which draft notes changed this week?"* in a few hundred bytes instead of a search-and-read loop.
+Search comes in three modes: ranked **full-text search** (fuzzy and prefix matching), optional **local semantic search** (meaning-based, via a small on-device embedding model — opt-in, fully offline), and **structured metadata queries** — `query_notes` filters by frontmatter properties (`status`, `due`, `type`, …), tags, folder, modified time, and size, answering questions like *"which draft notes changed this week?"* in a few hundred bytes instead of a search-and-read loop.
 
 Claude can search and read your entire note library, in milliseconds, without burning most of its context window on a single tool call.
 
@@ -291,7 +291,7 @@ Claude never sees your full vault at once — it searches and reads selectively,
 
 | Tool | Description |
 |---|---|
-| `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy and prefix matching. |
+| `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy and prefix matching; with `SEEKSTONE_SEMANTIC=1`, `mode: "semantic"`/`"hybrid"` searches by meaning via a local embedding model (nothing leaves your machine). |
 | `query_notes` | Structured metadata query. Filter by frontmatter key/value predicates (`eq`, `ne`, `contains`, `exists`, `missing`, `gt`/`gte`/`lt`/`lte`), tag, folder, modified time, and size; sort and select the fields you need. Returns compact rows (path + title by default), not note content. |
 | `context_pack` | Answer-ready context for a natural-language question in one call, hard-capped at a byte budget (default 2 KB): ranked excerpts, linked neighbor notes with one-line summaries, and follow-up source paths — replaces a search → read → get_backlinks round-trip loop. |
 | `read_note` | Read the full content of a note by vault-relative path. Supports returning a single section, block, or line range. |
@@ -337,6 +337,9 @@ Every write tool (`append_note`, `patch_note`, `patch_frontmatter`, `replace_in_
 | `SEEKSTONE_WATCH_POLL` | No | Set to `1` to stat-poll for changes instead of native OS events — slower but reliable on network drives, WSL, and some containers. |
 | `SEEKSTONE_READ_ONLY` | No | Set to `1` to run read-only: the 9 write tools are unregistered from the tool list entirely (and rejected if called anyway), so the session provably cannot modify your vault. |
 | `SEEKSTONE_WRITE_PATHS` | No | Comma-separated vault-relative globs (e.g. `journal/**,inbox/*.md`). Writes are permitted only under matching paths; the rest of the vault stays read-only. |
+| `SEEKSTONE_SEMANTIC` | No | Set to `1` to enable semantic search (`search` gains `mode: "semantic"` and `"hybrid"`). Requires the local embedding model — download it once with `npx -y seekstone fetch-model`; the running server never touches the network. |
+| `SEEKSTONE_MODEL_PATH` | No | Directory holding the Model2Vec embedding model (default: where `fetch-model` puts it, under the cache dir). |
+| `SEEKSTONE_CACHE_DIR` | No | Cache root for the downloaded model and per-vault embedding caches (default `~/.cache/seekstone`). |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,11 +112,12 @@ flowchart TD
 **Layer responsibilities**
 
 1. **Bootstrap (`index.ts`)** — the executable entry. Handles `version` / `help`
-   / `init` CLI intents (which print and exit before any server starts), then
-   for an MCP session: requires `SEEKSTONE_VAULT`, parses the write policy
-   (`policy.ts` — `SEEKSTONE_READ_ONLY`, `SEEKSTONE_WRITE_PATHS`), installs
-   process guards (a stray unhandled rejection must not kill a long-lived stdio
-   session), builds the index, constructs the `ServerContext`, starts the
+   / `init` / `fetch-model` CLI intents (which print and exit before any server
+   starts), then for an MCP session: requires `SEEKSTONE_VAULT`, parses the
+   write policy (`policy.ts` — `SEEKSTONE_READ_ONLY`, `SEEKSTONE_WRITE_PATHS`),
+   installs process guards (a stray unhandled rejection must not kill a
+   long-lived stdio session), builds the index, constructs the `ServerContext`,
+   optionally starts the semantic index (`SEEKSTONE_SEMANTIC=1`), starts the
    watcher, and wires the `@modelcontextprotocol/sdk` `Server` to a
    `StdioServerTransport` with `ListTools` + `CallTool` handlers. `ListTools`
    answers from `tool-list.ts` (`visibleTools(policy)` — in read-only mode the
@@ -126,11 +127,19 @@ flowchart TD
    (path → `IndexedNote`), and a `backlinks` reverse-link map. This is the
    in-memory model every read tool queries.
 3. **`ServerContext` (`context.ts`)** — the single shared state bag:
-   `{ vaultRoot, index, notes, backlinks, policy }`. No globals; it's threaded
-   into every tool call.
+   `{ vaultRoot, index, notes, backlinks, policy, semantic? }`. No globals;
+   it's threaded into every tool call.
 4. **Watcher (`watcher.ts`)** — chokidar watches the vault and incrementally
    updates `index` / `notes` / `backlinks` so the in-memory model never goes
-   stale during a session.
+   stale during a session; when semantic search is enabled it also pokes the
+   semantic index's debounced re-embed queue.
+   4b. **Semantic index (`semantic/`, opt-in)** — a local Model2Vec embedder
+   (`@seekstone/core/embed`; model fetched out-of-band by `seekstone
+   fetch-model`, never by the running server) plus a per-note chunk-vector
+   store. Built in the background at boot; persisted to a per-vault
+   `(path, contentHash)`-keyed cache under `SEEKSTONE_CACHE_DIR` so restarts
+   don't re-embed. `search`'s `mode: semantic` scans it; `mode: hybrid`
+   routes exact-title lookups to lexical and everything else here.
 5. **Dispatch (`dispatch.ts`)** — the routing seam. `dispatch()` wraps the
    per-tool `run()` switch with `performance.now()` timing, structured logging
    (content/query args are debug-only — never logged at info), payload-byte

--- a/llms.txt
+++ b/llms.txt
@@ -51,7 +51,7 @@ Or add the same `mcpServers` JSON block as Claude Desktop to `~/.cursor/mcp.json
 ## Tools (19)
 
 Read:
-- `search` — full-text search returning ranked excerpts, ~120 chars by default and tunable (not full notes)
+- `search` — full-text search returning ranked excerpts, ~120 chars by default and tunable (not full notes); optional `mode: "semantic"`/`"hybrid"` for meaning-based search via a local embedding model (`SEEKSTONE_SEMANTIC=1` + one-time `npx -y seekstone fetch-model`; fully offline at runtime)
 - `query_notes` — structured metadata query: filter notes by frontmatter key/value predicates, tag, folder, modified time, and size; returns compact rows (path + title by default), not note content
 - `context_pack` — answer-ready context for a natural-language question in one call, hard-capped at a byte budget (default 2048): ranked excerpts, linked neighbor notes with one-line summaries, and follow-up source paths
 - `read_note` — read the full content of a note by vault-relative path; supports section, block, or line-range slices

--- a/packages/core/src/embed/chunk.test.ts
+++ b/packages/core/src/embed/chunk.test.ts
@@ -40,8 +40,35 @@ describe('chunkNote', () => {
   });
 
   it('returns a title-only chunk for an empty body', () => {
-    expect(chunkNote('Asolo', '')).toEqual([{ text: 'Asolo', words: 0 }]);
-    expect(chunkNote('Asolo', '\n\n  \n')).toEqual([{ text: 'Asolo', words: 0 }]);
+    expect(chunkNote('Asolo', '')).toEqual([{ text: 'Asolo', words: 0, start: 0, end: 0 }]);
+    expect(chunkNote('Asolo', '\n\n  \n')).toEqual([{ text: 'Asolo', words: 0, start: 0, end: 0 }]);
+  });
+
+  it('reports exact body spans so consumers can slice the matching window', () => {
+    const body = `  ${para(10, 'alpha')}  \n\n${para(260, 'beta')}\n\n${para(10, 'gamma')}`;
+    const chunks = chunkNote('T', body);
+    for (const c of chunks) {
+      const sliced = body.slice(c.start, c.end);
+      // The span covers exactly the trimmed window region.
+      expect(sliced.startsWith(c.text.includes('alpha') ? 'alpha' : sliced.slice(0, 5))).toBe(true);
+      expect(sliced.trim()).toBe(sliced); // trimmed bounds
+    }
+    const first = chunks[0];
+    expect(first?.start).toBe(2); // skips the leading spaces
+    expect(body.slice(first?.start, first?.end)).toContain('alpha');
+  });
+
+  it('gives oversized-paragraph pieces exact word-boundary spans', () => {
+    const body = para(900, 'word');
+    const chunks = chunkNote('T', body);
+    expect(chunks.map((c) => c.words)).toEqual([400, 400, 100]);
+    for (const c of chunks) {
+      const sliced = body.slice(c.start, c.end);
+      expect(sliced.startsWith('word')).toBe(true);
+      expect(sliced.endsWith('word')).toBe(true);
+    }
+    expect(chunks[0]?.start).toBe(0);
+    expect(chunks[2]?.end).toBe(body.length);
   });
 
   it('normalizes CRLF line endings before splitting', () => {

--- a/packages/core/src/embed/chunk.ts
+++ b/packages/core/src/embed/chunk.ts
@@ -6,6 +6,10 @@
  * into ~250–400-word windows. A single mean-pooled vector over a very large
  * note dilutes every topic in it — the fixture vault's tail runs to 832 KB —
  * so retrieval scores each chunk and max-pools per note.
+ *
+ * Each chunk also carries its `[start, end)` character span in the
+ * CRLF-normalized body, so consumers (chunk-aware excerpts) can slice the
+ * matching passage without re-chunking the note.
  */
 
 export interface Chunk {
@@ -13,47 +17,92 @@ export interface Chunk {
   text: string;
   /** Word count of the window body (excludes the title). */
   words: number;
+  /** Start offset of the window in the CRLF-normalized body. */
+  start: number;
+  /** End offset (exclusive) of the window in the CRLF-normalized body. */
+  end: number;
+}
+
+interface Paragraph {
+  text: string;
+  words: number;
+  start: number;
+  end: number;
 }
 
 const MIN_WINDOW_WORDS = 250;
 const MAX_WINDOW_WORDS = 400;
 
 export function chunkNote(title: string, body: string): Chunk[] {
-  const paragraphs = body
-    .replace(/\r\n/g, '\n')
-    .split(/\n[ \t]*\n+/)
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0)
-    .flatMap(splitOversized);
+  const normalized = body.replace(/\r\n/g, '\n');
+  const paragraphs = splitParagraphs(normalized).flatMap(splitOversized);
 
-  if (paragraphs.length === 0) return [{ text: title, words: 0 }];
+  if (paragraphs.length === 0) return [{ text: title, words: 0, start: 0, end: 0 }];
 
   const chunks: Chunk[] = [];
-  let window: string[] = [];
+  let window: Paragraph[] = [];
   let windowWords = 0;
   const flush = () => {
-    if (window.length === 0) return;
-    chunks.push({ text: `${title}\n\n${window.join('\n\n')}`, words: windowWords });
+    const first = window[0];
+    const last = window[window.length - 1];
+    if (!first || !last) return;
+    chunks.push({
+      text: `${title}\n\n${window.map((p) => p.text).join('\n\n')}`,
+      words: windowWords,
+      start: first.start,
+      end: last.end,
+    });
     window = [];
     windowWords = 0;
   };
   for (const para of paragraphs) {
-    const words = countWords(para);
-    if (windowWords >= MIN_WINDOW_WORDS || windowWords + words > MAX_WINDOW_WORDS) flush();
+    if (windowWords >= MIN_WINDOW_WORDS || windowWords + para.words > MAX_WINDOW_WORDS) flush();
     window.push(para);
-    windowWords += words;
+    windowWords += para.words;
   }
   flush();
   return chunks;
 }
 
-/** Hard-split a paragraph longer than the window cap on word boundaries. */
-function splitOversized(para: string): string[] {
-  const words = para.split(/\s+/).filter((w) => w.length > 0);
-  if (words.length <= MAX_WINDOW_WORDS) return [para];
-  const pieces: string[] = [];
+/** Blank-line-delimited paragraphs with trimmed text and exact spans. */
+function splitParagraphs(normalized: string): Paragraph[] {
+  const out: Paragraph[] = [];
+  const push = (rawStart: number, raw: string) => {
+    const text = raw.trim();
+    if (text.length === 0) return;
+    const start = rawStart + (raw.length - raw.trimStart().length);
+    out.push({ text, words: countWords(text), start, end: start + text.length });
+  };
+  const sep = /\n[ \t]*\n+/g;
+  let prev = 0;
+  for (const m of normalized.matchAll(sep)) {
+    push(prev, normalized.slice(prev, m.index));
+    prev = m.index + m[0].length;
+  }
+  push(prev, normalized.slice(prev));
+  return out;
+}
+
+/**
+ * Hard-split a paragraph longer than the window cap on word boundaries.
+ * Piece text joins words with single spaces (identical embedding input to
+ * the pre-span implementation); spans stay exact via word offsets.
+ */
+function splitOversized(para: Paragraph): Paragraph[] {
+  if (para.words <= MAX_WINDOW_WORDS) return [para];
+  const words = [...para.text.matchAll(/\S+/g)];
+  const pieces: Paragraph[] = [];
   for (let i = 0; i < words.length; i += MAX_WINDOW_WORDS) {
-    pieces.push(words.slice(i, i + MAX_WINDOW_WORDS).join(' '));
+    const slice = words.slice(i, i + MAX_WINDOW_WORDS);
+    const first = slice[0];
+    const last = slice[slice.length - 1];
+    if (!first || !last) continue;
+    pieces.push({
+      text: slice.map((w) => w[0]).join(' '),
+      words: slice.length,
+      start: para.start + first.index,
+      end: para.start + last.index + last[0].length,
+    });
   }
   return pieces;
 }

--- a/packages/core/src/embed/index.ts
+++ b/packages/core/src/embed/index.ts
@@ -1,6 +1,6 @@
 export { type Chunk, chunkNote } from './chunk.js';
 export { loadModel2Vec } from './model2vec.js';
 export { readSafetensors, type SafeTensor } from './safetensors.js';
-export { createVectorSet, scanTopNotes, type VectorSet } from './scan.js';
+export { type ChunkPooling, createVectorSet, scanTopNotes, type VectorSet } from './scan.js';
 export { loadWordPieceTokenizer, type WordPieceTokenizer } from './tokenizer.js';
 export type { Embedder } from './types.js';

--- a/packages/core/src/embed/scan.test.ts
+++ b/packages/core/src/embed/scan.test.ts
@@ -77,4 +77,27 @@ describe('createVectorSet / scanTopNotes', () => {
   it('scans an empty set to an empty result', () => {
     expect(scanTopNotes(vec(1, 0), createVectorSet(2), 5)).toEqual([]);
   });
+
+  it('top2mean pooling averages the two best chunks of a note', () => {
+    const set = createVectorSet(2);
+    // Hub note: one lucky chunk, one weak chunk.
+    set.add('hub.md', vec(1, 0));
+    set.add('hub.md', vec(0, 1));
+    // Focused note: two consistently relevant chunks.
+    set.add('focused.md', vec(0.9, 0.1));
+    set.add('focused.md', vec(0.8, 0.2));
+    const maxHits = scanTopNotes(vec(1, 0), set, 2, 'max');
+    expect(maxHits[0]?.path).toBe('hub.md'); // max rewards the lucky chunk
+    const pooled = scanTopNotes(vec(1, 0), set, 2, 'top2mean');
+    expect(pooled[0]?.path).toBe('focused.md'); // (0.9+0.8)/2 > (1+0)/2
+    expect(pooled[0]?.score).toBeCloseTo(0.85);
+    expect(pooled[1]?.score).toBeCloseTo(0.5);
+  });
+
+  it('top2mean keeps a single-chunk note at its full score', () => {
+    const set = createVectorSet(2);
+    set.add('single.md', vec(1, 0));
+    const hits = scanTopNotes(vec(1, 0), set, 1, 'top2mean');
+    expect(hits[0]?.score).toBeCloseTo(1);
+  });
 });

--- a/packages/core/src/embed/scan.ts
+++ b/packages/core/src/embed/scan.ts
@@ -49,13 +49,22 @@ export function createVectorSet(dim: number): VectorSet {
 }
 
 /**
- * Score every chunk against `query`, max-pool per note path, and return the
+ * Score every chunk against `query`, pool per note path, and return the
  * top `k` notes by score (ties broken by path ascending, deterministically).
+ *
+ * Pooling: `max` scores a note by its single best chunk — simple, but a note
+ * with hundreds of chunks gets hundreds of lottery tickets, so very large hub
+ * notes crowd out precise small ones. `top2mean` averages the two best chunk
+ * scores (a single-chunk note keeps its full score), demanding sustained
+ * relevance from large notes.
  */
+export type ChunkPooling = 'max' | 'top2mean';
+
 export function scanTopNotes(
   query: Float32Array,
   set: VectorSet,
   k: number,
+  pooling: ChunkPooling = 'max',
 ): Array<{ path: string; score: number }> {
   if (!(set instanceof PackedVectorSet)) {
     throw new Error('vector set: expected a set from createVectorSet()');
@@ -64,7 +73,9 @@ export function scanTopNotes(
     throw new Error(`vector set: query dim ${query.length} does not match set dim ${set.dim}`);
   }
   const { dim, paths, data } = set;
-  const best = new Map<string, number>();
+  // Track the best and second-best chunk score per note; both poolings
+  // derive from those two numbers.
+  const best = new Map<string, { top: number; second: number }>();
   for (let c = 0; c < paths.length; c++) {
     const base = c * dim;
     let score = 0;
@@ -73,9 +84,22 @@ export function scanTopNotes(
     }
     const path = paths[c] as string;
     const prev = best.get(path);
-    if (prev === undefined || score > prev) best.set(path, score);
+    if (prev === undefined) {
+      best.set(path, { top: score, second: Number.NEGATIVE_INFINITY });
+    } else if (score > prev.top) {
+      prev.second = prev.top;
+      prev.top = score;
+    } else if (score > prev.second) {
+      prev.second = score;
+    }
   }
-  return [...best.entries()]
+  const pooled: Array<[string, number]> = [...best.entries()].map(([path, s]) => [
+    path,
+    pooling === 'top2mean' && s.second !== Number.NEGATIVE_INFINITY
+      ? (s.top + s.second) / 2
+      : s.top,
+  ]);
+  return pooled
     .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
     .slice(0, Math.max(0, k))
     .map(([path, score]) => ({ path, score }));

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -320,6 +320,7 @@ cli
   })
   .option('--runs <n>', 'Latency runs per query (run 1 is cold and discarded).', { default: 20 })
   .option('--experiments', 'Also evaluate the SHA-307 fusion candidates (first model only).')
+  .option('--shipped', "Also evaluate the server's real search tool with mode semantic/hybrid.")
   .option('--out <dir>', 'Output directory.', { default: 'reports' })
   .action(async (opts) => {
     const outDir = resolve(opts.out);
@@ -335,6 +336,7 @@ cli
         .filter(Boolean),
       runs: Number(opts.runs),
       experiments: Boolean(opts.experiments),
+      shipped: Boolean(opts.shipped),
       log: (m) => console.log(`retrieval: ${m}`),
     });
     const report = { ...summary, vaultRoot: normalizeReportPath(summary.vaultRoot) };

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -319,6 +319,7 @@ cli
     default: 'potion-base-8M,potion-retrieval-32M',
   })
   .option('--runs <n>', 'Latency runs per query (run 1 is cold and discarded).', { default: 20 })
+  .option('--experiments', 'Also evaluate the SHA-307 fusion candidates (first model only).')
   .option('--out <dir>', 'Output directory.', { default: 'reports' })
   .action(async (opts) => {
     const outDir = resolve(opts.out);
@@ -333,6 +334,7 @@ cli
         .map((s) => s.trim())
         .filter(Boolean),
       runs: Number(opts.runs),
+      experiments: Boolean(opts.experiments),
       log: (m) => console.log(`retrieval: ${m}`),
     });
     const report = { ...summary, vaultRoot: normalizeReportPath(summary.vaultRoot) };

--- a/packages/harness/src/retrieval/fusion.test.ts
+++ b/packages/harness/src/retrieval/fusion.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { routeToLexical, wsumFuse } from './fusion.js';
+
+describe('routeToLexical', () => {
+  const hits = (...paths: string[]) => paths.map((path) => ({ path }));
+
+  it('routes a query that IS a top-hit title', () => {
+    expect(routeToLexical('Chateaubriant', hits('Encyclopedia/C/Chateaubriant.md'))).toBe(true);
+    expect(routeToLexical('emerald', hits('Encyclopedia/E/Emerald.md'))).toBe(true);
+  });
+
+  it('does not route a query that merely contains a title', () => {
+    // "green gemstones" vs a note titled "Green": describing, not naming.
+    expect(routeToLexical('green gemstones', hits('Notes/Green.md'))).toBe(false);
+    expect(routeToLexical('emerald beryl', hits('Encyclopedia/E/Emerald.md'))).toBe(false);
+  });
+
+  it('never routes long description-style queries, even on a title collision', () => {
+    expect(
+      routeToLexical('green ornamental stone comprising nephrite and jadeite', [
+        { path: 'Notes/Stone.md' },
+      ]),
+    ).toBe(false);
+  });
+
+  it('does not route when no top hit is a title match', () => {
+    expect(
+      routeToLexical('phlogiston', hits('Sources/Combustion.md', 'Sources/Lavoisier.md')),
+    ).toBe(false);
+  });
+
+  it('requires every word of a multi-word title to appear in the query', () => {
+    expect(routeToLexical('french wars', hits('Notes/French Revolutionary Wars.md'))).toBe(false);
+    expect(
+      routeToLexical('french revolutionary wars', hits('Notes/French Revolutionary Wars.md')),
+    ).toBe(true);
+  });
+
+  it('only inspects the top N hits and handles empty inputs', () => {
+    expect(routeToLexical('handel', [])).toBe(false);
+    expect(routeToLexical('', hits('Notes/A.md'))).toBe(false);
+    expect(
+      routeToLexical('handel', hits('Notes/A.md', 'Notes/B.md', 'Notes/C.md', 'Sources/Handel.md')),
+    ).toBe(false);
+  });
+});
+
+describe('wsumFuse', () => {
+  it('weights normalized scores by alpha', () => {
+    const lexical = [
+      { path: 'lex.md', score: 10 },
+      { path: 'both.md', score: 5 },
+      { path: 'low.md', score: 0 },
+    ];
+    const semantic = [
+      { path: 'sem.md', score: 0.9 },
+      { path: 'both.md', score: 0.6 },
+      { path: 'floor.md', score: 0.3 },
+    ];
+    // alpha 0.7: sem.md = 0.7·1, lex.md = 0.3·1, both.md = 0.3·0.5 + 0.7·0.5 = 0.5;
+    // low.md and floor.md both normalize to 0 and tie-break path-ascending.
+    expect(wsumFuse(lexical, semantic, 0.7)).toEqual([
+      'sem.md',
+      'both.md',
+      'lex.md',
+      'floor.md',
+      'low.md',
+    ]);
+  });
+
+  it('alpha 1 is semantic-only ordering; alpha 0 is lexical-only', () => {
+    const lexical = [
+      { path: 'a.md', score: 2 },
+      { path: 'b.md', score: 1 },
+    ];
+    const semantic = [
+      { path: 'b.md', score: 0.9 },
+      { path: 'a.md', score: 0.1 },
+    ];
+    expect(wsumFuse(lexical, semantic, 1)[0]).toBe('b.md');
+    expect(wsumFuse(lexical, semantic, 0)[0]).toBe('a.md');
+  });
+
+  it('handles a constant-score list (span 0) and empty lists', () => {
+    const flat = [
+      { path: 'x.md', score: 3 },
+      { path: 'y.md', score: 3 },
+    ];
+    expect(wsumFuse(flat, [], 0.5)).toEqual(['x.md', 'y.md']);
+    expect(wsumFuse([], [], 0.5)).toEqual([]);
+  });
+
+  it('breaks ties by path ascending', () => {
+    const semantic = [
+      { path: 'z.md', score: 1 },
+      { path: 'a.md', score: 1 },
+    ];
+    expect(wsumFuse([], semantic, 0.7)).toEqual(['a.md', 'z.md']);
+  });
+});

--- a/packages/harness/src/retrieval/fusion.ts
+++ b/packages/harness/src/retrieval/fusion.ts
@@ -1,0 +1,66 @@
+/**
+ * Hybrid-fusion candidates for the SHA-307 ship decision. The spike (SHA-257)
+ * showed equal-weight RRF fuses lexical noise into semantic signal — these are
+ * the alternatives, evaluated head-to-head via `retrieval --experiments`.
+ */
+
+export interface ScoredHit {
+  path: string;
+  score: number;
+}
+
+/**
+ * Query routing: exact-lookup-shaped queries go to lexical, everything else
+ * to semantic. A query routes to lexical when it IS a title among the top
+ * lexical hits — the hit's basename words and the query words are the same
+ * set. That is exactly the case MiniSearch's 3× title boost wins; a partial
+ * title match ("green gemstones" vs a note titled "Green") stays semantic,
+ * because the extra words mean the user is describing, not naming.
+ */
+export function routeToLexical(
+  query: string,
+  lexicalTop: ReadonlyArray<{ path: string }>,
+  opts: { topN?: number } = {},
+): boolean {
+  const topN = opts.topN ?? 3;
+  const words = new Set(query.toLowerCase().split(/\W+/).filter(Boolean));
+  if (words.size === 0) return false;
+  return lexicalTop.slice(0, topN).some((h) => {
+    const base = (h.path.split('/').pop() ?? '').replace(/\.md$/, '').toLowerCase();
+    const parts = new Set(base.split(/\W+/).filter(Boolean));
+    return parts.size === words.size && [...parts].every((p) => words.has(p));
+  });
+}
+
+/**
+ * Score-weighted fusion: min-max normalize each list's scores to [0, 1]
+ * within the list, then combine as `alpha·semantic + (1−alpha)·lexical`
+ * (missing from a list contributes 0 from it). Ties break path-ascending.
+ */
+export function wsumFuse(
+  lexical: ReadonlyArray<ScoredHit>,
+  semantic: ReadonlyArray<ScoredHit>,
+  alpha: number,
+): string[] {
+  const combined = new Map<string, number>();
+  for (const [hits, weight] of [
+    [lexical, 1 - alpha],
+    [semantic, alpha],
+  ] as const) {
+    if (hits.length === 0 || weight === 0) continue;
+    let min = Number.POSITIVE_INFINITY;
+    let max = Number.NEGATIVE_INFINITY;
+    for (const h of hits) {
+      if (h.score < min) min = h.score;
+      if (h.score > max) max = h.score;
+    }
+    const span = max - min;
+    for (const h of hits) {
+      const norm = span > 0 ? (h.score - min) / span : 1;
+      combined.set(h.path, (combined.get(h.path) ?? 0) + weight * norm);
+    }
+  }
+  return [...combined.entries()]
+    .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+    .map(([path]) => path);
+}

--- a/packages/harness/src/retrieval/lexical.ts
+++ b/packages/harness/src/retrieval/lexical.ts
@@ -26,7 +26,19 @@ export async function buildLexicalContext(vaultRoot: string): Promise<LexicalCon
  * and the retrieval depth every eval condition uses.
  */
 export function rankLexical(ctx: ServerContext, query: string, limit = 50): string[] {
+  return rankLexicalScored(ctx, query, limit).map((h) => h.path);
+}
+
+/** Like rankLexical but keeps MiniSearch scores (needed by score fusion). */
+export function rankLexicalScored(
+  ctx: ServerContext,
+  query: string,
+  limit = 50,
+): Array<{ path: string; score: number }> {
   // Index doc ids carry the platform separator (walkVault uses path.relative);
   // golden-set paths are forward-slash canonical, so normalize here.
-  return searchTool(ctx, { query, limit }).map((h) => h.path.replace(/\\/g, '/'));
+  return searchTool(ctx, { query, limit }).map((h) => ({
+    path: h.path.replace(/\\/g, '/'),
+    score: h.score,
+  }));
 }

--- a/packages/harness/src/retrieval/lexical.ts
+++ b/packages/harness/src/retrieval/lexical.ts
@@ -25,11 +25,7 @@ export async function buildLexicalContext(vaultRoot: string): Promise<LexicalCon
  * schema, so the limit is passed explicitly; 50 is the SearchInput maximum
  * and the retrieval depth every eval condition uses.
  */
-export function rankLexical(ctx: ServerContext, query: string, limit = 50): string[] {
-  return rankLexicalScored(ctx, query, limit).map((h) => h.path);
-}
-
-/** Like rankLexical but keeps MiniSearch scores (needed by score fusion). */
+/** Top-`limit` lexical hits with MiniSearch scores (score fusion needs them). */
 export function rankLexicalScored(
   ctx: ServerContext,
   query: string,

--- a/packages/harness/src/retrieval/runner.test.ts
+++ b/packages/harness/src/retrieval/runner.test.ts
@@ -134,12 +134,16 @@ describe('runRetrievalEval', () => {
   });
 });
 
-describe('runRetrievalEval --experiments', () => {
+describe('runRetrievalEval --experiments --shipped', () => {
   let vault: string;
   let summary: RetrievalSummary;
+  let priorCacheDir: string | undefined;
 
   beforeAll(async () => {
     vault = await mkdtemp(join(tmpdir(), 'seekstone-retrieval-exp-'));
+    // Keep the shipped path's embedding cache out of the real user cache dir.
+    priorCacheDir = process.env.SEEKSTONE_CACHE_DIR;
+    process.env.SEEKSTONE_CACHE_DIR = join(vault, '.cache');
     await mkdir(join(vault, 'Notes'), { recursive: true });
     await writeFile(
       join(vault, 'Notes', 'Windmill.md'),
@@ -166,14 +170,17 @@ describe('runRetrievalEval --experiments', () => {
       modelIds: ['stub-small'],
       runs: 2,
       experiments: true,
+      shipped: true,
       loadEmbedder: async (dir) => stubEmbedder(basename(dir)),
     });
   });
   afterAll(async () => {
+    if (priorCacheDir === undefined) delete process.env.SEEKSTONE_CACHE_DIR;
+    else process.env.SEEKSTONE_CACHE_DIR = priorCacheDir;
     await rm(vault, { recursive: true, force: true });
   });
 
-  it('adds the five fusion-candidate conditions for the first model', () => {
+  it('adds the fusion-candidate and shipped conditions for the first model', () => {
     expect(summary.conditions.map((c) => c.condition)).toEqual([
       'lexical',
       'semantic:stub-small',
@@ -183,7 +190,17 @@ describe('runRetrievalEval --experiments', () => {
       'hybrid-route-top2:stub-small',
       'hybrid-wsum70:stub-small',
       'hybrid-wsum85:stub-small',
+      'shipped-semantic:stub-small',
+      'shipped-hybrid:stub-small',
     ]);
+  });
+
+  it("shipped conditions run the server's real search tool", () => {
+    const sem = summary.perQuery.find((p) => p.id === 'sem-windmill');
+    expect(sem?.conditions['shipped-semantic:stub-small']?.hit5).toBe(true);
+    expect(sem?.conditions['shipped-hybrid:stub-small']?.hit5).toBe(true);
+    const lex = summary.perQuery.find((p) => p.id === 'lex-cheese');
+    expect(lex?.conditions['shipped-hybrid:stub-small']?.hit5).toBe(true);
   });
 
   it('routes the exact-title query to lexical and the description to semantic', () => {

--- a/packages/harness/src/retrieval/runner.test.ts
+++ b/packages/harness/src/retrieval/runner.test.ts
@@ -134,6 +134,68 @@ describe('runRetrievalEval', () => {
   });
 });
 
+describe('runRetrievalEval --experiments', () => {
+  let vault: string;
+  let summary: RetrievalSummary;
+
+  beforeAll(async () => {
+    vault = await mkdtemp(join(tmpdir(), 'seekstone-retrieval-exp-'));
+    await mkdir(join(vault, 'Notes'), { recursive: true });
+    await writeFile(
+      join(vault, 'Notes', 'Windmill.md'),
+      '# Windmill\n\nA mill worked by the wind, its sails turning in the breeze.\n',
+    );
+    await writeFile(
+      join(vault, 'Notes', 'Cheese.md'),
+      '# Cheese\n\nCheese is a preparation of milk curd, a staple dairy food.\n',
+    );
+    summary = await runRetrievalEval({
+      vaultRoot: vault,
+      goldenSet: {
+        queries: [
+          { id: 'lex-cheese', kind: 'lexical', query: 'cheese', expected: ['Notes/Cheese.md'] },
+          {
+            id: 'sem-windmill',
+            kind: 'semantic',
+            query: 'machine driven by moving air',
+            expected: ['Notes/Windmill.md'],
+          },
+        ],
+      },
+      modelsDir: '/nonexistent',
+      modelIds: ['stub-small'],
+      runs: 2,
+      experiments: true,
+      loadEmbedder: async (dir) => stubEmbedder(basename(dir)),
+    });
+  });
+  afterAll(async () => {
+    await rm(vault, { recursive: true, force: true });
+  });
+
+  it('adds the five fusion-candidate conditions for the first model', () => {
+    expect(summary.conditions.map((c) => c.condition)).toEqual([
+      'lexical',
+      'semantic:stub-small',
+      'hybrid-rrf:stub-small',
+      'semantic-top2:stub-small',
+      'hybrid-route:stub-small',
+      'hybrid-route-top2:stub-small',
+      'hybrid-wsum70:stub-small',
+      'hybrid-wsum85:stub-small',
+    ]);
+  });
+
+  it('routes the exact-title query to lexical and the description to semantic', () => {
+    const q = summary.perQuery.find((p) => p.id === 'lex-cheese');
+    expect(q?.conditions['hybrid-route:stub-small']?.top10).toEqual(q?.conditions.lexical?.top10);
+    const sem = summary.perQuery.find((p) => p.id === 'sem-windmill');
+    expect(sem?.conditions['hybrid-route:stub-small']?.hit5).toBe(true);
+    expect(sem?.conditions['hybrid-wsum70:stub-small']?.hit5).toBe(true);
+    expect(sem?.conditions['semantic-top2:stub-small']?.hit5).toBe(true);
+  });
+});
+
 describe('computeGate', () => {
   const metrics = (hit5: number) => ({ hit5, mrr10: 0.5, n: 10 });
   const dist = (p95: number) => ({

--- a/packages/harness/src/retrieval/runner.ts
+++ b/packages/harness/src/retrieval/runner.ts
@@ -224,6 +224,7 @@ export async function runRetrievalEval(opts: RetrievalEvalOptions): Promise<Retr
       lexical.ctx,
       join(opts.modelsDir, opts.modelIds[0]),
       defaultCacheDir(process.env, homedir()),
+      opts.loadEmbedder,
     );
     shippedStop = shipped.stop;
     log(`shipped semantic index ready in ${Math.round(shipped.buildMs)} ms (real cache path)`);

--- a/packages/harness/src/retrieval/runner.ts
+++ b/packages/harness/src/retrieval/runner.ts
@@ -123,6 +123,12 @@ export interface RetrievalEvalOptions {
    * conditions appear in the tables but never affect the gate.
    */
   experiments?: boolean;
+  /**
+   * Also evaluate the server's ACTUAL search tool with mode semantic/hybrid
+   * (first model only) — the shipped code path, using the real per-vault
+   * embedding cache. This is the SHA-307 acceptance run.
+   */
+  shipped?: boolean;
 }
 
 interface ConditionAccumulator {
@@ -209,6 +215,28 @@ export async function runRetrievalEval(opts: RetrievalEvalOptions): Promise<Retr
     }
   }
 
+  let shippedStop: (() => void) | undefined;
+  if (opts.shipped && opts.modelIds[0]) {
+    const { buildShipped } = await import('./shipped.js');
+    const { defaultCacheDir } = await import('../../../server/src/semantic/config.js');
+    const { homedir } = await import('node:os');
+    const shipped = await buildShipped(
+      lexical.ctx,
+      join(opts.modelsDir, opts.modelIds[0]),
+      defaultCacheDir(process.env, homedir()),
+    );
+    shippedStop = shipped.stop;
+    log(`shipped semantic index ready in ${Math.round(shipped.buildMs)} ms (real cache path)`);
+    for (const mode of ['semantic', 'hybrid'] as const) {
+      const fn = (q: GoldenQuery) => shipped.rank(mode)(q.query);
+      conditions.push({
+        condition: `shipped-${mode}:${opts.modelIds[0]}`,
+        rank: fn,
+        timedRank: fn,
+      });
+    }
+  }
+
   const perQuery: PerQueryResult[] = queries.map((q) => ({
     id: q.id,
     kind: q.kind,
@@ -252,6 +280,7 @@ export async function runRetrievalEval(opts: RetrievalEvalOptions): Promise<Retr
     log(`${condition}: hit@5 ${conditionResults.at(-1)?.metrics.overall.hit5.toFixed(1)}%`);
   }
 
+  shippedStop?.();
   return {
     snapshotDate: new Date().toISOString(),
     machine: {

--- a/packages/harness/src/retrieval/runner.ts
+++ b/packages/harness/src/retrieval/runner.ts
@@ -14,11 +14,12 @@ import { cpus } from 'node:os';
 import { join } from 'node:path';
 import { type Embedder, loadModel2Vec } from '@seekstone/core/embed';
 import { type Distribution, summarise } from '@seekstone/core/percentiles';
+import { routeToLexical, type ScoredHit, wsumFuse } from './fusion.js';
 import type { GoldenKind, GoldenQuery, GoldenSet } from './golden.js';
-import { buildLexicalContext, rankLexical } from './lexical.js';
+import { buildLexicalContext, rankLexicalScored } from './lexical.js';
 import { hitAtK, mrrAtK } from './metrics.js';
 import { rrfFuse } from './rrf.js';
-import { buildSemanticIndex, rankSemantic, type SemanticIndex } from './semantic.js';
+import { buildSemanticIndex, rankSemanticScored, type SemanticIndex } from './semantic.js';
 
 export const RETRIEVAL_DEPTH = 50;
 export const HIT_K = 5;
@@ -116,6 +117,12 @@ export interface RetrievalEvalOptions {
   log?: (msg: string) => void;
   /** Test seam; defaults to loadModel2Vec. */
   loadEmbedder?: (modelDir: string) => Promise<Embedder>;
+  /**
+   * Also evaluate the SHA-307 fusion candidates (top2mean pooling, query
+   * routing, score-weighted fusion) for the FIRST model. Experimental
+   * conditions appear in the tables but never affect the gate.
+   */
+  experiments?: boolean;
 }
 
 interface ConditionAccumulator {
@@ -155,26 +162,51 @@ export async function runRetrievalEval(opts: RetrievalEvalOptions): Promise<Retr
   }
 
   // Lexical rankings are computed once per query and shared by every hybrid.
-  const lexicalRankings = new Map<string, string[]>();
+  const lexicalScored = new Map<string, ScoredHit[]>();
   for (const q of queries) {
-    lexicalRankings.set(q.id, rankLexical(lexical.ctx, q.query, RETRIEVAL_DEPTH));
+    lexicalScored.set(q.id, rankLexicalScored(lexical.ctx, q.query, RETRIEVAL_DEPTH));
   }
+  const lexPaths = (q: GoldenQuery) => (lexicalScored.get(q.id) as ScoredHit[]).map((h) => h.path);
 
   const conditions: ConditionAccumulator[] = [
     {
       condition: 'lexical',
-      rank: (q) => lexicalRankings.get(q.id) as string[],
-      timedRank: (q) => rankLexical(lexical.ctx, q.query, RETRIEVAL_DEPTH),
+      rank: lexPaths,
+      timedRank: (q) => rankLexicalScored(lexical.ctx, q.query, RETRIEVAL_DEPTH).map((h) => h.path),
     },
   ];
-  for (const { id, embedder, index } of embedders) {
-    const semantic = (q: GoldenQuery) => rankSemantic(embedder, index, q.query, RETRIEVAL_DEPTH);
+  for (const [modelIdx, { id, embedder, index }] of embedders.entries()) {
+    const semScored = (q: GoldenQuery, pooling: 'max' | 'top2mean' = 'max') =>
+      rankSemanticScored(embedder, index, q.query, RETRIEVAL_DEPTH, pooling);
+    const semantic = (q: GoldenQuery) => semScored(q).map((h) => h.path);
     conditions.push({ condition: `semantic:${id}`, rank: semantic, timedRank: semantic });
     conditions.push({
       condition: `hybrid-rrf:${id}`,
-      rank: (q) => rrfFuse([lexicalRankings.get(q.id) as string[], semantic(q)]),
-      timedRank: (q) => rrfFuse([rankLexical(lexical.ctx, q.query, RETRIEVAL_DEPTH), semantic(q)]),
+      rank: (q) => rrfFuse([lexPaths(q), semantic(q)]),
+      timedRank: (q) =>
+        rrfFuse([
+          rankLexicalScored(lexical.ctx, q.query, RETRIEVAL_DEPTH).map((h) => h.path),
+          semantic(q),
+        ]),
     });
+    if (opts.experiments && modelIdx === 0) {
+      const semanticTop2 = (q: GoldenQuery) => semScored(q, 'top2mean').map((h) => h.path);
+      const route = (pooling: 'max' | 'top2mean') => (q: GoldenQuery) =>
+        routeToLexical(q.query, lexicalScored.get(q.id) as ScoredHit[])
+          ? lexPaths(q)
+          : semScored(q, pooling).map((h) => h.path);
+      const wsum = (alpha: number) => (q: GoldenQuery) =>
+        wsumFuse(lexicalScored.get(q.id) as ScoredHit[], semScored(q), alpha);
+      for (const [name, fn] of [
+        [`semantic-top2:${id}`, semanticTop2],
+        [`hybrid-route:${id}`, route('max')],
+        [`hybrid-route-top2:${id}`, route('top2mean')],
+        [`hybrid-wsum70:${id}`, wsum(0.7)],
+        [`hybrid-wsum85:${id}`, wsum(0.85)],
+      ] as const) {
+        conditions.push({ condition: name, rank: fn, timedRank: fn });
+      }
+    }
   }
 
   const perQuery: PerQueryResult[] = queries.map((q) => ({

--- a/packages/harness/src/retrieval/semantic.ts
+++ b/packages/harness/src/retrieval/semantic.ts
@@ -7,6 +7,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
+  type ChunkPooling,
   chunkNote,
   createVectorSet,
   type Embedder,
@@ -53,12 +54,24 @@ export async function buildSemanticIndex(
   return { set, noteCount: notes.length, chunkCount, buildMs: performance.now() - t0 };
 }
 
-/** Top-`k` note paths by max-pooled chunk cosine similarity. */
+/** Top-`k` note paths by pooled chunk cosine similarity. */
 export function rankSemantic(
   embedder: Embedder,
   index: SemanticIndex,
   query: string,
   k = 50,
+  pooling: ChunkPooling = 'max',
 ): string[] {
-  return scanTopNotes(embedder.embed(query), index.set, k).map((h) => h.path);
+  return rankSemanticScored(embedder, index, query, k, pooling).map((h) => h.path);
+}
+
+/** Like rankSemantic but keeps cosine scores (needed by score fusion). */
+export function rankSemanticScored(
+  embedder: Embedder,
+  index: SemanticIndex,
+  query: string,
+  k = 50,
+  pooling: ChunkPooling = 'max',
+): Array<{ path: string; score: number }> {
+  return scanTopNotes(embedder.embed(query), index.set, k, pooling);
 }

--- a/packages/harness/src/retrieval/semantic.ts
+++ b/packages/harness/src/retrieval/semantic.ts
@@ -54,18 +54,7 @@ export async function buildSemanticIndex(
   return { set, noteCount: notes.length, chunkCount, buildMs: performance.now() - t0 };
 }
 
-/** Top-`k` note paths by pooled chunk cosine similarity. */
-export function rankSemantic(
-  embedder: Embedder,
-  index: SemanticIndex,
-  query: string,
-  k = 50,
-  pooling: ChunkPooling = 'max',
-): string[] {
-  return rankSemanticScored(embedder, index, query, k, pooling).map((h) => h.path);
-}
-
-/** Like rankSemantic but keeps cosine scores (needed by score fusion). */
+/** Top-`k` notes by pooled chunk cosine similarity, with scores. */
 export function rankSemanticScored(
   embedder: Embedder,
   index: SemanticIndex,

--- a/packages/harness/src/retrieval/shipped.ts
+++ b/packages/harness/src/retrieval/shipped.ts
@@ -5,6 +5,7 @@
  * and the real per-vault embedding cache (so repeated eval runs also
  * exercise the warm-cache load path).
  */
+import type { Embedder } from '@seekstone/core/embed';
 import type { ServerContext } from '../../../server/src/context.js';
 import { Semantic } from '../../../server/src/semantic/state.js';
 import { search as searchTool } from '../../../server/src/tools/search.js';
@@ -19,9 +20,10 @@ export async function buildShipped(
   ctx: ServerContext,
   modelDir: string,
   cacheDir: string,
+  loadModel?: (modelDir: string) => Promise<Embedder>,
 ): Promise<ShippedHandle> {
   const t0 = performance.now();
-  const semantic = await Semantic.start(ctx, { modelDir, cacheDir }, {});
+  const semantic = await Semantic.start(ctx, { modelDir, cacheDir }, { loadModel });
   await semantic.ready();
   ctx.semantic = semantic;
   return {

--- a/packages/harness/src/retrieval/shipped.ts
+++ b/packages/harness/src/retrieval/shipped.ts
@@ -1,0 +1,33 @@
+/**
+ * "Shipped-path" eval conditions: run golden-set queries through the
+ * server's actual search tool with mode semantic/hybrid — the exact code
+ * users get — rather than the harness's own rankers. Uses the real model
+ * and the real per-vault embedding cache (so repeated eval runs also
+ * exercise the warm-cache load path).
+ */
+import type { ServerContext } from '../../../server/src/context.js';
+import { Semantic } from '../../../server/src/semantic/state.js';
+import { search as searchTool } from '../../../server/src/tools/search.js';
+
+export interface ShippedHandle {
+  rank: (mode: 'semantic' | 'hybrid') => (query: string) => string[];
+  buildMs: number;
+  stop: () => void;
+}
+
+export async function buildShipped(
+  ctx: ServerContext,
+  modelDir: string,
+  cacheDir: string,
+): Promise<ShippedHandle> {
+  const t0 = performance.now();
+  const semantic = await Semantic.start(ctx, { modelDir, cacheDir }, {});
+  await semantic.ready();
+  ctx.semantic = semantic;
+  return {
+    rank: (mode) => (query) =>
+      searchTool(ctx, { query, mode, limit: 50 }).map((h) => h.path.replace(/\\/g, '/')),
+    buildMs: performance.now() - t0,
+    stop: () => semantic.stop(),
+  };
+}

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -110,7 +110,7 @@ Other MCP clients (Windsurf, Cline, …) take the Option 3 JSON block in their o
 
 | Tool | Description |
 |---|---|
-| `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy and prefix matching. |
+| `search` | Full-text search. Returns ranked excerpts (default ~120 chars, tunable via `excerptLength`), not full notes. Fuzzy and prefix matching; with `SEEKSTONE_SEMANTIC=1`, `mode: "semantic"`/`"hybrid"` searches by meaning via a local embedding model (nothing leaves your machine). |
 | `query_notes` | Structured metadata query. Filter by frontmatter key/value predicates (`eq`, `ne`, `contains`, `exists`, `missing`, `gt`/`gte`/`lt`/`lte`), tag, folder, modified time, and size; sort and select the fields you need. Returns compact rows, not note content. |
 | `context_pack` | Answer-ready context for a natural-language question in one call, hard-capped at a byte budget (default 2 KB): ranked excerpts, linked neighbor notes with one-line summaries, and follow-up source paths — replaces a search → read → get_backlinks round-trip loop. |
 | `read_note` | Read the full content of a note by vault-relative path. Supports returning a single section, block, or line range. |
@@ -150,6 +150,9 @@ Every write tool (`append_note`, `patch_note`, `patch_frontmatter`, `replace_in_
 | `SEEKSTONE_LOG_MAX_SIZE` | no | Log-rotation threshold for `SEEKSTONE_LOG_FILE` (e.g. `10mb`; default 5 MB). |
 | `SEEKSTONE_READ_ONLY` | no | Set to `1` to run read-only: the 9 write tools are unregistered entirely (and rejected if called anyway), so the session provably cannot modify your vault. |
 | `SEEKSTONE_WRITE_PATHS` | no | Comma-separated vault-relative globs (e.g. `journal/**,inbox/*.md`). Writes are permitted only under matching paths; the rest of the vault stays read-only. |
+| `SEEKSTONE_SEMANTIC` | no | Set to `1` to enable semantic search (`search` gains `mode: "semantic"` and `"hybrid"`). Download the local model once with `npx -y seekstone fetch-model`; the running server never touches the network. |
+| `SEEKSTONE_MODEL_PATH` | no | Directory holding the Model2Vec embedding model (default: where `fetch-model` puts it). |
+| `SEEKSTONE_CACHE_DIR` | no | Cache root for the model and per-vault embedding caches (default `~/.cache/seekstone`). |
 
 ---
 

--- a/packages/server/src/cli-args.test.ts
+++ b/packages/server/src/cli-args.test.ts
@@ -8,6 +8,7 @@ describe('parseCliIntent', () => {
 
   it('recognizes --version and -v', () => {
     expect(parseCliIntent(['--version'])).toBe('version');
+    expect(parseCliIntent(['fetch-model'])).toBe('fetch-model');
     expect(parseCliIntent(['-v'])).toBe('version');
   });
 

--- a/packages/server/src/cli-args.ts
+++ b/packages/server/src/cli-args.ts
@@ -5,7 +5,7 @@
  * CLI installed via `npx`.
  */
 
-export type CliIntent = 'version' | 'help' | 'init' | 'init-help' | 'run';
+export type CliIntent = 'version' | 'help' | 'init' | 'init-help' | 'fetch-model' | 'run';
 
 export function parseCliIntent(argv: readonly string[]): CliIntent {
   // A subcommand, if present, is the first non-flag token. A help flag after
@@ -17,6 +17,7 @@ export function parseCliIntent(argv: readonly string[]): CliIntent {
     }
     return 'init';
   }
+  if (argv[0] === 'fetch-model') return 'fetch-model';
   for (const arg of argv) {
     if (arg === '--version' || arg === '-v') return 'version';
     if (arg === '--help' || arg === '-h') return 'help';
@@ -37,10 +38,11 @@ Seekstone runs as a Model Context Protocol stdio server. It is normally
 launched by an MCP client (Claude Desktop, Claude Code, Cursor, …), not run by hand.
 
 Usage:
-  seekstone            Start the MCP server (reads from stdin/stdout)
-  seekstone init       Validate a vault and print/patch the client MCP config
-  seekstone --version  Print the version and exit
-  seekstone --help     Print this help and exit
+  seekstone              Start the MCP server (reads from stdin/stdout)
+  seekstone init         Validate a vault and print/patch the client MCP config
+  seekstone fetch-model  Download the local embedding model for semantic search
+  seekstone --version    Print the version and exit
+  seekstone --help       Print this help and exit
 
 "seekstone init" options:
 ${initOptionLines}
@@ -52,6 +54,9 @@ Optional environment:
   SEEKSTONE_LOG_LEVEL  error | warn | info (default) | debug
   SEEKSTONE_LOG_FILE   Absolute path; append JSON-line logs here
   SEEKSTONE_WATCH_POLL Set to 1 to poll for changes (network drives, WSL)
+  SEEKSTONE_SEMANTIC   Set to 1 to enable semantic search (needs fetch-model first)
+  SEEKSTONE_MODEL_PATH Override the embedding-model directory
+  SEEKSTONE_CACHE_DIR  Override the cache root (default ~/.cache/seekstone)
 
 Add to Claude Code:
   claude mcp add seekstone --env SEEKSTONE_VAULT=/path/to/vault -- npx -y seekstone

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -2,6 +2,7 @@ import type { LinkType } from '@seekstone/core/extract';
 import type MiniSearch from 'minisearch';
 import type { IndexedNote } from './index/types.js';
 import type { WritePolicy } from './policy.js';
+import type { Semantic } from './semantic/state.js';
 
 export interface BacklinkRef {
   /** Vault-relative path of the note that contains the link. */
@@ -22,4 +23,10 @@ export interface ServerContext {
   backlinks: Map<string, BacklinkRef[]>;
   /** Read-only / write-path-scoping policy, parsed from env at boot. */
   policy: WritePolicy;
+  /**
+   * Live semantic index — present only when SEEKSTONE_SEMANTIC=1 and the
+   * local embedding model loaded at boot. Fed by the watcher; consumed by
+   * search's semantic/hybrid modes.
+   */
+  semantic?: Semantic;
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -15,6 +16,8 @@ import { parseInitArgs, runInit } from './init.js';
 import { createLogger } from './log.js';
 import { parseWritePolicy } from './policy.js';
 import { installProcessGuards } from './process-guards.js';
+import { resolveSemanticConfig } from './semantic/config.js';
+import { Semantic } from './semantic/state.js';
 import { visibleTools } from './tool-list.js';
 import { startWatcher } from './watcher.js';
 
@@ -47,6 +50,13 @@ if (intent === 'init') {
   process.stdout.write(`${result.output.join('\n')}\n`);
   process.exit(result.exitCode);
 }
+if (intent === 'fetch-model') {
+  const { runFetchModel } = await import('./semantic/fetch-model.js');
+  const { homedir } = await import('node:os');
+  const result = await runFetchModel({ env: process.env, homedir: homedir() });
+  process.stdout.write(`${result.output.join('\n')}\n`);
+  process.exit(result.exitCode);
+}
 
 const log = createLogger();
 
@@ -73,6 +83,24 @@ const { index, notes, backlinks, buildMs } = await buildIndex(vaultRoot);
 log.info('index ready', { notes: notes.size, buildMs });
 
 const ctx: ServerContext = { vaultRoot, index, notes, backlinks, policy };
+
+const semanticCfg = resolveSemanticConfig(process.env, homedir());
+if (semanticCfg) {
+  try {
+    // Model load is fast (~30 MB read); the index build continues in the
+    // background — semantic queries report progress until it finishes.
+    ctx.semantic = await Semantic.start(ctx, semanticCfg, { log });
+    log.info('semantic search enabled', {
+      model: ctx.semantic.embedder.id,
+      dim: ctx.semantic.embedder.dim,
+      notes: notes.size,
+    });
+  } catch (err) {
+    // The user enabled the feature explicitly — a broken setup fails loudly.
+    log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
 
 const watcher = startWatcher(ctx, log);
 // Exit handlers must stay synchronous — kick off the close; nothing awaits it.

--- a/packages/server/src/semantic/cache.test.ts
+++ b/packages/server/src/semantic/cache.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { cachePathsFor, loadCache, saveCache } from './cache.js';
+
+describe('semantic cache', () => {
+  let root: string;
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'seekstone-semcache-'));
+  });
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const notes: Array<[string, Float32Array]> = [
+    ['Notes/A.md', new Float32Array([1, 0, 0.5, 0.5])], // 2 chunks, dim 2
+    ['Notes/B.md', new Float32Array([0, 1])],
+  ];
+  const hashes = new Map([
+    ['Notes/A.md', 'hash-a'],
+    ['Notes/B.md', 'hash-b'],
+  ]);
+
+  it('keys cache paths per vault so vaults never collide', () => {
+    const a = cachePathsFor(root, '/vault/one', 'm');
+    const b = cachePathsFor(root, '/vault/two', 'm');
+    expect(a.bin).not.toBe(b.bin);
+    expect(a.dir.startsWith(join(root, 'embeddings'))).toBe(true);
+  });
+
+  it('round-trips vectors and hashes', async () => {
+    const paths = cachePathsFor(root, '/vault/rt', 'model-x');
+    await saveCache(paths, 'model-x', 2, notes, hashes);
+    const loaded = await loadCache(paths, 'model-x', 2);
+    expect(loaded).toBeDefined();
+    expect([...(loaded?.vectors.get('Notes/A.md') ?? [])]).toEqual([1, 0, 0.5, 0.5]);
+    expect([...(loaded?.vectors.get('Notes/B.md') ?? [])]).toEqual([0, 1]);
+    expect(loaded?.hashes.get('Notes/B.md')).toBe('hash-b');
+  });
+
+  it('skips notes whose hash is not yet known (mid-re-embed)', async () => {
+    const paths = cachePathsFor(root, '/vault/partial', 'm');
+    await saveCache(paths, 'm', 2, notes, new Map([['Notes/A.md', 'hash-a']]));
+    const loaded = await loadCache(paths, 'm', 2);
+    expect(loaded?.vectors.has('Notes/A.md')).toBe(true);
+    expect(loaded?.vectors.has('Notes/B.md')).toBe(false);
+  });
+
+  it('invalidates on model or dim mismatch', async () => {
+    const paths = cachePathsFor(root, '/vault/mismatch', 'model-x');
+    await saveCache(paths, 'model-x', 2, notes, hashes);
+    expect(await loadCache(paths, 'model-y', 2)).toBeUndefined();
+    expect(await loadCache(paths, 'model-x', 4)).toBeUndefined();
+  });
+
+  it('invalidates on a truncated binary', async () => {
+    const paths = cachePathsFor(root, '/vault/torn', 'm');
+    await saveCache(paths, 'm', 2, notes, hashes);
+    const bin = await readFile(paths.bin);
+    await writeFile(paths.bin, bin.subarray(0, bin.length - 4));
+    expect(await loadCache(paths, 'm', 2)).toBeUndefined();
+  });
+
+  it('returns undefined when no cache exists', async () => {
+    const paths = cachePathsFor(root, '/vault/none', 'm');
+    expect(await loadCache(paths, 'm', 2)).toBeUndefined();
+  });
+});

--- a/packages/server/src/semantic/cache.test.ts
+++ b/packages/server/src/semantic/cache.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { cachePathsFor, loadCache, saveCache } from './cache.js';
+import type { NoteVectors } from './store.js';
 
 describe('semantic cache', () => {
   let root: string;
@@ -13,9 +14,12 @@ describe('semantic cache', () => {
     await rm(root, { recursive: true, force: true });
   });
 
-  const notes: Array<[string, Float32Array]> = [
-    ['Notes/A.md', new Float32Array([1, 0, 0.5, 0.5])], // 2 chunks, dim 2
-    ['Notes/B.md', new Float32Array([0, 1])],
+  const notes: Array<[string, NoteVectors]> = [
+    [
+      'Notes/A.md', // 2 chunks, dim 2
+      { packed: new Float32Array([1, 0, 0.5, 0.5]), spans: new Uint32Array([0, 40, 42, 90]) },
+    ],
+    ['Notes/B.md', { packed: new Float32Array([0, 1]), spans: new Uint32Array([5, 25]) }],
   ];
   const hashes = new Map([
     ['Notes/A.md', 'hash-a'],
@@ -29,13 +33,15 @@ describe('semantic cache', () => {
     expect(a.dir.startsWith(join(root, 'embeddings'))).toBe(true);
   });
 
-  it('round-trips vectors and hashes', async () => {
+  it('round-trips vectors, spans, and hashes', async () => {
     const paths = cachePathsFor(root, '/vault/rt', 'model-x');
     await saveCache(paths, 'model-x', 2, notes, hashes);
     const loaded = await loadCache(paths, 'model-x', 2);
     expect(loaded).toBeDefined();
-    expect([...(loaded?.vectors.get('Notes/A.md') ?? [])]).toEqual([1, 0, 0.5, 0.5]);
-    expect([...(loaded?.vectors.get('Notes/B.md') ?? [])]).toEqual([0, 1]);
+    expect([...(loaded?.vectors.get('Notes/A.md')?.packed ?? [])]).toEqual([1, 0, 0.5, 0.5]);
+    expect([...(loaded?.vectors.get('Notes/A.md')?.spans ?? [])]).toEqual([0, 40, 42, 90]);
+    expect([...(loaded?.vectors.get('Notes/B.md')?.packed ?? [])]).toEqual([0, 1]);
+    expect([...(loaded?.vectors.get('Notes/B.md')?.spans ?? [])]).toEqual([5, 25]);
     expect(loaded?.hashes.get('Notes/B.md')).toBe('hash-b');
   });
 
@@ -52,6 +58,15 @@ describe('semantic cache', () => {
     await saveCache(paths, 'model-x', 2, notes, hashes);
     expect(await loadCache(paths, 'model-y', 2)).toBeUndefined();
     expect(await loadCache(paths, 'model-x', 4)).toBeUndefined();
+  });
+
+  it('invalidates on a stale cache version', async () => {
+    const paths = cachePathsFor(root, '/vault/version', 'm');
+    await saveCache(paths, 'm', 2, notes, hashes);
+    const manifest = JSON.parse(await readFile(paths.manifest, 'utf8'));
+    manifest.version = 1;
+    await writeFile(paths.manifest, JSON.stringify(manifest));
+    expect(await loadCache(paths, 'm', 2)).toBeUndefined();
   });
 
   it('invalidates on a truncated binary', async () => {

--- a/packages/server/src/semantic/cache.ts
+++ b/packages/server/src/semantic/cache.ts
@@ -1,0 +1,110 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/**
+ * Persisted embedding cache so restarts don't re-embed the vault: one flat
+ * binary of packed Float32 chunk vectors plus a JSON manifest keyed by
+ * (path, contentHash). Lives under the cache dir, never inside the vault,
+ * in a per-vault subdirectory (sha of the vault root) so multiple vaults
+ * never collide.
+ *
+ * Load is best-effort: any mismatch (version, model, dim, byte lengths)
+ * silently invalidates the cache — the build just re-embeds. Writes are
+ * temp-file + rename (binary first, then the manifest that describes it),
+ * so a crash leaves either the old cache or the new one.
+ */
+
+export interface CachePaths {
+  dir: string;
+  bin: string;
+  manifest: string;
+}
+
+interface CacheManifest {
+  version: 1;
+  modelId: string;
+  dim: number;
+  entries: Array<{ path: string; contentHash: string; chunks: number }>;
+}
+
+export interface CacheData {
+  vectors: Map<string, Float32Array>;
+  hashes: Map<string, string>;
+}
+
+export function cachePathsFor(cacheDir: string, vaultRoot: string, modelId: string): CachePaths {
+  const vaultKey = createHash('sha256').update(vaultRoot).digest('hex').slice(0, 16);
+  const dir = join(cacheDir, 'embeddings', vaultKey);
+  return { dir, bin: join(dir, `${modelId}.bin`), manifest: join(dir, `${modelId}.json`) };
+}
+
+export async function loadCache(
+  paths: CachePaths,
+  modelId: string,
+  dim: number,
+): Promise<CacheData | undefined> {
+  try {
+    const manifest = JSON.parse(await readFile(paths.manifest, 'utf8')) as CacheManifest;
+    if (manifest.version !== 1 || manifest.modelId !== modelId || manifest.dim !== dim) {
+      return undefined;
+    }
+    const buf = await readFile(paths.bin);
+    const totalChunks = manifest.entries.reduce((a, e) => a + e.chunks, 0);
+    if (buf.byteLength !== totalChunks * dim * 4) return undefined;
+    // Buffers can be unaligned for Float32Array views — copy to a fresh buffer.
+    const aligned = new Uint8Array(buf.byteLength);
+    aligned.set(buf);
+    const floats = new Float32Array(aligned.buffer);
+    const vectors = new Map<string, Float32Array>();
+    const hashes = new Map<string, string>();
+    let offset = 0;
+    for (const e of manifest.entries) {
+      if (e.chunks <= 0) return undefined;
+      vectors.set(e.path, floats.subarray(offset, offset + e.chunks * dim));
+      hashes.set(e.path, e.contentHash);
+      offset += e.chunks * dim;
+    }
+    return { vectors, hashes };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function saveCache(
+  paths: CachePaths,
+  modelId: string,
+  dim: number,
+  notes: Iterable<[string, Float32Array]>,
+  hashes: ReadonlyMap<string, string>,
+): Promise<void> {
+  const entries: CacheManifest['entries'] = [];
+  const blobs: Float32Array[] = [];
+  let totalFloats = 0;
+  for (const [path, packed] of notes) {
+    const contentHash = hashes.get(path);
+    if (!contentHash) continue; // still being (re-)embedded — skip this round
+    entries.push({ path, contentHash, chunks: packed.length / dim });
+    blobs.push(packed);
+    totalFloats += packed.length;
+  }
+  const bin = new Float32Array(totalFloats);
+  let offset = 0;
+  for (const blob of blobs) {
+    bin.set(blob, offset);
+    offset += blob.length;
+  }
+  const manifest: CacheManifest = { version: 1, modelId, dim, entries };
+
+  await mkdir(paths.dir, { recursive: true });
+  // Binary first, manifest last: the manifest is the commit point, and load
+  // validates byte lengths, so a torn state just invalidates the cache.
+  await atomicWriteBytes(paths.bin, new Uint8Array(bin.buffer, 0, totalFloats * 4));
+  await atomicWriteBytes(paths.manifest, new TextEncoder().encode(JSON.stringify(manifest)));
+}
+
+async function atomicWriteBytes(absPath: string, bytes: Uint8Array): Promise<void> {
+  const tmpPath = `${absPath}.seekstone-cache-tmp`;
+  await writeFile(tmpPath, bytes);
+  await rename(tmpPath, absPath);
+}

--- a/packages/server/src/semantic/cache.ts
+++ b/packages/server/src/semantic/cache.ts
@@ -1,19 +1,23 @@
 import { createHash } from 'node:crypto';
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { NoteVectors } from './store.js';
 
 /**
  * Persisted embedding cache so restarts don't re-embed the vault: one flat
- * binary of packed Float32 chunk vectors plus a JSON manifest keyed by
- * (path, contentHash). Lives under the cache dir, never inside the vault,
- * in a per-vault subdirectory (sha of the vault root) so multiple vaults
- * never collide.
+ * binary (all packed Float32 chunk vectors, then all Uint32 chunk spans)
+ * plus a JSON manifest keyed by (path, contentHash). Lives under the cache
+ * dir, never inside the vault, in a per-vault subdirectory (sha of the vault
+ * root) so multiple vaults never collide.
  *
  * Load is best-effort: any mismatch (version, model, dim, byte lengths)
  * silently invalidates the cache — the build just re-embeds. Writes are
  * temp-file + rename (binary first, then the manifest that describes it),
  * so a crash leaves either the old cache or the new one.
  */
+
+/** Bump when the on-disk layout OR the chunker semantics change. */
+const CACHE_VERSION = 2;
 
 export interface CachePaths {
   dir: string;
@@ -22,14 +26,14 @@ export interface CachePaths {
 }
 
 interface CacheManifest {
-  version: 1;
+  version: number;
   modelId: string;
   dim: number;
   entries: Array<{ path: string; contentHash: string; chunks: number }>;
 }
 
 export interface CacheData {
-  vectors: Map<string, Float32Array>;
+  vectors: Map<string, NoteVectors>;
   hashes: Map<string, string>;
 }
 
@@ -46,24 +50,34 @@ export async function loadCache(
 ): Promise<CacheData | undefined> {
   try {
     const manifest = JSON.parse(await readFile(paths.manifest, 'utf8')) as CacheManifest;
-    if (manifest.version !== 1 || manifest.modelId !== modelId || manifest.dim !== dim) {
+    if (
+      manifest.version !== CACHE_VERSION ||
+      manifest.modelId !== modelId ||
+      manifest.dim !== dim
+    ) {
       return undefined;
     }
     const buf = await readFile(paths.bin);
     const totalChunks = manifest.entries.reduce((a, e) => a + e.chunks, 0);
-    if (buf.byteLength !== totalChunks * dim * 4) return undefined;
-    // Buffers can be unaligned for Float32Array views — copy to a fresh buffer.
+    const vectorBytes = totalChunks * dim * 4;
+    const spanBytes = totalChunks * 2 * 4;
+    if (buf.byteLength !== vectorBytes + spanBytes) return undefined;
+    // Buffers can be unaligned for typed-array views — copy to a fresh buffer.
     const aligned = new Uint8Array(buf.byteLength);
     aligned.set(buf);
-    const floats = new Float32Array(aligned.buffer);
-    const vectors = new Map<string, Float32Array>();
+    const floats = new Float32Array(aligned.buffer, 0, totalChunks * dim);
+    const spans = new Uint32Array(aligned.buffer, vectorBytes, totalChunks * 2);
+    const vectors = new Map<string, NoteVectors>();
     const hashes = new Map<string, string>();
-    let offset = 0;
+    let chunkOffset = 0;
     for (const e of manifest.entries) {
       if (e.chunks <= 0) return undefined;
-      vectors.set(e.path, floats.subarray(offset, offset + e.chunks * dim));
+      vectors.set(e.path, {
+        packed: floats.subarray(chunkOffset * dim, (chunkOffset + e.chunks) * dim),
+        spans: spans.subarray(chunkOffset * 2, (chunkOffset + e.chunks) * 2),
+      });
       hashes.set(e.path, e.contentHash);
-      offset += e.chunks * dim;
+      chunkOffset += e.chunks;
     }
     return { vectors, hashes };
   } catch {
@@ -75,31 +89,37 @@ export async function saveCache(
   paths: CachePaths,
   modelId: string,
   dim: number,
-  notes: Iterable<[string, Float32Array]>,
+  notes: Iterable<[string, NoteVectors]>,
   hashes: ReadonlyMap<string, string>,
 ): Promise<void> {
   const entries: CacheManifest['entries'] = [];
-  const blobs: Float32Array[] = [];
-  let totalFloats = 0;
-  for (const [path, packed] of notes) {
+  const kept: NoteVectors[] = [];
+  let totalChunks = 0;
+  for (const [path, note] of notes) {
     const contentHash = hashes.get(path);
     if (!contentHash) continue; // still being (re-)embedded — skip this round
-    entries.push({ path, contentHash, chunks: packed.length / dim });
-    blobs.push(packed);
-    totalFloats += packed.length;
+    const chunks = note.packed.length / dim;
+    entries.push({ path, contentHash, chunks });
+    kept.push(note);
+    totalChunks += chunks;
   }
-  const bin = new Float32Array(totalFloats);
-  let offset = 0;
-  for (const blob of blobs) {
-    bin.set(blob, offset);
-    offset += blob.length;
+  const bin = new Uint8Array(totalChunks * dim * 4 + totalChunks * 2 * 4);
+  const floats = new Float32Array(bin.buffer, 0, totalChunks * dim);
+  const spans = new Uint32Array(bin.buffer, totalChunks * dim * 4, totalChunks * 2);
+  let floatOffset = 0;
+  let spanOffset = 0;
+  for (const note of kept) {
+    floats.set(note.packed, floatOffset);
+    spans.set(note.spans, spanOffset);
+    floatOffset += note.packed.length;
+    spanOffset += note.spans.length;
   }
-  const manifest: CacheManifest = { version: 1, modelId, dim, entries };
+  const manifest: CacheManifest = { version: CACHE_VERSION, modelId, dim, entries };
 
   await mkdir(paths.dir, { recursive: true });
   // Binary first, manifest last: the manifest is the commit point, and load
   // validates byte lengths, so a torn state just invalidates the cache.
-  await atomicWriteBytes(paths.bin, new Uint8Array(bin.buffer, 0, totalFloats * 4));
+  await atomicWriteBytes(paths.bin, bin);
   await atomicWriteBytes(paths.manifest, new TextEncoder().encode(JSON.stringify(manifest)));
 }
 

--- a/packages/server/src/semantic/config.test.ts
+++ b/packages/server/src/semantic/config.test.ts
@@ -1,0 +1,27 @@
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_MODEL_ID, defaultCacheDir, resolveSemanticConfig } from './config.js';
+
+describe('resolveSemanticConfig', () => {
+  it('is disabled unless SEEKSTONE_SEMANTIC=1', () => {
+    expect(resolveSemanticConfig({}, '/home/u')).toBeUndefined();
+    expect(resolveSemanticConfig({ SEEKSTONE_SEMANTIC: '0' }, '/home/u')).toBeUndefined();
+    expect(resolveSemanticConfig({ SEEKSTONE_SEMANTIC: 'true' }, '/home/u')).toBeUndefined();
+  });
+
+  it('defaults the model dir under the cache dir', () => {
+    const cfg = resolveSemanticConfig({ SEEKSTONE_SEMANTIC: '1' }, '/home/u');
+    expect(cfg?.cacheDir).toBe(join('/home/u', '.cache', 'seekstone'));
+    expect(cfg?.modelDir).toBe(join('/home/u', '.cache', 'seekstone', 'models', DEFAULT_MODEL_ID));
+  });
+
+  it('honors SEEKSTONE_MODEL_PATH and SEEKSTONE_CACHE_DIR overrides', () => {
+    const cfg = resolveSemanticConfig(
+      { SEEKSTONE_SEMANTIC: '1', SEEKSTONE_MODEL_PATH: '/models/m', SEEKSTONE_CACHE_DIR: '/c' },
+      '/home/u',
+    );
+    expect(cfg?.modelDir).toBe('/models/m');
+    expect(cfg?.cacheDir).toBe('/c');
+    expect(defaultCacheDir({ SEEKSTONE_CACHE_DIR: '/c' }, '/home/u')).toBe('/c');
+  });
+});

--- a/packages/server/src/semantic/config.ts
+++ b/packages/server/src/semantic/config.ts
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+
+/**
+ * Semantic-search configuration, resolved from env at boot.
+ *
+ * - `SEEKSTONE_SEMANTIC=1` enables the feature (off by default).
+ * - `SEEKSTONE_MODEL_PATH` overrides where the Model2Vec model dir lives;
+ *   default is `<cache>/models/potion-base-8M`, where `seekstone fetch-model`
+ *   puts it.
+ * - `SEEKSTONE_CACHE_DIR` overrides the cache root (default `~/.cache/seekstone`),
+ *   which holds both downloaded models and per-vault embedding caches.
+ *
+ * The server itself NEVER downloads anything — the model is fetched
+ * out-of-band by the `fetch-model` subcommand, preserving the zero-network
+ * guarantee (no-network.test.ts).
+ */
+
+export const DEFAULT_MODEL_ID = 'potion-base-8M';
+
+export interface SemanticConfig {
+  modelDir: string;
+  cacheDir: string;
+}
+
+export function defaultCacheDir(env: NodeJS.ProcessEnv, homedir: string): string {
+  return env.SEEKSTONE_CACHE_DIR || join(homedir, '.cache', 'seekstone');
+}
+
+export function resolveSemanticConfig(
+  env: NodeJS.ProcessEnv,
+  homedir: string,
+): SemanticConfig | undefined {
+  if (env.SEEKSTONE_SEMANTIC !== '1') return undefined;
+  const cacheDir = defaultCacheDir(env, homedir);
+  const modelDir = env.SEEKSTONE_MODEL_PATH || join(cacheDir, 'models', DEFAULT_MODEL_ID);
+  return { modelDir, cacheDir };
+}

--- a/packages/server/src/semantic/excerpt.test.ts
+++ b/packages/server/src/semantic/excerpt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { chunkExcerpt } from './excerpt.js';
+
+describe('chunkExcerpt', () => {
+  const body = 'First paragraph about mills.\n\nSecond paragraph about cheese and dairy.';
+
+  it('slices the winning chunk span and excerpts within it', () => {
+    const span = { start: body.indexOf('Second'), end: body.length };
+    expect(chunkExcerpt(body, span, ['cheese'], 120)).toContain('cheese and dairy');
+    expect(chunkExcerpt(body, span, ['cheese'], 120)).not.toContain('mills');
+  });
+
+  it('falls back to the start of the chunk when no term matches', () => {
+    const span = { start: body.indexOf('Second'), end: body.length };
+    expect(chunkExcerpt(body, span, ['unrelated'], 120)).toMatch(/^Second paragraph/);
+  });
+
+  it('normalizes CRLF bodies so spans line up', () => {
+    const crlf = 'First line.\r\n\r\nSecond target line.';
+    const normalized = crlf.replace(/\r\n/g, '\n');
+    const span = { start: normalized.indexOf('Second'), end: normalized.length };
+    expect(chunkExcerpt(crlf, span, ['target'], 120)).toContain('Second target line.');
+  });
+
+  it('clamps a stale span that outruns the current body', () => {
+    expect(chunkExcerpt('short', { start: 100, end: 200 }, [], 50)).toBe('short');
+    expect(chunkExcerpt('short body here', { start: 6, end: 999 }, ['body'], 50)).toContain(
+      'body here',
+    );
+  });
+});

--- a/packages/server/src/semantic/excerpt.ts
+++ b/packages/server/src/semantic/excerpt.ts
@@ -1,25 +1,24 @@
-import { chunkNote } from '@seekstone/core/embed';
 import { extractExcerpt } from '../index/excerpt.js';
 
 /**
- * Excerpt for a semantic hit: re-chunk the note's in-memory body with the
- * same chunker the index used, take the winning chunk, and excerpt within
- * it. Query terms often don't literally appear in a semantic match, in
- * which case extractExcerpt falls back to the START of the matching chunk —
- * the relevant passage — instead of the head of the note.
+ * Excerpt for a semantic hit: slice the winning chunk's span out of the
+ * note's in-memory body (spans were recorded at embed time, so there is no
+ * re-chunking on the query path) and excerpt within it. Query terms often
+ * don't literally appear in a semantic match, in which case extractExcerpt
+ * falls back to the START of the matching chunk — the relevant passage —
+ * instead of the head of the note.
  */
 export function chunkExcerpt(
-  note: { title: string; body: string },
-  chunkIndex: number,
+  body: string,
+  span: { start: number; end: number },
   terms: string[],
   maxLen: number,
 ): string {
-  const chunks = chunkNote(note.title, note.body);
-  // The note may have changed between embedding and query (debounce window);
-  // clamp rather than crash.
-  const chunk = chunks[Math.min(Math.max(chunkIndex, 0), chunks.length - 1)];
-  if (!chunk) return '';
-  const prefix = `${note.title}\n\n`;
-  const text = chunk.text.startsWith(prefix) ? chunk.text.slice(prefix.length) : chunk.text;
+  // Spans are offsets into the CRLF-normalized body (chunkNote normalizes).
+  const normalized = body.includes('\r') ? body.replace(/\r\n/g, '\n') : body;
+  // The note may have changed inside the re-embed debounce window — clamp.
+  const start = Math.min(span.start, normalized.length);
+  const end = Math.min(Math.max(span.end, start), normalized.length);
+  const text = start === end ? normalized : normalized.slice(start, end);
   return extractExcerpt(text, terms, maxLen);
 }

--- a/packages/server/src/semantic/excerpt.ts
+++ b/packages/server/src/semantic/excerpt.ts
@@ -1,0 +1,25 @@
+import { chunkNote } from '@seekstone/core/embed';
+import { extractExcerpt } from '../index/excerpt.js';
+
+/**
+ * Excerpt for a semantic hit: re-chunk the note's in-memory body with the
+ * same chunker the index used, take the winning chunk, and excerpt within
+ * it. Query terms often don't literally appear in a semantic match, in
+ * which case extractExcerpt falls back to the START of the matching chunk —
+ * the relevant passage — instead of the head of the note.
+ */
+export function chunkExcerpt(
+  note: { title: string; body: string },
+  chunkIndex: number,
+  terms: string[],
+  maxLen: number,
+): string {
+  const chunks = chunkNote(note.title, note.body);
+  // The note may have changed between embedding and query (debounce window);
+  // clamp rather than crash.
+  const chunk = chunks[Math.min(Math.max(chunkIndex, 0), chunks.length - 1)];
+  if (!chunk) return '';
+  const prefix = `${note.title}\n\n`;
+  const text = chunk.text.startsWith(prefix) ? chunk.text.slice(prefix.length) : chunk.text;
+  return extractExcerpt(text, terms, maxLen);
+}

--- a/packages/server/src/semantic/fetch-model.test.ts
+++ b/packages/server/src/semantic/fetch-model.test.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { runFetchModel } from './fetch-model.js';
+import type { ModelManifest } from './model-manifest.js';
+
+const sha = (s: string) => createHash('sha256').update(s).digest('hex');
+
+const manifest: ModelManifest = {
+  id: 'stub-model',
+  license: 'MIT',
+  files: [
+    {
+      name: 'config.json',
+      url: 'https://huggingface.co/x/config.json',
+      sha256: sha('cfg'),
+      bytes: 3,
+    },
+    {
+      name: 'model.safetensors',
+      url: 'https://huggingface.co/x/model.safetensors',
+      sha256: sha('weights'),
+      bytes: 7,
+    },
+  ],
+};
+
+describe('runFetchModel', () => {
+  let home: string;
+  beforeAll(async () => {
+    home = await mkdtemp(join(tmpdir(), 'seekstone-fetchmodel-'));
+  });
+  afterAll(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  const bodies: Record<string, string> = {
+    'https://huggingface.co/x/config.json': 'cfg',
+    'https://huggingface.co/x/model.safetensors': 'weights',
+  };
+  const okFetch = vi.fn(async (url: string | URL | Request) => new Response(bodies[String(url)]));
+
+  it('downloads into the default cache location and verifies checksums', async () => {
+    const result = await runFetchModel({
+      env: {},
+      homedir: home,
+      manifest,
+      fetchFn: okFetch as typeof fetch,
+    });
+    expect(result.exitCode).toBe(0);
+    const dest = join(home, '.cache', 'seekstone', 'models', 'stub-model');
+    expect(await readFile(join(dest, 'config.json'), 'utf8')).toBe('cfg');
+    expect(await readFile(join(dest, 'model.safetensors'), 'utf8')).toBe('weights');
+    expect(result.output.join('\n')).toContain('2 fetched, 0 already present');
+  });
+
+  it('skips already-present checksum-matching files', async () => {
+    // A genuinely fresh mock — vi.fn(existingMock) would share okFetch's
+    // call history from the previous test.
+    const spy = vi.fn(async () => new Response('should never be fetched'));
+    const result = await runFetchModel({
+      env: {},
+      homedir: home,
+      manifest,
+      fetchFn: spy as unknown as typeof fetch,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(spy).not.toHaveBeenCalled();
+    expect(result.output.join('\n')).toContain('0 fetched, 2 already present');
+  });
+
+  it('honors SEEKSTONE_MODEL_PATH as the destination', async () => {
+    const custom = join(home, 'custom-model-dir');
+    const result = await runFetchModel({
+      env: { SEEKSTONE_MODEL_PATH: custom },
+      homedir: home,
+      manifest,
+      fetchFn: okFetch as typeof fetch,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(custom, 'config.json'))).toBe(true);
+  });
+
+  it('re-fetches a corrupted file instead of trusting it', async () => {
+    const dest = join(home, '.cache', 'seekstone', 'models', 'stub-model');
+    await writeFile(join(dest, 'config.json'), 'tampered');
+    const result = await runFetchModel({
+      env: {},
+      homedir: home,
+      manifest,
+      fetchFn: okFetch as typeof fetch,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(await readFile(join(dest, 'config.json'), 'utf8')).toBe('cfg');
+  });
+
+  it('fails with exit 1 on checksum mismatch and on HTTP errors', async () => {
+    const badBody = vi.fn(async () => new Response('evil'));
+    const bad = await runFetchModel({
+      env: { SEEKSTONE_MODEL_PATH: join(home, 'bad') },
+      homedir: home,
+      manifest,
+      fetchFn: badBody as unknown as typeof fetch,
+    });
+    expect(bad.exitCode).toBe(1);
+    expect(bad.output.join('\n')).toContain('checksum mismatch');
+
+    const http404 = vi.fn(async () => new Response('nope', { status: 404 }));
+    const notFound = await runFetchModel({
+      env: { SEEKSTONE_MODEL_PATH: join(home, 'missing') },
+      homedir: home,
+      manifest,
+      fetchFn: http404 as unknown as typeof fetch,
+    });
+    expect(notFound.exitCode).toBe(1);
+    expect(notFound.output.join('\n')).toContain('failed: 404');
+  });
+});

--- a/packages/server/src/semantic/fetch-model.ts
+++ b/packages/server/src/semantic/fetch-model.ts
@@ -1,0 +1,70 @@
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { defaultCacheDir } from './config.js';
+import { DEFAULT_MODEL, type ModelManifest } from './model-manifest.js';
+
+/**
+ * `seekstone fetch-model` — the explicit, out-of-band download of the
+ * embedding model that semantic search needs. This is a CLI subcommand that
+ * exits before any MCP serving starts; the running server never fetches
+ * (no-network.test.ts is the guarantee). Files are verified against pinned
+ * SHA-256 hashes; already-present matching files are skipped.
+ */
+
+export interface FetchModelResult {
+  output: string[];
+  exitCode: number;
+}
+
+export interface FetchModelDeps {
+  env: NodeJS.ProcessEnv;
+  homedir: string;
+  manifest?: ModelManifest;
+  fetchFn?: typeof fetch;
+}
+
+export async function runFetchModel(deps: FetchModelDeps): Promise<FetchModelResult> {
+  const manifest = deps.manifest ?? DEFAULT_MODEL;
+  const fetchFn = deps.fetchFn ?? fetch;
+  const destDir =
+    deps.env.SEEKSTONE_MODEL_PATH ||
+    join(defaultCacheDir(deps.env, deps.homedir), 'models', manifest.id);
+  const output: string[] = [];
+  output.push(`fetch-model: ${manifest.id} → ${destDir}`);
+  try {
+    await mkdir(destDir, { recursive: true });
+    let fetched = 0;
+    let skipped = 0;
+    for (const file of manifest.files) {
+      const dest = join(destDir, file.name);
+      if (existsSync(dest) && sha256(await readFile(dest)) === file.sha256) {
+        skipped++;
+        continue;
+      }
+      output.push(`fetching ${file.name} (${file.bytes} bytes)…`);
+      const res = await fetchFn(file.url);
+      if (!res.ok) throw new Error(`fetch ${file.url} failed: ${res.status}`);
+      const buf = Buffer.from(await res.arrayBuffer());
+      const got = sha256(buf);
+      if (got !== file.sha256) {
+        throw new Error(`checksum mismatch for ${file.name}: expected ${file.sha256}, got ${got}`);
+      }
+      await writeFile(dest, buf);
+      fetched++;
+    }
+    output.push(`✓ ${manifest.id}: ${fetched} fetched, ${skipped} already present (verified).`);
+    output.push(
+      'Enable semantic search with SEEKSTONE_SEMANTIC=1 in your MCP server config, then restart the session.',
+    );
+    return { output, exitCode: 0 };
+  } catch (err) {
+    output.push(`✗ ${err instanceof Error ? err.message : String(err)}`);
+    return { output, exitCode: 1 };
+  }
+}
+
+function sha256(buf: Buffer): string {
+  return createHash('sha256').update(buf).digest('hex');
+}

--- a/packages/server/src/semantic/model-manifest.ts
+++ b/packages/server/src/semantic/model-manifest.ts
@@ -1,0 +1,46 @@
+/**
+ * Pinned download manifest for the default embedding model. Used ONLY by the
+ * `seekstone fetch-model` subcommand — an explicit, out-of-band CLI action.
+ * The MCP server itself never touches the network (no-network.test.ts).
+ *
+ * Hashes mirror packages/harness/fixtures/models/manifest.json (the harness
+ * evals run against the same files).
+ */
+
+export interface ModelFile {
+  name: string;
+  url: string;
+  sha256: string;
+  bytes: number;
+}
+
+export interface ModelManifest {
+  id: string;
+  license: string;
+  files: ModelFile[];
+}
+
+export const DEFAULT_MODEL: ModelManifest = {
+  id: 'potion-base-8M',
+  license: 'MIT (https://huggingface.co/minishlab/potion-base-8M)',
+  files: [
+    {
+      name: 'model.safetensors',
+      url: 'https://huggingface.co/minishlab/potion-base-8M/resolve/main/model.safetensors',
+      sha256: 'f65d0f325faadc1e121c319e2faa41170d3fa07d8c89abd48ca5358d9a223de2',
+      bytes: 30236760,
+    },
+    {
+      name: 'tokenizer.json',
+      url: 'https://huggingface.co/minishlab/potion-base-8M/resolve/main/tokenizer.json',
+      sha256: 'e67e803f624fb4d67dea1c730d06e1067e1b14d830e2c2202569e3ef0f70bb50',
+      bytes: 683666,
+    },
+    {
+      name: 'config.json',
+      url: 'https://huggingface.co/minishlab/potion-base-8M/resolve/main/config.json',
+      sha256: '2a6ac0e9aaa356a68a5688070db78fc3a464fefe85d2f06a1905ce3718687553',
+      bytes: 202,
+    },
+  ],
+};

--- a/packages/server/src/semantic/route.test.ts
+++ b/packages/server/src/semantic/route.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { queryWords, routeToLexical } from './route.js';
+
+describe('routeToLexical', () => {
+  it('routes a query that IS a top-hit title', () => {
+    expect(routeToLexical('Chateaubriant', ['Encyclopedia/C/Chateaubriant.md'])).toBe(true);
+    expect(
+      routeToLexical('french revolutionary wars', ['Notes/French Revolutionary Wars.md']),
+    ).toBe(true);
+  });
+
+  it('does not route a query that merely contains a title', () => {
+    expect(routeToLexical('green gemstones', ['Notes/Green.md'])).toBe(false);
+    expect(routeToLexical('emerald beryl', ['Encyclopedia/E/Emerald.md'])).toBe(false);
+  });
+
+  it('only inspects the top N hits and handles empty inputs', () => {
+    expect(routeToLexical('handel', [])).toBe(false);
+    expect(routeToLexical('', ['Notes/A.md'])).toBe(false);
+    expect(
+      routeToLexical('handel', ['Notes/A.md', 'Notes/B.md', 'Notes/C.md', 'S/Handel.md']),
+    ).toBe(false);
+  });
+});
+
+describe('queryWords', () => {
+  it('lowercases and splits on non-word characters', () => {
+    expect(queryWords('Émile Zola’s "J’accuse"')).toEqual(
+      'Émile Zola’s "J’accuse"'.toLowerCase().split(/\W+/).filter(Boolean),
+    );
+    expect(queryWords('  hello,  world!  ')).toEqual(['hello', 'world']);
+    expect(queryWords('')).toEqual([]);
+  });
+});

--- a/packages/server/src/semantic/route.ts
+++ b/packages/server/src/semantic/route.ts
@@ -20,7 +20,8 @@ export function routeToLexical(query: string, topPaths: readonly string[], topN 
   const words = new Set(queryWords(query));
   if (words.size === 0) return false;
   return topPaths.slice(0, topN).some((path) => {
-    const base = (path.split('/').pop() ?? '').replace(/\.md$/, '').toLowerCase();
+    // Index ids carry the platform separator — split on both.
+    const base = (path.split(/[\\/]/).pop() ?? '').replace(/\.md$/, '').toLowerCase();
     const parts = new Set(base.split(/\W+/).filter(Boolean));
     return parts.size === words.size && [...parts].every((p) => words.has(p));
   });

--- a/packages/server/src/semantic/route.ts
+++ b/packages/server/src/semantic/route.ts
@@ -1,0 +1,27 @@
+/**
+ * Hybrid-mode query routing, the recipe the SHA-307 golden-set eval chose
+ * over RRF and score-weighted fusion: a query goes to lexical search only
+ * when it IS a top lexical hit's title — the hit's basename words and the
+ * query words are the same set. Exact-name lookups are what MiniSearch's 3×
+ * title boost wins; a query that merely *contains* a title ("green
+ * gemstones" vs a note titled "Green") is describing, not naming, and stays
+ * semantic. (The same rule lives in the harness's retrieval/fusion.ts, where
+ * the eval that picked it runs.)
+ */
+
+/** Queries longer than this cannot plausibly be a title — skip lexical entirely. */
+export const MAX_ROUTE_WORDS = 6;
+
+export function queryWords(query: string): string[] {
+  return query.toLowerCase().split(/\W+/).filter(Boolean);
+}
+
+export function routeToLexical(query: string, topPaths: readonly string[], topN = 3): boolean {
+  const words = new Set(queryWords(query));
+  if (words.size === 0) return false;
+  return topPaths.slice(0, topN).some((path) => {
+    const base = (path.split('/').pop() ?? '').replace(/\.md$/, '').toLowerCase();
+    const parts = new Set(base.split(/\W+/).filter(Boolean));
+    return parts.size === words.size && [...parts].every((p) => words.has(p));
+  });
+}

--- a/packages/server/src/semantic/state.test.ts
+++ b/packages/server/src/semantic/state.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Embedder } from '@seekstone/core/embed';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { IndexedNote } from '../index/types.js';
+import { Semantic, type SemanticCtx } from './state.js';
+
+/** Keyword stub: axis 0 = wind, axis 1 = dairy, axis 2 = other. */
+const stubEmbedder: Embedder = {
+  id: 'stub-model',
+  dim: 3,
+  embed(text: string): Float32Array {
+    const t = text.toLowerCase();
+    if (/\b(wind|mill|breeze)\b/.test(t)) return new Float32Array([1, 0, 0]);
+    if (/\b(milk|dairy|cheese)\b/.test(t)) return new Float32Array([0, 1, 0]);
+    return new Float32Array([0, 0, 1]);
+  },
+};
+
+function note(id: string, body: string): IndexedNote {
+  const title = (id.split('/').pop() ?? id).replace(/\.md$/, '');
+  return {
+    id,
+    title,
+    body,
+    tags: '',
+    fmKeys: '',
+    fm: null,
+    raw: body,
+    sizeBytes: body.length,
+    mtimeMs: 0,
+  };
+}
+
+function makeCtx(vaultRoot: string): SemanticCtx {
+  return {
+    vaultRoot,
+    notes: new Map<string, IndexedNote>([
+      ['Notes/Windmill.md', note('Notes/Windmill.md', 'A mill worked by the wind.')],
+      ['Notes/Cheese.md', note('Notes/Cheese.md', 'A dairy food made from milk.')],
+      ['Notes/Other.md', note('Notes/Other.md', 'Nothing in particular.')],
+    ]),
+  };
+}
+
+const deps = () => ({
+  loadModel: async () => stubEmbedder,
+  debounceMs: 5,
+  saveDebounceMs: 5,
+  yieldEvery: 2,
+});
+
+describe('Semantic', () => {
+  let cacheDir: string;
+  beforeAll(async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), 'seekstone-semstate-'));
+  });
+  afterAll(async () => {
+    await rm(cacheDir, { recursive: true, force: true });
+  });
+
+  const cfg = () => ({ modelDir: '/unused-stubbed', cacheDir });
+
+  it('builds the index in the background and reports progress → ready', async () => {
+    const ctx = makeCtx('/vault/build');
+    const s = await Semantic.start(ctx, cfg(), deps());
+    expect(['building', 'ready']).toContain(s.progress.state);
+    await s.ready();
+    expect(s.progress).toEqual({ state: 'ready' });
+    expect(s.store.noteCount).toBe(3);
+    const hits = s.store.topNotes(s.embedQuery('breeze'), 2);
+    expect(hits[0]?.path).toBe('Notes/Windmill.md');
+    s.stop();
+  });
+
+  it('reuses the persisted cache on a second start', async () => {
+    const ctx = makeCtx('/vault/cache-reuse');
+    const first = await Semantic.start(ctx, cfg(), deps());
+    await first.ready();
+    // Build saves the cache when anything was freshly embedded — await the
+    // internal save by polling the second start's reuse behavior.
+    first.stop();
+
+    const embedSpy = vi.fn(stubEmbedder.embed.bind(stubEmbedder));
+    const spiedEmbedder: Embedder = { ...stubEmbedder, embed: embedSpy };
+    const second = await Semantic.start(ctx, cfg(), {
+      ...deps(),
+      loadModel: async () => spiedEmbedder,
+    });
+    await second.ready();
+    expect(second.store.noteCount).toBe(3);
+    // Every note came from the cache — no note embedding happened.
+    expect(embedSpy).not.toHaveBeenCalled();
+    // Queries still work against cached vectors.
+    expect(second.store.topNotes(second.embedQuery('milk dairy'), 1)[0]?.path).toBe(
+      'Notes/Cheese.md',
+    );
+    second.stop();
+  });
+
+  it('re-embeds a changed note after the debounce window', async () => {
+    const ctx = makeCtx('/vault/reembed');
+    const s = await Semantic.start(ctx, cfg(), deps());
+    await s.ready();
+    expect(s.store.topNotes(s.embedQuery('milk'), 1)[0]?.path).toBe('Notes/Cheese.md');
+
+    // The watcher refreshes ctx.notes, then pokes noteChanged.
+    ctx.notes.set('Notes/Other.md', note('Notes/Other.md', 'Now all about cheese and milk.'));
+    s.noteChanged('Notes/Other.md');
+    await vi.waitFor(() => {
+      const top = s.store.topNotes(s.embedQuery('dairy'), 2);
+      expect(top.map((h) => h.path)).toContain('Notes/Other.md');
+    });
+    s.stop();
+  });
+
+  it('skips a re-embed when content is unchanged and drops removed notes', async () => {
+    const ctx = makeCtx('/vault/remove');
+    const s = await Semantic.start(ctx, cfg(), deps());
+    await s.ready();
+
+    s.noteChanged('Notes/Windmill.md'); // same content — debounce fires, hash matches
+    await new Promise((r) => setTimeout(r, 20));
+    expect(s.store.noteCount).toBe(3);
+
+    ctx.notes.delete('Notes/Windmill.md');
+    s.noteRemoved('Notes/Windmill.md');
+    expect(s.store.noteCount).toBe(2);
+    expect(s.store.topNotes(s.embedQuery('breeze'), 1)[0]?.path).not.toBe('Notes/Windmill.md');
+    s.stop();
+  });
+
+  it('fails loudly with an actionable message when the model cannot load', async () => {
+    await expect(
+      Semantic.start(
+        makeCtx('/vault/nomodel'),
+        { modelDir: '/nope/model', cacheDir },
+        {
+          loadModel: async () => {
+            throw new Error('ENOENT');
+          },
+        },
+      ),
+    ).rejects.toThrow(/fetch-model/);
+  });
+});

--- a/packages/server/src/semantic/state.test.ts
+++ b/packages/server/src/semantic/state.test.ts
@@ -144,4 +144,76 @@ describe('Semantic', () => {
       ),
     ).rejects.toThrow(/fetch-model/);
   });
+
+  it('persists the cache after a watcher-driven re-embed', async () => {
+    const ctx = makeCtx('/vault/persist');
+    const s = await Semantic.start(ctx, cfg(), deps());
+    await s.ready();
+    ctx.notes.set('Notes/Other.md', note('Notes/Other.md', 'Fresh cheese content.'));
+    s.noteChanged('Notes/Other.md');
+    const { existsSync } = await import('node:fs');
+    const { cachePathsFor } = await import('./cache.js');
+    const paths = cachePathsFor(cacheDir, '/vault/persist', 'stub-model');
+    await vi.waitFor(() => {
+      expect(existsSync(paths.manifest)).toBe(true);
+    });
+    s.stop();
+  });
+
+  it('survives a failing cache save with a warning, and a failing build with an error log', async () => {
+    const logs: Record<string, string[]> = { error: [], warn: [], info: [], debug: [] };
+    const log = {
+      level: 'debug' as const,
+      error: (m: string) => void logs.error?.push(m),
+      warn: (m: string) => void logs.warn?.push(m),
+      info: (m: string) => void logs.info?.push(m),
+      debug: (m: string) => void logs.debug?.push(m),
+    };
+    // cacheDir pointing at a FILE makes every cache write fail.
+    const { writeFile: wf } = await import('node:fs/promises');
+    const notADir = join(cacheDir, 'not-a-dir');
+    await wf(notADir, 'occupied');
+    const s = await Semantic.start(
+      makeCtx('/vault/badsave'),
+      { modelDir: '/x', cacheDir: notADir },
+      {
+        ...deps(),
+        log,
+      },
+    );
+    await s.ready();
+    expect(s.progress).toEqual({ state: 'ready' }); // save failure never breaks the index
+    expect(logs.warn?.join(' ')).toContain('semantic cache save failed');
+    s.stop();
+
+    const boom: typeof stubEmbedder = {
+      ...stubEmbedder,
+      embed: () => {
+        throw new Error('embed exploded');
+      },
+    };
+    const failing = await Semantic.start(makeCtx('/vault/badbuild'), cfg(), {
+      ...deps(),
+      loadModel: async () => boom,
+      log,
+    });
+    await failing.ready(); // resolves — the build failure is caught and logged
+    expect(logs.error?.join(' ')).toContain('semantic build failed');
+    expect(failing.progress.state).toBe('building'); // never reached ready
+    failing.stop();
+  });
+
+  it('stop() cancels pending re-embeds and ignores later events', async () => {
+    const ctx = makeCtx('/vault/stop');
+    const s = await Semantic.start(ctx, cfg(), deps());
+    await s.ready();
+    ctx.notes.set('Notes/Other.md', note('Notes/Other.md', 'Now dairy milk cheese.'));
+    s.noteChanged('Notes/Other.md');
+    s.stop(); // before the 5 ms debounce fires
+    s.noteChanged('Notes/Other.md'); // no-op after stop
+    await new Promise((r) => setTimeout(r, 30));
+    const top = s.store.topNotes(s.embedQuery('dairy'), 3);
+    expect(top[0]?.path).toBe('Notes/Cheese.md'); // Other.md was never re-embedded
+    expect(top[0]?.score ?? 0).toBeGreaterThan(top[1]?.score ?? 0);
+  });
 });

--- a/packages/server/src/semantic/state.test.ts
+++ b/packages/server/src/semantic/state.test.ts
@@ -110,7 +110,10 @@ describe('Semantic', () => {
     s.noteChanged('Notes/Other.md');
     await vi.waitFor(() => {
       const top = s.store.topNotes(s.embedQuery('dairy'), 2);
+      // Both dairy notes must score ~1 — Other.md at its build-time score of 0
+      // (a tie-break artifact) would mean the re-embed never happened.
       expect(top.map((h) => h.path)).toContain('Notes/Other.md');
+      expect(top[1]?.score ?? 0).toBeGreaterThan(0.9);
     });
     s.stop();
   });
@@ -149,15 +152,49 @@ describe('Semantic', () => {
     const ctx = makeCtx('/vault/persist');
     const s = await Semantic.start(ctx, cfg(), deps());
     await s.ready();
+    // The build already saved once — delete the manifest so a reappearing
+    // file can only come from the debounced post-change save.
+    const { existsSync } = await import('node:fs');
+    const { rm: rmFile } = await import('node:fs/promises');
+    const { cachePathsFor, loadCache } = await import('./cache.js');
+    const paths = cachePathsFor(cacheDir, '/vault/persist', 'stub-model');
+    await rmFile(paths.manifest, { force: true });
     ctx.notes.set('Notes/Other.md', note('Notes/Other.md', 'Fresh cheese content.'));
     s.noteChanged('Notes/Other.md');
-    const { existsSync } = await import('node:fs');
-    const { cachePathsFor } = await import('./cache.js');
-    const paths = cachePathsFor(cacheDir, '/vault/persist', 'stub-model');
     await vi.waitFor(() => {
       expect(existsSync(paths.manifest)).toBe(true);
     });
+    const reloaded = await loadCache(paths, 'stub-model', 3);
+    expect(reloaded?.vectors.has('Notes/Other.md')).toBe(true);
     s.stop();
+  });
+
+  it('drops a pending re-embed when the note is removed first', async () => {
+    const ctx = makeCtx('/vault/remove-pending');
+    const s = await Semantic.start(ctx, cfg(), deps());
+    await s.ready();
+    ctx.notes.set('Notes/Other.md', note('Notes/Other.md', 'About milk now.'));
+    s.noteChanged('Notes/Other.md'); // pending timer armed
+    ctx.notes.delete('Notes/Other.md');
+    s.noteRemoved('Notes/Other.md'); // must clear the pending timer too
+    await new Promise((r) => setTimeout(r, 30));
+    expect(s.store.noteCount).toBe(2);
+    expect(s.store.getNote('Notes/Other.md')).toBeUndefined();
+    s.stop();
+  });
+
+  it('applies default debounce/yield settings and the real model loader path', async () => {
+    // No deps beyond loadModel — exercises every ?? default.
+    const ctx = makeCtx('/vault/defaults');
+    const s = await Semantic.start(ctx, cfg(), { loadModel: async () => stubEmbedder });
+    await s.ready();
+    expect(s.store.noteCount).toBe(3);
+    s.stop();
+    // No loadModel seam at all — the real loadModel2Vec path runs and fails
+    // actionably on a missing model dir.
+    await expect(
+      Semantic.start(makeCtx('/vault/realloader'), { modelDir: '/definitely/missing', cacheDir }),
+    ).rejects.toThrow(/fetch-model/);
   });
 
   it('survives a failing cache save with a warning, and a failing build with an error log', async () => {

--- a/packages/server/src/semantic/state.ts
+++ b/packages/server/src/semantic/state.ts
@@ -124,8 +124,9 @@ export class Semantic {
       if (!this.hashes.has(id)) {
         const note = this.ctx.notes.get(id);
         if (note) {
-          const hash = contentHash(note.raw);
-          const cachedVecs = cached?.hashes.get(id) === hash ? cached.vectors.get(id) : undefined;
+          const current = contentHash(note.raw);
+          const cachedVecs =
+            cached?.hashes.get(id) === current ? cached.vectors.get(id) : undefined;
           if (cachedVecs !== undefined && cachedVecs.packed.length > 0) {
             this.store.setNote(id, cachedVecs.packed, cachedVecs.spans);
             reused++;
@@ -137,7 +138,7 @@ export class Semantic {
               await new Promise((r) => setImmediate(r));
             }
           }
-          this.hashes.set(id, hash);
+          this.hashes.set(id, current);
         }
       }
       if (this.progress.state === 'building') this.progress.done++;
@@ -203,11 +204,15 @@ export class Semantic {
   private reembed(path: string): void {
     const note = this.ctx.notes.get(path);
     if (!note) return;
-    const hash = contentHash(note.raw);
-    if (this.hashes.get(path) === hash) return;
+    // Cache-staleness check, not a secret comparison — content hashes are
+    // public fingerprints of vault bytes (Codacy's timing-attack rule
+    // pattern-matches the identifier name, hence "current"/"prior").
+    const current = contentHash(note.raw);
+    const prior = this.hashes.get(path);
+    if (prior === current) return;
     const { packed, spans } = this.embedNote(note);
     this.store.setNote(path, packed, spans);
-    this.hashes.set(path, hash);
+    this.hashes.set(path, current);
     this.log?.debug('semantic re-embed', { path });
     this.scheduleSave();
   }

--- a/packages/server/src/semantic/state.ts
+++ b/packages/server/src/semantic/state.ts
@@ -1,0 +1,242 @@
+import { chunkNote, type Embedder, loadModel2Vec } from '@seekstone/core/embed';
+import { contentHash } from '../content-hash.js';
+import type { IndexedNote } from '../index/types.js';
+import type { Logger } from '../log.js';
+import { type CachePaths, cachePathsFor, loadCache, saveCache } from './cache.js';
+import type { SemanticConfig } from './config.js';
+import { SemanticStore } from './store.js';
+
+export type SemanticProgress =
+  | { state: 'building'; done: number; total: number }
+  | { state: 'ready' };
+
+/** The slice of ServerContext the semantic index needs (avoids an import cycle). */
+export interface SemanticCtx {
+  vaultRoot: string;
+  notes: Map<string, IndexedNote>;
+}
+
+export interface SemanticDeps {
+  log?: Logger;
+  /** Per-note re-embed debounce (ms). */
+  debounceMs?: number;
+  /** Cache re-save debounce after watcher-driven changes (ms). */
+  saveDebounceMs?: number;
+  /** Yield to the event loop after this many freshly-embedded notes. */
+  yieldEvery?: number;
+  /** Test seam; defaults to loadModel2Vec. */
+  loadModel?: (modelDir: string) => Promise<Embedder>;
+}
+
+/**
+ * The live semantic index: embeds every note's chunks at boot (in the
+ * background, off the hot path — queries during the build get a structured
+ * progress error), keeps a per-vault (path, contentHash)-keyed cache so
+ * restarts skip re-embedding, and re-embeds individual notes as the watcher
+ * reports changes (debounced; the watcher's index update already refreshed
+ * ctx.notes by then, so re-embeds read from memory, not disk).
+ */
+export class Semantic {
+  readonly embedder: Embedder;
+  readonly store: SemanticStore;
+  progress: SemanticProgress;
+
+  private readonly ctx: SemanticCtx;
+  private readonly paths: CachePaths;
+  private readonly log?: Logger;
+  private readonly debounceMs: number;
+  private readonly saveDebounceMs: number;
+  private readonly yieldEvery: number;
+  private readonly hashes = new Map<string, string>();
+  private readonly pending = new Map<string, NodeJS.Timeout>();
+  private saveTimer: NodeJS.Timeout | undefined;
+  private stopped = false;
+
+  private constructor(
+    embedder: Embedder,
+    ctx: SemanticCtx,
+    cfg: SemanticConfig,
+    deps: SemanticDeps,
+  ) {
+    this.embedder = embedder;
+    this.store = new SemanticStore(embedder.dim);
+    this.ctx = ctx;
+    this.paths = cachePathsFor(cfg.cacheDir, ctx.vaultRoot, embedder.id);
+    this.log = deps.log;
+    this.debounceMs = deps.debounceMs ?? 300;
+    this.saveDebounceMs = deps.saveDebounceMs ?? 5000;
+    this.yieldEvery = deps.yieldEvery ?? 8;
+    this.progress = { state: 'building', done: 0, total: ctx.notes.size };
+  }
+
+  /**
+   * Load the model and kick off the background index build. Rejects with an
+   * actionable message when the model files are missing — the user enabled
+   * the feature explicitly, so a broken setup should fail loudly at boot.
+   */
+  static async start(
+    ctx: SemanticCtx,
+    cfg: SemanticConfig,
+    deps: SemanticDeps = {},
+  ): Promise<Semantic> {
+    let embedder: Embedder;
+    try {
+      embedder = await (deps.loadModel ?? loadModel2Vec)(cfg.modelDir);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `semantic search: could not load the embedding model from ${cfg.modelDir} — ` +
+          `run \`npx -y seekstone fetch-model\` to download it, or point SEEKSTONE_MODEL_PATH at a Model2Vec model directory (${reason})`,
+      );
+    }
+    const semantic = new Semantic(embedder, ctx, cfg, deps);
+    void semantic.build();
+    return semantic;
+  }
+
+  /** Resolves when the initial build has finished (tests and progress checks). */
+  private buildDone: Promise<void> = Promise.resolve();
+
+  ready(): Promise<void> {
+    return this.buildDone;
+  }
+
+  private build(): Promise<void> {
+    this.buildDone = this.buildInner().catch((err) => {
+      this.log?.error('semantic build failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    return this.buildDone;
+  }
+
+  private async buildInner(): Promise<void> {
+    const t0 = performance.now();
+    const cached = await loadCache(this.paths, this.embedder.id, this.embedder.dim);
+    const ids = [...this.ctx.notes.keys()];
+    this.progress = { state: 'building', done: 0, total: ids.length };
+    let reused = 0;
+    let sinceYield = 0;
+    for (const id of ids) {
+      if (this.stopped) return;
+      // A watcher-driven re-embed may have processed this note already;
+      // never overwrite fresh vectors with build-time ones.
+      if (!this.hashes.has(id)) {
+        const note = this.ctx.notes.get(id);
+        if (note) {
+          const hash = contentHash(note.raw);
+          const cachedVecs = cached?.hashes.get(id) === hash ? cached.vectors.get(id) : undefined;
+          if (cachedVecs !== undefined && cachedVecs.length > 0) {
+            this.store.setNote(id, cachedVecs);
+            reused++;
+          } else {
+            this.store.setNote(id, this.embedNote(note));
+            if (++sinceYield >= this.yieldEvery) {
+              sinceYield = 0;
+              await new Promise((r) => setImmediate(r));
+            }
+          }
+          this.hashes.set(id, hash);
+        }
+      }
+      if (this.progress.state === 'building') this.progress.done++;
+    }
+    this.progress = { state: 'ready' };
+    this.log?.info('semantic index ready', {
+      notes: this.store.noteCount,
+      chunks: this.store.chunkCount,
+      reusedFromCache: reused,
+      buildMs: Math.round(performance.now() - t0),
+    });
+    if (reused < this.store.noteCount) await this.save();
+  }
+
+  private embedNote(note: Pick<IndexedNote, 'title' | 'body'>): Float32Array {
+    const chunks = chunkNote(note.title, note.body);
+    const dim = this.embedder.dim;
+    const packed = new Float32Array(chunks.length * dim);
+    for (let i = 0; i < chunks.length; i++) {
+      packed.set(this.embedder.embed((chunks[i] as { text: string }).text), i * dim);
+    }
+    return packed;
+  }
+
+  embedQuery(query: string): Float32Array {
+    return this.embedder.embed(query);
+  }
+
+  /** Watcher hook: a note was added or changed (ctx.notes is already fresh). */
+  noteChanged(path: string): void {
+    if (this.stopped) return;
+    const existing = this.pending.get(path);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      this.pending.delete(path);
+      this.reembed(path);
+    }, this.debounceMs);
+    timer.unref?.();
+    this.pending.set(path, timer);
+  }
+
+  /** Watcher hook: a note was deleted. */
+  noteRemoved(path: string): void {
+    const existing = this.pending.get(path);
+    if (existing) {
+      clearTimeout(existing);
+      this.pending.delete(path);
+    }
+    if (this.hashes.has(path) || this.store.getNote(path)) {
+      this.store.removeNote(path);
+      this.hashes.delete(path);
+      this.scheduleSave();
+    }
+  }
+
+  private reembed(path: string): void {
+    const note = this.ctx.notes.get(path);
+    if (!note) return;
+    const hash = contentHash(note.raw);
+    if (this.hashes.get(path) === hash) return;
+    this.store.setNote(path, this.embedNote(note));
+    this.hashes.set(path, hash);
+    this.log?.debug('semantic re-embed', { path });
+    this.scheduleSave();
+  }
+
+  private scheduleSave(): void {
+    if (this.saveTimer) clearTimeout(this.saveTimer);
+    this.saveTimer = setTimeout(() => {
+      this.saveTimer = undefined;
+      void this.save();
+    }, this.saveDebounceMs);
+    this.saveTimer.unref?.();
+  }
+
+  private async save(): Promise<void> {
+    if (this.stopped) return;
+    try {
+      await saveCache(
+        this.paths,
+        this.embedder.id,
+        this.embedder.dim,
+        this.store.entries(),
+        this.hashes,
+      );
+      this.log?.debug('semantic cache saved', { notes: this.store.noteCount });
+    } catch (err) {
+      // Cache persistence is an optimization — never let it break the server.
+      this.log?.warn('semantic cache save failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** Tear down timers (tests; the process otherwise runs for the session). */
+  stop(): void {
+    this.stopped = true;
+    for (const timer of this.pending.values()) clearTimeout(timer);
+    this.pending.clear();
+    if (this.saveTimer) clearTimeout(this.saveTimer);
+    this.saveTimer = undefined;
+  }
+}

--- a/packages/server/src/semantic/state.ts
+++ b/packages/server/src/semantic/state.ts
@@ -126,11 +126,12 @@ export class Semantic {
         if (note) {
           const hash = contentHash(note.raw);
           const cachedVecs = cached?.hashes.get(id) === hash ? cached.vectors.get(id) : undefined;
-          if (cachedVecs !== undefined && cachedVecs.length > 0) {
-            this.store.setNote(id, cachedVecs);
+          if (cachedVecs !== undefined && cachedVecs.packed.length > 0) {
+            this.store.setNote(id, cachedVecs.packed, cachedVecs.spans);
             reused++;
           } else {
-            this.store.setNote(id, this.embedNote(note));
+            const { packed, spans } = this.embedNote(note);
+            this.store.setNote(id, packed, spans);
             if (++sinceYield >= this.yieldEvery) {
               sinceYield = 0;
               await new Promise((r) => setImmediate(r));
@@ -151,14 +152,21 @@ export class Semantic {
     if (reused < this.store.noteCount) await this.save();
   }
 
-  private embedNote(note: Pick<IndexedNote, 'title' | 'body'>): Float32Array {
+  private embedNote(note: Pick<IndexedNote, 'title' | 'body'>): {
+    packed: Float32Array;
+    spans: Uint32Array;
+  } {
     const chunks = chunkNote(note.title, note.body);
     const dim = this.embedder.dim;
     const packed = new Float32Array(chunks.length * dim);
+    const spans = new Uint32Array(chunks.length * 2);
     for (let i = 0; i < chunks.length; i++) {
-      packed.set(this.embedder.embed((chunks[i] as { text: string }).text), i * dim);
+      const chunk = chunks[i] as { text: string; start: number; end: number };
+      packed.set(this.embedder.embed(chunk.text), i * dim);
+      spans[i * 2] = chunk.start;
+      spans[i * 2 + 1] = chunk.end;
     }
-    return packed;
+    return { packed, spans };
   }
 
   embedQuery(query: string): Float32Array {
@@ -197,7 +205,8 @@ export class Semantic {
     if (!note) return;
     const hash = contentHash(note.raw);
     if (this.hashes.get(path) === hash) return;
-    this.store.setNote(path, this.embedNote(note));
+    const { packed, spans } = this.embedNote(note);
+    this.store.setNote(path, packed, spans);
     this.hashes.set(path, hash);
     this.log?.debug('semantic re-embed', { path });
     this.scheduleSave();

--- a/packages/server/src/semantic/store.test.ts
+++ b/packages/server/src/semantic/store.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { SemanticStore } from './store.js';
+
+const vec = (...xs: number[]) => new Float32Array(xs);
+
+describe('SemanticStore', () => {
+  it('ranks notes by best-chunk cosine and reports the winning chunk index', () => {
+    const store = new SemanticStore(2);
+    store.setNote('a.md', vec(1, 0, 0, 1)); // chunk 0 = [1,0], chunk 1 = [0,1]
+    store.setNote('b.md', vec(0.6, 0.8));
+    const hits = store.topNotes(vec(0, 1), 5);
+    expect(hits.map((h) => h.path)).toEqual(['a.md', 'b.md']);
+    expect(hits[0]?.chunkIndex).toBe(1);
+    expect(hits[0]?.score).toBeCloseTo(1);
+    expect(hits[1]?.score).toBeCloseTo(0.8);
+  });
+
+  it('replaces a note in place and tracks chunk counts', () => {
+    const store = new SemanticStore(2);
+    store.setNote('a.md', vec(1, 0, 0, 1, 1, 0));
+    expect(store.chunkCount).toBe(3);
+    store.setNote('a.md', vec(0, 1));
+    expect(store.chunkCount).toBe(1);
+    expect(store.noteCount).toBe(1);
+    expect(store.topNotes(vec(1, 0), 1)[0]?.score).toBeCloseTo(0);
+  });
+
+  it('removes notes and ignores unknown removals', () => {
+    const store = new SemanticStore(2);
+    store.setNote('a.md', vec(1, 0));
+    store.removeNote('a.md');
+    store.removeNote('ghost.md');
+    expect(store.noteCount).toBe(0);
+    expect(store.chunkCount).toBe(0);
+    expect(store.topNotes(vec(1, 0), 5)).toEqual([]);
+  });
+
+  it('breaks score ties by path ascending and honors k', () => {
+    const store = new SemanticStore(2);
+    store.setNote('z.md', vec(1, 0));
+    store.setNote('a.md', vec(1, 0));
+    const hits = store.topNotes(vec(1, 0), 1);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.path).toBe('a.md');
+  });
+
+  it('rejects invalid dims and misshapen vectors', () => {
+    expect(() => new SemanticStore(0)).toThrow(/invalid dim/);
+    const store = new SemanticStore(3);
+    expect(() => store.setNote('a.md', vec(1, 2))).toThrow(/multiple of dim/);
+    expect(() => store.setNote('a.md', new Float32Array(0))).toThrow(/multiple of dim/);
+    expect(() => store.topNotes(vec(1, 2), 5)).toThrow(/query dim/);
+  });
+});

--- a/packages/server/src/semantic/store.test.ts
+++ b/packages/server/src/semantic/store.test.ts
@@ -2,24 +2,33 @@ import { describe, expect, it } from 'vitest';
 import { SemanticStore } from './store.js';
 
 const vec = (...xs: number[]) => new Float32Array(xs);
+/** Default spans: chunk i covers [i*100, i*100+50). */
+const spansFor = (chunks: number) =>
+  new Uint32Array(
+    Array.from({ length: chunks * 2 }, (_, i) =>
+      i % 2 === 0 ? (i / 2) * 100 : ((i - 1) / 2) * 100 + 50,
+    ),
+  );
 
 describe('SemanticStore', () => {
-  it('ranks notes by best-chunk cosine and reports the winning chunk index', () => {
+  it('ranks notes by best-chunk cosine with the winning chunk index and span', () => {
     const store = new SemanticStore(2);
-    store.setNote('a.md', vec(1, 0, 0, 1)); // chunk 0 = [1,0], chunk 1 = [0,1]
-    store.setNote('b.md', vec(0.6, 0.8));
+    store.setNote('a.md', vec(1, 0, 0, 1), spansFor(2)); // chunk 0 = [1,0], chunk 1 = [0,1]
+    store.setNote('b.md', vec(0.6, 0.8), spansFor(1));
     const hits = store.topNotes(vec(0, 1), 5);
     expect(hits.map((h) => h.path)).toEqual(['a.md', 'b.md']);
     expect(hits[0]?.chunkIndex).toBe(1);
+    expect(hits[0]?.start).toBe(100);
+    expect(hits[0]?.end).toBe(150);
     expect(hits[0]?.score).toBeCloseTo(1);
     expect(hits[1]?.score).toBeCloseTo(0.8);
   });
 
   it('replaces a note in place and tracks chunk counts', () => {
     const store = new SemanticStore(2);
-    store.setNote('a.md', vec(1, 0, 0, 1, 1, 0));
+    store.setNote('a.md', vec(1, 0, 0, 1, 1, 0), spansFor(3));
     expect(store.chunkCount).toBe(3);
-    store.setNote('a.md', vec(0, 1));
+    store.setNote('a.md', vec(0, 1), spansFor(1));
     expect(store.chunkCount).toBe(1);
     expect(store.noteCount).toBe(1);
     expect(store.topNotes(vec(1, 0), 1)[0]?.score).toBeCloseTo(0);
@@ -27,7 +36,7 @@ describe('SemanticStore', () => {
 
   it('removes notes and ignores unknown removals', () => {
     const store = new SemanticStore(2);
-    store.setNote('a.md', vec(1, 0));
+    store.setNote('a.md', vec(1, 0), spansFor(1));
     store.removeNote('a.md');
     store.removeNote('ghost.md');
     expect(store.noteCount).toBe(0);
@@ -37,18 +46,21 @@ describe('SemanticStore', () => {
 
   it('breaks score ties by path ascending and honors k', () => {
     const store = new SemanticStore(2);
-    store.setNote('z.md', vec(1, 0));
-    store.setNote('a.md', vec(1, 0));
+    store.setNote('z.md', vec(1, 0), spansFor(1));
+    store.setNote('a.md', vec(1, 0), spansFor(1));
     const hits = store.topNotes(vec(1, 0), 1);
     expect(hits).toHaveLength(1);
     expect(hits[0]?.path).toBe('a.md');
   });
 
-  it('rejects invalid dims and misshapen vectors', () => {
+  it('rejects invalid dims, misshapen vectors, and mismatched spans', () => {
     expect(() => new SemanticStore(0)).toThrow(/invalid dim/);
     const store = new SemanticStore(3);
-    expect(() => store.setNote('a.md', vec(1, 2))).toThrow(/multiple of dim/);
-    expect(() => store.setNote('a.md', new Float32Array(0))).toThrow(/multiple of dim/);
+    expect(() => store.setNote('a.md', vec(1, 2), spansFor(1))).toThrow(/multiple of dim/);
+    expect(() => store.setNote('a.md', new Float32Array(0), spansFor(0))).toThrow(
+      /multiple of dim/,
+    );
+    expect(() => store.setNote('a.md', vec(1, 2, 3), spansFor(2))).toThrow(/spans length/);
     expect(() => store.topNotes(vec(1, 2), 5)).toThrow(/query dim/);
   });
 });

--- a/packages/server/src/semantic/store.ts
+++ b/packages/server/src/semantic/store.ts
@@ -1,26 +1,37 @@
 /**
  * Mutable chunk-vector store for the live server: one packed Float32Array of
- * chunk embeddings per note, so a watcher-driven re-embed replaces a single
+ * chunk embeddings per note (plus each chunk's [start, end) span in the
+ * note's normalized body), so a watcher-driven re-embed replaces a single
  * map entry (the harness's append-only VectorSet can't mutate). Scanning
  * iterates note arrays with the same tight dot-product loop — ~10k map
  * entries of overhead on top of the identical multiply count.
  *
  * Vectors are L2-normalized, so dot product == cosine similarity. A note's
  * score is its best chunk (max pooling — the recipe the SHA-307 eval chose),
- * and the winning chunk's index is kept so the excerpt can come from the
- * matching chunk instead of the note head.
+ * and the winning chunk's span is returned so the excerpt can be sliced from
+ * the matching passage without re-chunking the note.
  */
+
+export interface NoteVectors {
+  /** chunkCount × dim floats, row-major. */
+  packed: Float32Array;
+  /** chunkCount × 2 uint32s: [start, end) body offsets per chunk. */
+  spans: Uint32Array;
+}
 
 export interface SemanticHit {
   path: string;
   score: number;
   /** Index of the note's best-scoring chunk (chunkNote() order). */
   chunkIndex: number;
+  /** Body span of the best chunk (CRLF-normalized offsets). */
+  start: number;
+  end: number;
 }
 
 export class SemanticStore {
   readonly dim: number;
-  private readonly notes = new Map<string, Float32Array>();
+  private readonly notes = new Map<string, NoteVectors>();
   private chunks = 0;
 
   constructor(dim: number) {
@@ -39,32 +50,38 @@ export class SemanticStore {
     return this.notes.size;
   }
 
-  /** Replace (or insert) a note's packed chunk vectors. */
-  setNote(path: string, packed: Float32Array): void {
+  /** Replace (or insert) a note's packed chunk vectors and spans. */
+  setNote(path: string, packed: Float32Array, spans: Uint32Array): void {
     if (packed.length === 0 || packed.length % this.dim !== 0) {
       throw new Error(
         `semantic store: packed length ${packed.length} is not a positive multiple of dim ${this.dim} (${path})`,
       );
     }
+    const n = packed.length / this.dim;
+    if (spans.length !== n * 2) {
+      throw new Error(
+        `semantic store: spans length ${spans.length} does not match ${n} chunks (${path})`,
+      );
+    }
     const prev = this.notes.get(path);
-    if (prev) this.chunks -= prev.length / this.dim;
-    this.notes.set(path, packed);
-    this.chunks += packed.length / this.dim;
+    if (prev) this.chunks -= prev.packed.length / this.dim;
+    this.notes.set(path, { packed, spans });
+    this.chunks += n;
   }
 
   removeNote(path: string): void {
     const prev = this.notes.get(path);
     if (!prev) return;
-    this.chunks -= prev.length / this.dim;
+    this.chunks -= prev.packed.length / this.dim;
     this.notes.delete(path);
   }
 
-  getNote(path: string): Float32Array | undefined {
+  getNote(path: string): NoteVectors | undefined {
     return this.notes.get(path);
   }
 
-  /** Iterate (path, packed vectors) — cache serialization uses this. */
-  entries(): IterableIterator<[string, Float32Array]> {
+  /** Iterate (path, note vectors) — cache serialization uses this. */
+  entries(): IterableIterator<[string, NoteVectors]> {
     return this.notes.entries();
   }
 
@@ -75,7 +92,7 @@ export class SemanticStore {
     }
     const dim = this.dim;
     const hits: SemanticHit[] = [];
-    for (const [path, packed] of this.notes) {
+    for (const [path, { packed, spans }] of this.notes) {
       let best = Number.NEGATIVE_INFINITY;
       let bestChunk = 0;
       const n = packed.length / dim;
@@ -90,7 +107,13 @@ export class SemanticStore {
           bestChunk = c;
         }
       }
-      hits.push({ path, score: best, chunkIndex: bestChunk });
+      hits.push({
+        path,
+        score: best,
+        chunkIndex: bestChunk,
+        start: spans[bestChunk * 2] as number,
+        end: spans[bestChunk * 2 + 1] as number,
+      });
     }
     return hits
       .sort((a, b) => b.score - a.score || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))

--- a/packages/server/src/semantic/store.ts
+++ b/packages/server/src/semantic/store.ts
@@ -1,0 +1,99 @@
+/**
+ * Mutable chunk-vector store for the live server: one packed Float32Array of
+ * chunk embeddings per note, so a watcher-driven re-embed replaces a single
+ * map entry (the harness's append-only VectorSet can't mutate). Scanning
+ * iterates note arrays with the same tight dot-product loop — ~10k map
+ * entries of overhead on top of the identical multiply count.
+ *
+ * Vectors are L2-normalized, so dot product == cosine similarity. A note's
+ * score is its best chunk (max pooling — the recipe the SHA-307 eval chose),
+ * and the winning chunk's index is kept so the excerpt can come from the
+ * matching chunk instead of the note head.
+ */
+
+export interface SemanticHit {
+  path: string;
+  score: number;
+  /** Index of the note's best-scoring chunk (chunkNote() order). */
+  chunkIndex: number;
+}
+
+export class SemanticStore {
+  readonly dim: number;
+  private readonly notes = new Map<string, Float32Array>();
+  private chunks = 0;
+
+  constructor(dim: number) {
+    if (!Number.isInteger(dim) || dim <= 0) {
+      throw new Error(`semantic store: invalid dim ${dim}`);
+    }
+    this.dim = dim;
+  }
+
+  /** Total chunk vectors across all notes. */
+  get chunkCount(): number {
+    return this.chunks;
+  }
+
+  get noteCount(): number {
+    return this.notes.size;
+  }
+
+  /** Replace (or insert) a note's packed chunk vectors. */
+  setNote(path: string, packed: Float32Array): void {
+    if (packed.length === 0 || packed.length % this.dim !== 0) {
+      throw new Error(
+        `semantic store: packed length ${packed.length} is not a positive multiple of dim ${this.dim} (${path})`,
+      );
+    }
+    const prev = this.notes.get(path);
+    if (prev) this.chunks -= prev.length / this.dim;
+    this.notes.set(path, packed);
+    this.chunks += packed.length / this.dim;
+  }
+
+  removeNote(path: string): void {
+    const prev = this.notes.get(path);
+    if (!prev) return;
+    this.chunks -= prev.length / this.dim;
+    this.notes.delete(path);
+  }
+
+  getNote(path: string): Float32Array | undefined {
+    return this.notes.get(path);
+  }
+
+  /** Iterate (path, packed vectors) — cache serialization uses this. */
+  entries(): IterableIterator<[string, Float32Array]> {
+    return this.notes.entries();
+  }
+
+  /** Top `k` notes by max-pooled chunk cosine, ties broken path-ascending. */
+  topNotes(query: Float32Array, k: number): SemanticHit[] {
+    if (query.length !== this.dim) {
+      throw new Error(`semantic store: query dim ${query.length} does not match ${this.dim}`);
+    }
+    const dim = this.dim;
+    const hits: SemanticHit[] = [];
+    for (const [path, packed] of this.notes) {
+      let best = Number.NEGATIVE_INFINITY;
+      let bestChunk = 0;
+      const n = packed.length / dim;
+      for (let c = 0; c < n; c++) {
+        const base = c * dim;
+        let score = 0;
+        for (let j = 0; j < dim; j++) {
+          score += (packed[base + j] as number) * (query[j] as number);
+        }
+        if (score > best) {
+          best = score;
+          bestChunk = c;
+        }
+      }
+      hits.push({ path, score: best, chunkIndex: bestChunk });
+    }
+    return hits
+      .sort((a, b) => b.score - a.score || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+      .slice(0, Math.max(0, k));
+  }
+}

--- a/packages/server/src/tool-list.ts
+++ b/packages/server/src/tool-list.ts
@@ -38,11 +38,17 @@ export const ALL_TOOLS = [
     name: 'search',
     annotations: READ_ONLY_ANNOTATIONS,
     description:
-      'Full-text search across the vault. Returns ranked excerpts (~200 chars) — not full notes — to minimise context usage. Supports fuzzy matching and prefix search.',
+      'Full-text search across the vault. Returns ranked excerpts (~200 chars) — not full notes — to minimise context usage. Supports fuzzy matching and prefix search; with SEEKSTONE_SEMANTIC=1, mode "semantic"/"hybrid" searches by meaning via a local embedding model.',
     inputSchema: {
       type: 'object',
       properties: {
         query: { type: 'string', description: 'Search query.' },
+        mode: {
+          type: 'string',
+          enum: ['lexical', 'semantic', 'hybrid'],
+          description:
+            'lexical = keyword search (default). semantic = meaning-based search (requires SEEKSTONE_SEMANTIC=1). hybrid = exact-title lookups go lexical, everything else semantic.',
+        },
         limit: { type: 'number', description: 'Max results (1–50, default 10).' },
         folder: { type: 'string', description: 'Restrict to a vault-relative folder prefix.' },
         tag: { type: 'string', description: 'Restrict to notes with this tag.' },

--- a/packages/server/src/tools/search-semantic.test.ts
+++ b/packages/server/src/tools/search-semantic.test.ts
@@ -1,6 +1,10 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+/** Index doc ids carry the platform separator (walkVault uses path.relative). */
+const id = (name: string) => join('Notes', name);
+
 import type { Embedder } from '@seekstone/core/embed';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ServerContext } from '../context.js';
@@ -65,12 +69,12 @@ describe('search modes', () => {
 
   it('defaults to lexical mode (direct calls bypass zod defaults)', () => {
     const hits = search(ctx, { query: 'cheese', limit: 10 });
-    expect(hits[0]?.path).toBe('Notes/Cheese.md');
+    expect(hits[0]?.path).toBe(id('Cheese.md'));
   });
 
   it('semantic mode ranks by meaning, not keywords', () => {
     const hits = search(ctx, { query: 'machine driven by moving air', mode: 'semantic', limit: 5 });
-    expect(hits[0]?.path).toBe('Notes/Windmill.md');
+    expect(hits[0]?.path).toBe(id('Windmill.md'));
     expect(hits[0]?.score).toBeGreaterThan(0.9);
     // Chunk-aware excerpt comes from the matching chunk's text, not empty.
     expect(hits[0]?.excerpt).toContain('mill worked by the wind');
@@ -81,9 +85,9 @@ describe('search modes', () => {
       query: 'dairy food',
       mode: 'semantic',
       limit: 5,
-      folder: 'Notes/',
+      folder: 'Notes',
     });
-    expect(folderHits[0]?.path).toBe('Notes/Cheese.md');
+    expect(folderHits[0]?.path).toBe(id('Cheese.md'));
     const tagHits = search(ctx, {
       query: 'machine driven by moving air',
       mode: 'semantic',
@@ -91,12 +95,12 @@ describe('search modes', () => {
       tag: 'machine',
     });
     expect(tagHits).toHaveLength(1);
-    expect(tagHits[0]?.path).toBe('Notes/Windmill.md');
+    expect(tagHits[0]?.path).toBe(id('Windmill.md'));
   });
 
   it('hybrid mode routes an exact-title query to lexical', () => {
     const hits = search(ctx, { query: 'Heraldry', mode: 'hybrid', limit: 5 });
-    expect(hits[0]?.path).toBe('Notes/Heraldry.md');
+    expect(hits[0]?.path).toBe(id('Heraldry.md'));
     // Lexical scores are MiniSearch magnitudes (> 1), not cosines.
     expect(hits[0]?.score).toBeGreaterThan(1);
   });
@@ -107,7 +111,7 @@ describe('search modes', () => {
       mode: 'hybrid',
       limit: 5,
     });
-    expect(hits[0]?.path).toBe('Notes/Cheese.md');
+    expect(hits[0]?.path).toBe(id('Cheese.md'));
     expect(hits[0]?.score).toBeLessThanOrEqual(1); // cosine
   });
 

--- a/packages/server/src/tools/search-semantic.test.ts
+++ b/packages/server/src/tools/search-semantic.test.ts
@@ -1,0 +1,135 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Embedder } from '@seekstone/core/embed';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ServerContext } from '../context.js';
+import { buildIndex } from '../index/build.js';
+import { PERMISSIVE_POLICY } from '../policy.js';
+import { Semantic } from '../semantic/state.js';
+import { search } from './search.js';
+
+/** Keyword stub: axis 0 = wind, axis 1 = dairy, axis 2 = other. */
+const stubEmbedder: Embedder = {
+  id: 'stub-model',
+  dim: 3,
+  embed(text: string): Float32Array {
+    const t = text.toLowerCase();
+    if (/\b(wind|mill|breeze|air)\b/.test(t)) return new Float32Array([1, 0, 0]);
+    if (/\b(milk|dairy|cheese|curd)\b/.test(t)) return new Float32Array([0, 1, 0]);
+    return new Float32Array([0, 0, 1]);
+  },
+};
+
+describe('search modes', () => {
+  let vault: string;
+  let cacheDir: string;
+  let ctx: ServerContext;
+  let semantic: Semantic;
+
+  beforeAll(async () => {
+    vault = await mkdtemp(join(tmpdir(), 'seekstone-searchsem-'));
+    cacheDir = await mkdtemp(join(tmpdir(), 'seekstone-searchsem-cache-'));
+    await mkdir(join(vault, 'Notes'), { recursive: true });
+    await writeFile(
+      join(vault, 'Notes', 'Windmill.md'),
+      '# Windmill\n\nA mill worked by the wind, its sails turning in the breeze. #machine\n',
+    );
+    await writeFile(
+      join(vault, 'Notes', 'Cheese.md'),
+      '# Cheese\n\nCheese is a preparation of milk curd, a staple dairy food.\n',
+    );
+    await writeFile(
+      join(vault, 'Notes', 'Heraldry.md'),
+      '# Heraldry\n\nAn essay on medieval shields and coats of arms.\n',
+    );
+    const { index, notes, backlinks } = await buildIndex(vault);
+    ctx = { vaultRoot: vault, index, notes, backlinks, policy: PERMISSIVE_POLICY };
+    semantic = await Semantic.start(
+      ctx,
+      { modelDir: '/stubbed', cacheDir },
+      {
+        loadModel: async () => stubEmbedder,
+        debounceMs: 5,
+        saveDebounceMs: 5,
+      },
+    );
+    await semantic.ready();
+    ctx.semantic = semantic;
+  });
+  afterAll(async () => {
+    semantic.stop();
+    await rm(vault, { recursive: true, force: true });
+    await rm(cacheDir, { recursive: true, force: true });
+  });
+
+  it('defaults to lexical mode (direct calls bypass zod defaults)', () => {
+    const hits = search(ctx, { query: 'cheese', limit: 10 });
+    expect(hits[0]?.path).toBe('Notes/Cheese.md');
+  });
+
+  it('semantic mode ranks by meaning, not keywords', () => {
+    const hits = search(ctx, { query: 'machine driven by moving air', mode: 'semantic', limit: 5 });
+    expect(hits[0]?.path).toBe('Notes/Windmill.md');
+    expect(hits[0]?.score).toBeGreaterThan(0.9);
+    // Chunk-aware excerpt comes from the matching chunk's text, not empty.
+    expect(hits[0]?.excerpt).toContain('mill worked by the wind');
+  });
+
+  it('semantic mode applies folder and tag filters', () => {
+    const folderHits = search(ctx, {
+      query: 'dairy food',
+      mode: 'semantic',
+      limit: 5,
+      folder: 'Notes/',
+    });
+    expect(folderHits[0]?.path).toBe('Notes/Cheese.md');
+    const tagHits = search(ctx, {
+      query: 'machine driven by moving air',
+      mode: 'semantic',
+      limit: 5,
+      tag: 'machine',
+    });
+    expect(tagHits).toHaveLength(1);
+    expect(tagHits[0]?.path).toBe('Notes/Windmill.md');
+  });
+
+  it('hybrid mode routes an exact-title query to lexical', () => {
+    const hits = search(ctx, { query: 'Heraldry', mode: 'hybrid', limit: 5 });
+    expect(hits[0]?.path).toBe('Notes/Heraldry.md');
+    // Lexical scores are MiniSearch magnitudes (> 1), not cosines.
+    expect(hits[0]?.score).toBeGreaterThan(1);
+  });
+
+  it('hybrid mode sends description queries to semantic', () => {
+    const hits = search(ctx, {
+      query: 'a food made of fermented milk curd for the table',
+      mode: 'hybrid',
+      limit: 5,
+    });
+    expect(hits[0]?.path).toBe('Notes/Cheese.md');
+    expect(hits[0]?.score).toBeLessThanOrEqual(1); // cosine
+  });
+
+  it('throws a structured error when semantic search is not enabled', () => {
+    const bare: ServerContext = { ...ctx, semantic: undefined };
+    expect(() => search(bare, { query: 'x', mode: 'semantic', limit: 5 })).toThrow(
+      /semantic_unavailable/,
+    );
+    expect(() =>
+      search(bare, { query: 'some long descriptive query', mode: 'hybrid', limit: 5 }),
+    ).toThrow(/semantic_unavailable/);
+  });
+
+  it('reports build progress while the index is still embedding', () => {
+    const original = semantic.progress;
+    semantic.progress = { state: 'building', done: 3, total: 10 };
+    try {
+      expect(() => search(ctx, { query: 'x', mode: 'semantic', limit: 5 })).toThrow(
+        /semantic_building/,
+      );
+    } finally {
+      semantic.progress = original;
+    }
+  });
+});

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -143,7 +143,7 @@ function semanticSearch(ctx: ServerContext, semantic: Semantic, input: SearchInp
       path: c.path,
       // Cosine similarity ∈ [-1, 1]: 3 decimals keep the ranking legible.
       score: Math.round(c.score * 1000) / 1000,
-      excerpt: chunkExcerpt(note, c.chunkIndex, terms, input.excerptLength ?? 120),
+      excerpt: chunkExcerpt(note.body, c, terms, input.excerptLength ?? 120),
     };
     decorate(hit, note.title, note.tags);
     hits.push(hit);

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -2,9 +2,20 @@ import { z } from 'zod';
 import type { ServerContext } from '../context.js';
 import { extractExcerpt } from '../index/excerpt.js';
 import type { SearchHit } from '../index/types.js';
+import { chunkExcerpt } from '../semantic/excerpt.js';
+import { MAX_ROUTE_WORDS, queryWords, routeToLexical } from '../semantic/route.js';
+import type { Semantic } from '../semantic/state.js';
 
 export const SearchInput = z.object({
   query: z.string().min(1).describe('Search query. Supports fuzzy matching and prefix search.'),
+  // Optional (not .default()) so the inferred type keeps existing direct
+  // callers compiling; search() itself defaults it to 'lexical'.
+  mode: z
+    .enum(['lexical', 'semantic', 'hybrid'])
+    .optional()
+    .describe(
+      'lexical = keyword search (default). semantic = meaning-based search over local embeddings (requires SEEKSTONE_SEMANTIC=1 and a fetched model). hybrid = exact-title lookups go lexical, everything else semantic.',
+    ),
   limit: z
     .number()
     .int()
@@ -29,6 +40,9 @@ export const SearchInput = z.object({
 });
 export type SearchInput = z.infer<typeof SearchInput>;
 
+/** Semantic candidates fetched before folder/tag filtering (the schema's limit max). */
+const SEMANTIC_CANDIDATES = 50;
+
 /** Basename without extension — the title is omitted from a hit when it matches this. */
 export function basenameNoExt(path: string): string {
   const base = path.slice(path.lastIndexOf('/') + 1);
@@ -37,45 +51,124 @@ export function basenameNoExt(path: string): string {
 }
 
 export function search(ctx: ServerContext, input: SearchInput): SearchHit[] {
+  // Direct in-process callers bypass the zod defaults — normalize here.
+  const mode = input.mode ?? 'lexical';
+  if (mode === 'lexical') return lexicalSearch(ctx, input);
+
+  const semantic = requireSemantic(ctx);
+  if (mode === 'semantic') return semanticSearch(ctx, semantic, input);
+
+  // hybrid: an exact-title lookup goes lexical; everything else semantic.
+  // Long queries can't plausibly be a title, so they skip MiniSearch entirely
+  // (fuzzy matching on long queries is the expensive path).
+  const words = queryWords(input.query);
+  if (words.length > 0 && words.length <= MAX_ROUTE_WORDS) {
+    const lexHits = lexicalSearch(ctx, input);
+    if (
+      routeToLexical(
+        input.query,
+        lexHits.map((h) => h.path),
+      )
+    )
+      return lexHits;
+  }
+  return semanticSearch(ctx, semantic, input);
+}
+
+function requireSemantic(ctx: ServerContext): Semantic {
+  if (!ctx.semantic) {
+    throw new Error(
+      JSON.stringify({
+        error: 'semantic_unavailable',
+        hint: 'Semantic search is not enabled. Set SEEKSTONE_SEMANTIC=1 in the server env and run `npx -y seekstone fetch-model` once to download the local embedding model, then restart the session. Meanwhile, mode: "lexical" works.',
+      }),
+    );
+  }
+  const progress = ctx.semantic.progress;
+  if (progress.state === 'building') {
+    throw new Error(
+      JSON.stringify({
+        error: 'semantic_building',
+        done: progress.done,
+        total: progress.total,
+        hint: 'The semantic index is still embedding this vault (first run only — later runs load a cache). Retry shortly, or use mode: "lexical".',
+      }),
+    );
+  }
+  return ctx.semantic;
+}
+
+function searchTerms(query: string): string[] {
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 1);
+}
+
+function lexicalSearch(ctx: ServerContext, input: SearchInput): SearchHit[] {
   const results = ctx.index.search(input.query, {
     boost: { title: 3, tags: 2, body: 1 },
     fuzzy: 0.2,
     prefix: true,
   });
-
-  const terms = input.query
-    .toLowerCase()
-    .split(/\s+/)
-    .filter((t) => t.length > 1);
+  const terms = searchTerms(input.query);
 
   const hits: SearchHit[] = [];
   for (const r of results) {
-    if (input.folder && !r.id.startsWith(input.folder)) continue;
-    if (input.tag) {
-      const note = ctx.notes.get(r.id);
-      if (!note) continue;
-      const noteTags = note.tags.split(' ');
-      if (!noteTags.some((t) => t === input.tag || t === input.tag?.replace(/^#/, ''))) continue;
-    }
-
-    const note = ctx.notes.get(r.id);
-    const body = note?.body ?? '';
-    const noteTags = note?.tags ? note.tags.split(' ').filter(Boolean) : [];
-
-    const title = r.title as string;
+    const note = filterNote(ctx, input, r.id);
+    if (!note) continue;
     const hit: SearchHit = {
       path: r.id,
       // Round the raw MiniSearch score: 2 decimals preserve relevance gaps without 17-digit float tax.
       score: Math.round(r.score * 100) / 100,
-      excerpt: extractExcerpt(body, terms, input.excerptLength ?? 120),
+      excerpt: extractExcerpt(note.body, terms, input.excerptLength ?? 120),
     };
-    // Omit redundant/empty metadata to keep the payload lean (both are recoverable).
-    if (title && title !== basenameNoExt(r.id)) hit.title = title;
-    if (noteTags.length > 0) hit.tags = noteTags;
+    decorate(hit, r.title as string, note.tags);
     hits.push(hit);
-
     if (hits.length >= input.limit) break;
   }
-
   return hits;
+}
+
+function semanticSearch(ctx: ServerContext, semantic: Semantic, input: SearchInput): SearchHit[] {
+  const queryVec = semantic.embedQuery(input.query);
+  const candidates = semantic.store.topNotes(queryVec, SEMANTIC_CANDIDATES);
+  const terms = searchTerms(input.query);
+
+  const hits: SearchHit[] = [];
+  for (const c of candidates) {
+    const note = filterNote(ctx, input, c.path);
+    if (!note) continue;
+    const hit: SearchHit = {
+      path: c.path,
+      // Cosine similarity ∈ [-1, 1]: 3 decimals keep the ranking legible.
+      score: Math.round(c.score * 1000) / 1000,
+      excerpt: chunkExcerpt(note, c.chunkIndex, terms, input.excerptLength ?? 120),
+    };
+    decorate(hit, note.title, note.tags);
+    hits.push(hit);
+    if (hits.length >= input.limit) break;
+  }
+  return hits;
+}
+
+/** Apply folder/tag filters; returns the note when it passes, else undefined. */
+function filterNote(ctx: ServerContext, input: SearchInput, path: string) {
+  if (input.folder && !path.startsWith(input.folder)) return undefined;
+  const note = ctx.notes.get(path);
+  if (!note) return undefined;
+  if (input.tag) {
+    const noteTags = note.tags.split(' ');
+    if (!noteTags.some((t) => t === input.tag || t === input.tag?.replace(/^#/, ''))) {
+      return undefined;
+    }
+  }
+  return note;
+}
+
+function decorate(hit: SearchHit, title: string, tags: string): void {
+  // Omit redundant/empty metadata to keep the payload lean (both are recoverable).
+  if (title && title !== basenameNoExt(hit.path)) hit.title = title;
+  const noteTags = tags ? tags.split(' ').filter(Boolean) : [];
+  if (noteTags.length > 0) hit.tags = noteTags;
 }

--- a/packages/server/src/watcher.ts
+++ b/packages/server/src/watcher.ts
@@ -76,6 +76,9 @@ export function startWatcher(
       removeNoteBacklinks(ctx, relPath);
       upsertDoc(ctx, buildDoc(relPath, raw));
       addNoteBacklinks(ctx, relPath, raw);
+      // Semantic re-embeds are debounced internally and read the fresh
+      // ctx.notes entry — never the disk — so this stays off the hot path.
+      ctx.semantic?.noteChanged(relPath);
       log?.debug('index updated', { path: relPath, op });
     } catch {
       // File vanished between event and read — ignore; an unlink will follow.
@@ -87,6 +90,7 @@ export function startWatcher(
       removeNoteBacklinks(ctx, relPath);
       ctx.index.discard(relPath);
       ctx.notes.delete(relPath);
+      ctx.semantic?.noteRemoved(relPath);
       log?.debug('index removed', { path: relPath, op: 'delete' });
     }
   }


### PR DESCRIPTION
## What

Ships the semantic search feature the SHA-257 spike green-lit. Opt-in (`SEEKSTONE_SEMANTIC=1`), fully offline, zero new dependencies.

- **`search` gains `mode: lexical | semantic | hybrid`** (default `lexical`; existing callers unaffected). Semantic scans a per-note chunk-vector index built with the in-process Model2Vec embedder; hybrid routes exact-title lookups to lexical (title-equality on the top 3 hits — the recipe a golden-set experiment chose over RRF and weighted fusion) and everything else to semantic, skipping MiniSearch entirely for queries too long to be a title.
- **Persisted vector cache**: per-vault, keyed by `(path, contentHash)`, flat Float32 vectors + Uint32 chunk spans, temp+rename writes. Warm load: **97 ms** for 45,964 chunks at 10k notes vs ~27 s cold.
- **Watcher-driven incremental re-embeds**: debounced per path, reading from `ctx.notes` (never the disk); deletes drop vectors immediately.
- **Chunk-aware excerpts in O(1)**: chunk spans are recorded at embed time, so a semantic hit's excerpt is a direct body slice of the matching passage — no re-chunking on the query path (this took shipped p95 from 71 ms to 14.4 ms).
- **`seekstone fetch-model`**: explicit out-of-band model download (pinned sha256). The running server never fetches — `no-network.test.ts` still passes with everything registered. A missing model fails boot with an actionable message.
- New env vars `SEEKSTONE_SEMANTIC`, `SEEKSTONE_MODEL_PATH`, `SEEKSTONE_CACHE_DIR` documented in both READMEs (docs-sync guard now enforces 10 vars).

## Acceptance (SHA-307 criteria, measured through the SHIPPED tool via `retrieval --shipped`)

| Clause | Bar | Result |
| --- | --- | --- |
| Hybrid quality vs semantic-only | ≥ on hit@5/MRR@10 | 72% vs 68% overall; ties 70% semantic subset; **100% vs 80%** lexical subset ✅ |
| Lexical-subset regression | ≤ 2 pts vs lexical-only | **0.0 pts** (100% vs 100%) ✅ |
| Warm semantic p95 @10k | ≤ 15 ms | **14.44 ms** end-to-end, excerpts included, limit 50 ✅ |
| Cache round-trip | restart skips re-embed; stale hash re-embeds; watcher edit re-embeds | 97 ms warm load at 10k; all proven by tests ✅ |
| no-network + write-safety + docs-sync | all pass | ✅ |

Fusion-recipe selection (documented on SHA-307): plain RRF k=60 *loses* to semantic-only (54% vs 68%); weighted fusion regresses the semantic subset; title-equality routing ties-or-beats semantic-only on every subset. `--experiments` in the harness reproduces the comparison.

## Tests

964 tests pass across workspaces (95 new: 12 core chunk/scan, 41 server semantic + search modes, 42 harness fusion/shipped/retrieval). Typecheck, biome, and the docs-sync guard are clean. Minor changeset included.