### PR TITLE
SHA-318: fix .mcpb startup crash — force single-file bundle, guard against chunk emission

### DIFF
--- a/.changeset/mcpb-single-file-bundle.md
+++ b/.changeset/mcpb-single-file-bundle.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Fix the .mcpb extension crashing at startup (`ERR_MODULE_NOT_FOUND: chunk-*.js`). tsup's ESM code splitting (default-on) emitted separate chunk files for the dynamic `import()` introduced with semantic search in 0.15.0, and the mcpb pipeline only ships the sharded `index.js` — the chunks were silently dropped, so the installed extension died on launch. Both builds now set `splitting: false`, and `build-mcpb.mjs` fails loudly if the build ever emits more than one file.

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
   target: 'node22',
   outDir: 'dist',
   bundle: true,
+  // tsup defaults splitting to true for ESM; a dynamic import() then emits
+  // chunk-*.js files and the output stops being a single-file bundle.
+  splitting: false,
   // Force the otherwise-default-external workspace package to be inlined.
   noExternal: [/^@seekstone\//],
   // Inline the package version so `seekstone --version` works in the bundle.

--- a/packages/server/tsup.mcpb.config.ts
+++ b/packages/server/tsup.mcpb.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
   target: 'node22',
   outDir: 'dist',
   bundle: true,
+  // tsup defaults splitting to true for ESM; a dynamic import() then emits
+  // chunk-*.js files that the shard/loader pipeline would drop, breaking the
+  // installed extension at startup. The output must stay a single file.
+  splitting: false,
   noExternal: [/.*/],
   banner: {
     js: `import { createRequire } from 'module'; var require = createRequire(import.meta.url);`,

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -49,6 +49,18 @@ console.log(`Stamped manifest.json with version ${version}`);
 console.log('Building server (mcpb — all deps bundled)...');
 execSync('npx tsup --config tsup.mcpb.config.ts', { stdio: 'inherit', cwd: serverDir });
 
+// Guard: the build must emit exactly one file. Only dist/index.js is sharded
+// and staged, so a chunk-*.js (from tsup's ESM code splitting, triggered by any
+// dynamic import()) would be silently dropped and the installed extension would
+// die at startup with ERR_MODULE_NOT_FOUND.
+const emitted = readdirSync(join(serverDir, 'dist')).filter((f) => f !== 'index.js');
+if (emitted.length > 0) {
+  throw new Error(
+    `mcpb: build emitted extra files next to dist/index.js (${emitted.join(', ')}). ` +
+      'The bundle must be a single file — check `splitting: false` in tsup.mcpb.config.ts.',
+  );
+}
+
 // 4. Stage metadata + the sharded bundle.
 console.log('Staging + sharding...');
 rmSync(stage, { recursive: true, force: true });


### PR DESCRIPTION
Fixes SHA-318.

## Symptom

Every `.mcpb` built since 0.15.0 crashes at startup — the installed extension dies before completing the MCP handshake, and Claude Desktop shows the server as disconnected. Running the installed bundle by hand:

```
ERR_MODULE_NOT_FOUND: Cannot find module '…/T/chunk-HOO7SMNQ.js'
imported from …/T/seekstone-bundle-9f85fe85cfe1f7e5.mjs
```

## Root cause

SHA-307 (#265) added a dynamic `await import('./semantic/fetch-model.js')` in `packages/server/src/index.ts`. tsup defaults `splitting: true` for ESM output, so that dynamic import made it emit `chunk-*.js` files alongside `dist/index.js`. `scripts/build-mcpb.mjs` only shards `dist/index.js` into the `.part` files the loader reassembles — the chunks were silently dropped, so the reassembled server can't resolve them and exits at module-link time.

The npm package is **not** affected (it ships the whole `dist/`, chunks included). The smoke test only covers the npm tarball, which is why nothing caught this.

## Fix

- `splitting: false` in both `tsup.mcpb.config.ts` and `tsup.config.ts` — dynamic imports get inlined and the output is genuinely a single file again.
- Guard in `build-mcpb.mjs`: fail the build loudly if tsup emits anything besides `dist/index.js` (same spirit as the SHA-169 per-file-size guard).
- Patch changeset → 0.15.1.

## Verification

Extracted the rebuilt `.mcpb` and drove a real MCP handshake against the 10k-note fixture vault: index builds (10,000 notes), 19 tools listed, `initialize` + `tools/list` answer correctly. Biome and the shard tests pass.

## Follow-up

Republish the rebuilt `.mcpb` wherever the 0.15.0 artifact is distributed — anyone who downloaded it has a broken extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAADJrpHu8uQ9qvF5qg8tQ