### PR TITLE
SHA-319: fix Windows backslash index keys — nested-note wikilinks, backlinks, path lookups

### DIFF
--- a/.changeset/windows-forward-slash-index-keys.md
+++ b/.changeset/windows-forward-slash-index-keys.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+Fix Windows breaking basename wikilink resolution, backlinks, and path lookups for notes in subdirectories (#268). The vault scan stored platform-native `path.relative()` output as the index key, so on Windows a nested note was keyed `Projects\Core.md` while wikilink resolution, the file watcher, and MCP client paths all assume forward slashes — `[[Core]]` never resolved, `get_backlinks` returned zero, and every path-keyed tool lookup missed. Index keys are now forward-slash vault-relative paths on every platform.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6151,7 +6151,7 @@
     },
     "packages/server": {
       "name": "seekstone",
-      "version": "0.13.1",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/packages/core/src/walk.test.ts
+++ b/packages/core/src/walk.test.ts
@@ -47,7 +47,18 @@ describe('walkVault', () => {
 
     expect(byRel['note.md']?.kind).toBe('note');
     expect(byRel['image.png']?.kind).toBe('image');
-    expect(byRel[join('sub', 'nested.md')]?.kind).toBe('note');
+    expect(byRel['sub/nested.md']?.kind).toBe('note');
+  });
+
+  it('returns forward-slash relPaths on every platform (SHA-319)', async () => {
+    // Windows CI is the run that makes this meaningful: path.relative()
+    // emits `sub\nested.md` there, and backslash keys break wikilink
+    // resolution and every notes.get(path) lookup downstream.
+    const entries = await walkVault(tmpDir);
+    for (const e of entries) {
+      expect(e.relPath).not.toContain('\\');
+      expect(e.topDir).not.toContain('\\');
+    }
   });
 
   it('reports sizeBytes > 0 for each entry', async () => {

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -77,8 +77,10 @@ export async function walkVault(vaultRoot: string): Promise<FileEntry[]> {
     const absPath = typeof m === 'string' ? m : m.path;
     const stats = typeof m === 'string' ? await stat(absPath) : m.stats;
     if (!stats) continue;
-    const relPath = relative(vaultRoot, absPath);
-    const topDir = relPath.split(sep)[0] ?? '';
+    // Index keys are forward-slash vault-relative paths on every platform —
+    // the watcher, wikilink resolution, and MCP tool inputs all assume `/`.
+    const relPath = relative(vaultRoot, absPath).split(sep).join('/');
+    const topDir = relPath.split('/')[0] ?? '';
     entries.push({
       absPath,
       relPath,

--- a/packages/harness/src/retrieval/lexical.ts
+++ b/packages/harness/src/retrieval/lexical.ts
@@ -31,10 +31,8 @@ export function rankLexicalScored(
   query: string,
   limit = 50,
 ): Array<{ path: string; score: number }> {
-  // Index doc ids carry the platform separator (walkVault uses path.relative);
-  // golden-set paths are forward-slash canonical, so normalize here.
   return searchTool(ctx, { query, limit }).map((h) => ({
-    path: h.path.replace(/\\/g, '/'),
+    path: h.path,
     score: h.score,
   }));
 }

--- a/packages/harness/src/retrieval/semantic.ts
+++ b/packages/harness/src/retrieval/semantic.ts
@@ -37,9 +37,7 @@ export async function buildSemanticIndex(
   // main thread either way, so it happens inline per note.
   await mapLimit(notes, 32, async (entry) => {
     const raw = await readFile(join(vaultRoot, entry.relPath), 'utf8');
-    // walkVault relPaths carry the platform separator; golden-set paths are
-    // forward-slash canonical, so normalize at the eval boundary.
-    const relPath = entry.relPath.replace(/\\/g, '/');
+    const relPath = entry.relPath;
     const fm = parseFrontmatter(raw);
     const fmTitle = fm.data?.title;
     const title =

--- a/packages/harness/src/retrieval/shipped.ts
+++ b/packages/harness/src/retrieval/shipped.ts
@@ -27,8 +27,7 @@ export async function buildShipped(
   await semantic.ready();
   ctx.semantic = semantic;
   return {
-    rank: (mode) => (query) =>
-      searchTool(ctx, { query, mode, limit: 50 }).map((h) => h.path.replace(/\\/g, '/')),
+    rank: (mode) => (query) => searchTool(ctx, { query, mode, limit: 50 }).map((h) => h.path),
     buildMs: performance.now() - t0,
     stop: () => semantic.stop(),
   };

--- a/packages/server/src/index/build.test.ts
+++ b/packages/server/src/index/build.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -130,6 +130,29 @@ describe('buildIndex', () => {
     const note = notes.get('with-fm.md');
     expect(note?.tags).toContain('alpha');
     expect(note?.tags).toContain('beta');
+  });
+
+  it('nested-folder notes: forward-slash keys, basename + path wikilinks resolve (SHA-319)', async () => {
+    // On Windows, path.relative() emits `Projects\Core.md`; before the walk
+    // normalization that key broke resolveLink's basename split('/') and every
+    // notes.get() with a client-supplied `/`-style path. GH #268.
+    const nestedVault = await mkdtemp(join(tmpdir(), 'seekstone-nested-'));
+    try {
+      await mkdir(join(nestedVault, 'Projects'));
+      await writeFile(join(nestedVault, 'Projects', 'Core.md'), '# Core\n', 'utf8');
+      await writeFile(join(nestedVault, 'Home.md'), 'See [[Core]].\n', 'utf8');
+      await writeFile(join(nestedVault, 'ByPath.md'), 'See [[Projects/Core]].\n', 'utf8');
+
+      const { notes, backlinks } = await buildIndex(nestedVault);
+
+      expect(notes.has('Projects/Core.md')).toBe(true);
+      expect(backlinks.get('Projects/Core.md')).toEqual([
+        { path: 'ByPath.md', line: 1, linkType: 'wikilink' },
+        { path: 'Home.md', line: 1, linkType: 'wikilink' },
+      ]);
+    } finally {
+      await rm(nestedVault, { recursive: true, force: true });
+    }
   });
 
   it('backlinks index picks up frontmatter wikilinks split across lines by folding', async () => {

--- a/packages/server/src/semantic/route.ts
+++ b/packages/server/src/semantic/route.ts
@@ -20,8 +20,7 @@ export function routeToLexical(query: string, topPaths: readonly string[], topN 
   const words = new Set(queryWords(query));
   if (words.size === 0) return false;
   return topPaths.slice(0, topN).some((path) => {
-    // Index ids carry the platform separator — split on both.
-    const base = (path.split(/[\\/]/).pop() ?? '').replace(/\.md$/, '').toLowerCase();
+    const base = (path.split('/').pop() ?? '').replace(/\.md$/, '').toLowerCase();
     const parts = new Set(base.split(/\W+/).filter(Boolean));
     return parts.size === words.size && [...parts].every((p) => words.has(p));
   });

--- a/packages/server/src/tools/search-semantic.test.ts
+++ b/packages/server/src/tools/search-semantic.test.ts
@@ -2,8 +2,8 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-/** Index doc ids carry the platform separator (walkVault uses path.relative). */
-const id = (name: string) => join('Notes', name);
+/** Index doc ids are forward-slash vault-relative paths on every platform. */
+const id = (name: string) => `Notes/${name}`;
 
 import type { Embedder } from '@seekstone/core/embed';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';


### PR DESCRIPTION
Fixes #268.

## Root cause

`walkVault()` stored platform-native `path.relative()` output as the in-memory index key, so on Windows a nested note was keyed `Projects\Core.md` while everything downstream assumes `/`:

- `resolveLink()` extracts candidate basenames with `split('/')`, so the basename stayed `projects\core` and basename wikilinks (`[[Core]]`) to nested notes never resolved — breaking both `get_links` and the backlink index build.
- The watcher already normalizes its keys to `/` (`watcher.ts:71`, with a comment declaring the forward-slash invariant), so on Windows a watched edit re-indexed the same note under a second key.
- Every tool doing `ctx.notes.get(input.path)` with a client-supplied `/`-style path missed the `\`-keyed entry for nested notes.

## Fix

Normalize at the scan boundary: `walkVault` now emits forward-slash `relPath`/`topDir` on every platform, restoring the watcher's documented invariant for all consumers at once. With the invariant guaranteed, the downstream compensation is removed: `route.ts`'s both-separator split (also subtly wrong on posix, where `\` is a legal filename character) and three harness eval-boundary backslash rewrites (`lexical.ts`, `semantic.ts`, `shipped.ts`). `competitors.ts` keeps its rewrites — they normalize external competitor servers' output.

## Regression coverage

Written to exercise the bug for real on the `windows-latest` CI leg (trivially green on posix):

- `walk.test.ts`: `walkVault` emits no backslashes in `relPath`/`topDir`.
- `build.test.ts`: nested-folder fixture — `Projects/Core.md` keyed with `/`; both `[[Core]]` (basename) and `[[Projects/Core]]` (path-style) resolve into the backlink index.

Also verified end-to-end by driving the real `get_links`/`get_backlinks` tool functions against the issue's exact repro vault.

The `package-lock.json` hunk is a stale version sync (0.13.1 → 0.15.1) picked up from the last release commit.

Linear: SHA-319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWWAJVQdm1K3WN2A4SXSoE