### PR TITLE
fix(release): unmix the maxsim changeset (private core package broke every release run)

### DIFF
--- a/.changeset/maxsim-rerank.md
+++ b/.changeset/maxsim-rerank.md
@@ -1,6 +1,5 @@
 ---
 'seekstone': minor
-'@seekstone/core': minor
 ---
 
 Semantic and hybrid search now rerank the top-50 candidates with a static late-interaction MaxSim stage: per query token, the max cosine over the winning chunk's token vectors (IDF-weighted over the candidate set) is fused with the stage-1 score. Recovers discriminating terms that mean-pooling dilutes — dev-split semantic hit@5 70.4% → 85.2% with lexical routing untouched, no new dependencies, and no embedding-cache format change. Core gains `maxsimScore`/`maxsimScoreAll`/`maxsimScoreTokens`, `candidateSetIdf`, and per-token vector access (`TokenEmbedder`) on the Model2Vec loader.

--- a/.changeset/pooling-strategies-core.md
+++ b/.changeset/pooling-strategies-core.md
@@ -1,5 +1,0 @@
----
-'@seekstone/core': minor
----
-
-`scanTopNotes` accepts a `ChunkPooling` beyond `max`/`top2mean`: `{ kind: 'logdiscount', lambda }` and `{ kind: 'softmax', temperature }`, all driven by a new streaming `PoolAccumulator` (same dot products, aggregation only). Exported with `poolingId` / `assertValidPooling`.


### PR DESCRIPTION
The Release workflow has failed on every main push since #291: `maxsim-rerank.md` declares both `seekstone` and the private, unpublished `@seekstone/core`, which the changesets pipeline treats as ignored — a 'mixed changeset' hard error in `changeset version`. This drops the core entry (core ships inside the server bundle; its API notes stay in the changeset prose) and removes the core-only `pooling-strategies-core.md`, unconsumable for the same reason. `changeset status` now resolves to a clean `seekstone` minor — unblocking the 0.17.0 release that carries MaxSim, the 32M opt-in, the write journal/undo, and the audit log.