### PR TITLE
perf(SHA-328): cold index no longer quadratic — resolveLink via precomputed maps

### DIFF
--- a/.changeset/quadratic-cold-index.md
+++ b/.changeset/quadratic-cold-index.md
@@ -1,0 +1,5 @@
+---
+'seekstone': patch
+---
+
+Cold index build no longer quadratic on link-heavy vaults. `resolveLink` used to scan every indexed note for each non-exact wikilink target, making backlink indexing O(links × notes) — ~17 minutes on a 10k-note vault with 131k links. Loose resolution now goes through basename/path lookup maps built once per index build (and once per watcher event), bringing that same build to seconds. Resolution precedence is unchanged (exact → +.md → basename → path-without-extension); ambiguous targets (duplicate basenames) now resolve deterministically to the lexicographically smallest note path instead of depending on index insertion order.

--- a/packages/server/src/index/backlinks.ts
+++ b/packages/server/src/index/backlinks.ts
@@ -1,6 +1,6 @@
 import { extractLinksWithLines } from '@seekstone/core/extract';
 import type { BacklinkRef, ServerContext } from '../context.js';
-import { resolveLink } from './resolve.js';
+import { buildResolveMaps, resolveLink } from './resolve.js';
 
 /**
  * Incremental backlink-index maintenance, shared by the watcher and the
@@ -11,8 +11,11 @@ import { resolveLink } from './resolve.js';
 export function removeNoteBacklinks(ctx: ServerContext, relPath: string): void {
   const oldDoc = ctx.notes.get(relPath);
   if (oldDoc === undefined) return;
-  for (const link of extractLinksWithLines(oldDoc.raw)) {
-    const resolved = resolveLink(link.target, ctx.notes);
+  const links = extractLinksWithLines(oldDoc.raw);
+  if (links.length === 0) return;
+  const maps = buildResolveMaps(ctx.notes);
+  for (const link of links) {
+    const resolved = resolveLink(link.target, ctx.notes, maps);
     if (resolved === undefined) continue;
     const arr = ctx.backlinks.get(resolved);
     if (arr === undefined) continue;
@@ -23,8 +26,11 @@ export function removeNoteBacklinks(ctx: ServerContext, relPath: string): void {
 
 export function addNoteBacklinks(ctx: ServerContext, relPath: string, raw: string): void {
   const seen = new Set<string>();
-  for (const link of extractLinksWithLines(raw)) {
-    const resolved = resolveLink(link.target, ctx.notes);
+  const links = extractLinksWithLines(raw);
+  if (links.length === 0) return;
+  const maps = buildResolveMaps(ctx.notes);
+  for (const link of links) {
+    const resolved = resolveLink(link.target, ctx.notes, maps);
     if (resolved === undefined) continue;
     const dedupeKey = `${relPath}\0${resolved}`;
     if (seen.has(dedupeKey)) continue;

--- a/packages/server/src/index/build.ts
+++ b/packages/server/src/index/build.ts
@@ -5,7 +5,7 @@ import { parseFrontmatter } from '@seekstone/core/frontmatter';
 import { walkVault } from '@seekstone/core/walk';
 import MiniSearch from 'minisearch';
 import type { BacklinkRef } from '../context.js';
-import { resolveLink } from './resolve.js';
+import { buildResolveMaps, resolveLink } from './resolve.js';
 import type { IndexedNote } from './types.js';
 
 export type VaultIndex = MiniSearch<IndexedNote>;
@@ -79,10 +79,11 @@ export async function buildIndex(vaultRoot: string): Promise<BuildResult> {
 
 function buildBacklinks(notes: Map<string, IndexedNote>): Map<string, BacklinkRef[]> {
   const result = new Map<string, BacklinkRef[]>();
+  const resolveMaps = buildResolveMaps(notes);
   for (const [srcPath, doc] of notes) {
     const seen = new Set<string>();
     for (const link of extractLinksWithLines(doc.raw)) {
-      const resolved = resolveLink(link.target, notes);
+      const resolved = resolveLink(link.target, notes, resolveMaps);
       if (resolved === undefined) continue;
       // De-duplicate: one entry per (source, resolved-target) pair
       const dedupeKey = `${srcPath}\0${resolved}`;

--- a/packages/server/src/index/resolve.test.ts
+++ b/packages/server/src/index/resolve.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildResolveMaps, resolveLink } from './resolve.js';
 
-const notesOf = (...paths: string[]): Map<string, unknown> =>
-  new Map(paths.map((p) => [p, {}]));
+const notesOf = (...paths: string[]): Map<string, unknown> => new Map(paths.map((p) => [p, {}]));
 
 describe('resolveLink', () => {
   it('exact path match wins', () => {

--- a/packages/server/src/index/resolve.test.ts
+++ b/packages/server/src/index/resolve.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { buildResolveMaps, resolveLink } from './resolve.js';
+
+const notesOf = (...paths: string[]): Map<string, unknown> =>
+  new Map(paths.map((p) => [p, {}]));
+
+describe('resolveLink', () => {
+  it('exact path match wins', () => {
+    const notes = notesOf('Projects/Core.md');
+    expect(resolveLink('Projects/Core.md', notes)).toBe('Projects/Core.md');
+  });
+
+  it('adds .md for path-style targets', () => {
+    const notes = notesOf('Projects/Core.md');
+    expect(resolveLink('Projects/Core', notes)).toBe('Projects/Core.md');
+  });
+
+  it('resolves a bare basename to a nested note', () => {
+    const notes = notesOf('Projects/Core.md', 'Home.md');
+    expect(resolveLink('Core', notes)).toBe('Projects/Core.md');
+  });
+
+  it('basename match is case-insensitive', () => {
+    const notes = notesOf('Projects/Core.md');
+    expect(resolveLink('core', notes)).toBe('Projects/Core.md');
+  });
+
+  it('path-without-extension match is case-insensitive', () => {
+    const notes = notesOf('Projects/Core.md');
+    expect(resolveLink('projects/core', notes)).toBe('Projects/Core.md');
+  });
+
+  it('exact match beats basename match', () => {
+    // Target names an existing full path; a same-basename note elsewhere must not win.
+    const notes = notesOf('a/Core.md', 'Core.md');
+    expect(resolveLink('Core.md', notes)).toBe('Core.md');
+    expect(resolveLink('Core', notes)).toBe('Core.md');
+  });
+
+  it('basename match beats path-without-extension match', () => {
+    // Documented precedence: the basename tier resolves before the case-variant
+    // full-path tier, so "b/note" goes to the basename winner (A < B) even
+    // though B/Note.md matches the target's full path case-insensitively.
+    const notes = notesOf('A/Note.md', 'B/Note.md');
+    expect(resolveLink('b/note', notes)).toBe('A/Note.md');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    const notes = notesOf('Projects/Core.md');
+    expect(resolveLink('Missing', notes)).toBeUndefined();
+    expect(resolveLink('Missing', new Map())).toBeUndefined();
+  });
+
+  it('ambiguous basename resolves deterministically regardless of insertion order', () => {
+    const a = ['Encyclopedia/I/Index.md', 'zoo/Index.md'];
+    const forward = notesOf(...a);
+    const reverse = notesOf(...[...a].reverse());
+    expect(resolveLink('index', forward)).toBe('Encyclopedia/I/Index.md');
+    expect(resolveLink('index', reverse)).toBe('Encyclopedia/I/Index.md');
+  });
+
+  it('prebuilt maps resolve identically to mapless calls', () => {
+    const notes = notesOf('Projects/Core.md', 'a/Core.md', 'Home.md', 'x/note.md', 'B/Note.md');
+    const maps = buildResolveMaps(notes);
+    for (const target of [
+      'Projects/Core.md',
+      'Projects/Core',
+      'Core',
+      'core',
+      'projects/core',
+      'b/note',
+      'Home',
+      'Missing',
+    ]) {
+      expect(resolveLink(target, notes, maps)).toBe(resolveLink(target, notes));
+    }
+  });
+});

--- a/packages/server/src/index/resolve.ts
+++ b/packages/server/src/index/resolve.ts
@@ -3,21 +3,49 @@
  *
  * Uses Obsidian's loose resolution: exact match → add .md → basename match
  * → path-without-extension match. Returns undefined if no note matches.
+ *
+ * Ambiguity (two notes sharing a basename, or case-variant paths) resolves to
+ * the lexicographically smallest note path — deterministic regardless of how
+ * the notes map was populated.
  */
-export function resolveLink(target: string, notes: Map<string, unknown>): string | undefined {
+
+export interface ResolveMaps {
+  /** lowercased basename (no .md) → winning note path */
+  byBasename: Map<string, string>;
+  /** lowercased path without .md → winning note path */
+  byPathNoExt: Map<string, string>;
+}
+
+/**
+ * Precompute the loose-resolution lookup maps for a notes map. Build once per
+ * batch (index build, watcher event) and pass to resolveLink so each loose
+ * resolution is O(1) instead of a scan of every note.
+ */
+export function buildResolveMaps(notes: Map<string, unknown>): ResolveMaps {
+  const byBasename = new Map<string, string>();
+  const byPathNoExt = new Map<string, string>();
+  for (const path of notes.keys()) {
+    const pathNoExt = path.replace(/\.md$/i, '').toLowerCase();
+    const base = pathNoExt.split('/').pop() ?? pathNoExt;
+    const prevBase = byBasename.get(base);
+    if (prevBase === undefined || path < prevBase) byBasename.set(base, path);
+    const prevPath = byPathNoExt.get(pathNoExt);
+    if (prevPath === undefined || path < prevPath) byPathNoExt.set(pathNoExt, path);
+  }
+  return { byBasename, byPathNoExt };
+}
+
+export function resolveLink(
+  target: string,
+  notes: Map<string, unknown>,
+  maps?: ResolveMaps,
+): string | undefined {
   if (notes.has(target)) return target;
   const withMd = `${target}.md`;
   if (notes.has(withMd)) return withMd;
 
+  const m = maps ?? buildResolveMaps(notes);
   const targetLower = target.toLowerCase();
-  const targetBase = (target.split('/').pop() ?? target).toLowerCase();
-
-  for (const path of notes.keys()) {
-    const pathNoExt = path.replace(/\.md$/i, '');
-    if (pathNoExt.toLowerCase() === targetLower) return path;
-    const pathBase = (pathNoExt.split('/').pop() ?? pathNoExt).toLowerCase();
-    if (pathBase === targetBase) return path;
-  }
-
-  return undefined;
+  const targetBase = targetLower.split('/').pop() ?? targetLower;
+  return m.byBasename.get(targetBase) ?? m.byPathNoExt.get(targetLower);
 }

--- a/packages/server/src/tools/rewrite_links.ts
+++ b/packages/server/src/tools/rewrite_links.ts
@@ -59,8 +59,9 @@ export interface RewriteNoteLinksResult {
 function wikiTargetFor(newPath: string, postNotes: Map<string, unknown>): string {
   const noExt = newPath.replace(/\.md$/i, '');
   const base = noExt.split('/').pop() ?? noExt;
-  // Count basename collisions directly — resolveLink picks the first match by
-  // map iteration order, which is not a stable notion of "unambiguous".
+  // Count basename collisions directly — resolveLink breaks ties toward the
+  // lexicographically smallest path, but "resolves for us" is not the same as
+  // "unambiguous in Obsidian".
   const baseLower = base.toLowerCase();
   let matches = 0;
   for (const p of postNotes.keys()) {


### PR DESCRIPTION
Fixes [SHA-328](https://linear.app/shaqster/issue/SHA-328/quadratic-cold-index-resolvelink-scans-all-notes-per-wikilink-17-min). Found by fixture v2 (SHA-322).

## Problem

`resolveLink` fell through to a linear scan of every indexed note for each non-exact wikilink target — which is every normal `[[Basename]]` link. `buildIndex → buildBacklinks` calls it once per link, so cold index build was **O(links × notes)**: 1,035 s on the fixture-v2 vault (10k notes, 131k links), paid at server startup on any link-dense vault and by the harness retrieval eval on every run.

## Fix

- `buildResolveMaps(notes)` precomputes two lookup maps (lowercased basename → path, lowercased path-no-ext → path); `resolveLink` takes them as an optional third arg and falls back to lazy construction, so exact-path hits stay O(1) at every call site and no other caller needed changes.
- `buildBacklinks` builds the maps once per cold index build; `addNoteBacklinks`/`removeNoteBacklinks` build them once per watcher/move event (fresh per operation — nothing cached, no staleness).
- Resolution precedence unchanged: exact → +.md → basename → path-without-extension.
- Ambiguous targets (duplicate basenames) now resolve **deterministically to the lexicographically smallest path**. The old tie-break was first-match in notes-map insertion order, which came from racing `Promise.all` readFile callbacks — non-deterministic across runs. Backlink indexes are now byte-identical across builds.

## Results (fixture v2, like-for-like)

| | before (committed v2 baseline) | after (this branch) |
| --- | ---: | ---: |
| Cold index, 10k notes / 131k links | 1,035,525 ms | **~12,900 ms (~80×)** |

## Verification

- 600 server tests pass (10 new in `resolve.test.ts`: precedence tiers, tie-break determinism, maps/mapless equivalence); 410 harness tests pass; typecheck clean.
- Old-vs-new resolution diffed on 20,490 fixture-v2 links: **0 differences**.
- Two consecutive builds produce byte-identical backlink indexes.
- Full shipped retrieval eval re-run on this branch: **zero hit@5/MRR changes** vs the committed v2 baseline; lexical build 1,035,525 → 11,410 ms in the eval's own measurement.

## Why the committed baseline is not refreshed here

The canonical `retrieval-eval.{json,md}` was produced on the 16-CPU machine. Regenerating it on this 10-CPU box would rewrite all warm latencies and flip the pre-registered ship gate for potion-base-8M (warm p95 13.73 → 19.07 ms) — a hardware artifact, not a code change. The stale `Lexical index build` metadata line refreshes with the next canon re-run on the canonical machine.

Changeset: `seekstone` patch.