### PR TITLE
fix(deps): bump transitive qs to 6.16.0 (SHA-331)

### DIFF
--- a/.changeset/qs-6-16-0.md
+++ b/.changeset/qs-6-16-0.md
@@ -1,0 +1,5 @@
+---
+'seekstone': patch
+---
+
+Bump transitive `qs` to 6.16.0 (via @modelcontextprotocol/sdk → express), resolving GHSA-4mjr-xmp4-gh2g (DoS via attacker-controlled isBuffer) and GHSA-x5fp-wj9c-mxmx (array-limit bypass via bracket-key comma parsing).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4852,9 +4852,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
Fixes [SHA-331](https://linear.app/shaqster/issue/SHA-331/fixdeps-bump-transitive-qs-to-6160-dependabot-alerts-34-35-ghsa-4mjr). Closes Dependabot alerts #34 and #35 (both moderate, same root cause).

- **#34** [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) — qs DoS via attacker-controlled isBuffer
- **#35** [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) — qs array-limit bypass via bracket-key comma parsing

`qs@6.15.3` reaches the published server's runtime tree via `@modelcontextprotocol/sdk` → `express` → `body-parser`. Both advisories are patched in `qs@6.16.0`, which the parent semver ranges (`^6.15.2`, `^6.14.0`) already admit — so this is a lockfile-only `npm update qs` (3 lines), no overrides.

Runtime dep of the published package → changeset included (`seekstone` patch). Server tests pass (590).