### PR TITLE
fix(semantic): pair the embedding cache manifest with the binary it describes

### DIFF
--- a/.changeset/semantic-cache-pairing.md
+++ b/.changeset/semantic-cache-pairing.md
@@ -1,0 +1,5 @@
+---
+"seekstone": patch
+---
+
+fix(semantic): pair the embedding cache's manifest with the binary it describes, so a manifest left beside another build's binary is rejected instead of mapping every note to another note's vectors. Existing caches are invalidated once by the version bump and re-embedded on next boot.

--- a/packages/server/src/semantic/cache.test.ts
+++ b/packages/server/src/semantic/cache.test.ts
@@ -1,8 +1,8 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { cachePathsFor, loadCache, saveCache } from './cache.js';
+import { cachePathsFor, loadCache, saveCache, tempPathFor } from './cache.js';
 import type { NoteVectors } from './store.js';
 
 describe('semantic cache', () => {
@@ -75,6 +75,52 @@ describe('semantic cache', () => {
     const bin = await readFile(paths.bin);
     await writeFile(paths.bin, bin.subarray(0, bin.length - 4));
     expect(await loadCache(paths, 'm', 2)).toBeUndefined();
+  });
+
+  it('invalidates when the binary is not the one the manifest describes', async () => {
+    const mine = cachePathsFor(root, '/vault/pairing-mine', 'm');
+    const theirs = cachePathsFor(root, '/vault/pairing-theirs', 'm');
+    const otherNotes: Array<[string, NoteVectors]> = [
+      [
+        'Notes/A.md',
+        {
+          packed: new Float32Array([0.25, 0.25, 0.75, 0.75]),
+          spans: new Uint32Array([1, 41, 43, 91]),
+        },
+      ],
+      ['Notes/B.md', { packed: new Float32Array([0.5, 0.5]), spans: new Uint32Array([6, 26]) }],
+    ];
+    await saveCache(mine, 'm', 2, notes, hashes);
+    await saveCache(theirs, 'm', 2, otherNotes, hashes);
+    const foreign = await readFile(theirs.bin);
+    expect(foreign.byteLength).toBe((await readFile(mine.bin)).byteLength);
+
+    await writeFile(mine.bin, foreign);
+
+    expect(await loadCache(mine, 'm', 2)).toBeUndefined();
+  });
+
+  it('serializes entries in a canonical order, whatever order the store yields', async () => {
+    const forward = cachePathsFor(root, '/vault/canon-fwd', 'm');
+    const reverse = cachePathsFor(root, '/vault/canon-rev', 'm');
+    await saveCache(forward, 'm', 2, notes, hashes);
+    await saveCache(reverse, 'm', 2, [...notes].reverse(), hashes);
+
+    expect(await readFile(reverse.bin)).toEqual(await readFile(forward.bin));
+    const fwd = JSON.parse(await readFile(forward.manifest, 'utf8'));
+    const rev = JSON.parse(await readFile(reverse.manifest, 'utf8'));
+    expect(rev.entries).toEqual(fwd.entries);
+    expect(rev.binHash).toBe(fwd.binHash);
+  });
+
+  it('never hands two writers the same temp path', () => {
+    const target = join(root, 'embeddings', 'vault', 'm.bin');
+    const first = tempPathFor(target);
+    const second = tempPathFor(target);
+    expect(first).not.toBe(second);
+    expect(dirname(first)).toBe(dirname(target));
+    expect(dirname(second)).toBe(dirname(target));
+    expect(first).not.toBe(target);
   });
 
   it('returns undefined when no cache exists', async () => {

--- a/packages/server/src/semantic/cache.ts
+++ b/packages/server/src/semantic/cache.ts
@@ -10,14 +10,14 @@ import type { NoteVectors } from './store.js';
  * dir, never inside the vault, in a per-vault subdirectory (sha of the vault
  * root) so multiple vaults never collide.
  *
- * Load is best-effort: any mismatch (version, model, dim, byte lengths)
- * silently invalidates the cache — the build just re-embeds. Writes are
- * temp-file + rename (binary first, then the manifest that describes it),
+ * Load is best-effort: any mismatch (version, model, dim, byte length,
+ * binHash) silently invalidates the cache — the build just re-embeds. Writes
+ * are temp-file + rename (binary first, then the manifest that describes it),
  * so a crash leaves either the old cache or the new one.
  */
 
 /** Bump when the on-disk layout OR the chunker semantics change. */
-const CACHE_VERSION = 2;
+const CACHE_VERSION = 3;
 
 export interface CachePaths {
   dir: string;
@@ -29,6 +29,7 @@ interface CacheManifest {
   version: number;
   modelId: string;
   dim: number;
+  binHash: string;
   entries: Array<{ path: string; contentHash: string; chunks: number }>;
 }
 
@@ -62,6 +63,7 @@ export async function loadCache(
     const vectorBytes = totalChunks * dim * 4;
     const spanBytes = totalChunks * 2 * 4;
     if (buf.byteLength !== vectorBytes + spanBytes) return undefined;
+    if (binHashOf(buf) !== manifest.binHash) return undefined;
     // Buffers can be unaligned for typed-array views — copy to a fresh buffer.
     const aligned = new Uint8Array(buf.byteLength);
     aligned.set(buf);
@@ -92,17 +94,22 @@ export async function saveCache(
   notes: Iterable<[string, NoteVectors]>,
   hashes: ReadonlyMap<string, string>,
 ): Promise<void> {
-  const entries: CacheManifest['entries'] = [];
-  const kept: NoteVectors[] = [];
+  const rows: Array<{ path: string; contentHash: string; chunks: number; note: NoteVectors }> = [];
   let totalChunks = 0;
   for (const [path, note] of notes) {
     const contentHash = hashes.get(path);
     if (!contentHash) continue; // still being (re-)embedded — skip this round
     const chunks = note.packed.length / dim;
-    entries.push({ path, contentHash, chunks });
-    kept.push(note);
+    rows.push({ path, contentHash, chunks, note });
     totalChunks += chunks;
   }
+  rows.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  const entries: CacheManifest['entries'] = rows.map(({ path, contentHash, chunks }) => ({
+    path,
+    contentHash,
+    chunks,
+  }));
+  const kept = rows.map((r) => r.note);
   const bin = new Uint8Array(totalChunks * dim * 4 + totalChunks * 2 * 4);
   const floats = new Float32Array(bin.buffer, 0, totalChunks * dim);
   const spans = new Uint32Array(bin.buffer, totalChunks * dim * 4, totalChunks * 2);
@@ -114,17 +121,35 @@ export async function saveCache(
     floatOffset += note.packed.length;
     spanOffset += note.spans.length;
   }
-  const manifest: CacheManifest = { version: CACHE_VERSION, modelId, dim, entries };
+  const manifest: CacheManifest = {
+    version: CACHE_VERSION,
+    modelId,
+    dim,
+    binHash: binHashOf(bin),
+    entries,
+  };
 
   await mkdir(paths.dir, { recursive: true });
   // Binary first, manifest last: the manifest is the commit point, and load
-  // validates byte lengths, so a torn state just invalidates the cache.
+  // validates the binary against the hash it records, so a torn state just
+  // invalidates the cache.
   await atomicWriteBytes(paths.bin, bin);
   await atomicWriteBytes(paths.manifest, new TextEncoder().encode(JSON.stringify(manifest)));
 }
 
+function binHashOf(bin: Uint8Array): string {
+  return createHash('sha256').update(bin).digest('hex');
+}
+
+let tempSeq = 0;
+
+export function tempPathFor(absPath: string): string {
+  tempSeq += 1;
+  return `${absPath}.${process.pid}.${tempSeq}.seekstone-cache-tmp`;
+}
+
 async function atomicWriteBytes(absPath: string, bytes: Uint8Array): Promise<void> {
-  const tmpPath = `${absPath}.seekstone-cache-tmp`;
+  const tmpPath = tempPathFor(absPath);
   await writeFile(tmpPath, bytes);
   await rename(tmpPath, absPath);
 }


### PR DESCRIPTION
## What & why

The persisted embedding cache can end up describing vectors it does not contain. When it does, every affected note is scored against another note's embedding, semantic and hybrid retrieval degrade sharply, and nothing reports it — no error, no warning, note count and chunk count unchanged. The state is also permanent: restarts and re-indexes do not repair it.

Its my own vault that gave wrong results when I benchmarked - Thats how this happened :)

# What is changed

All in `packages/server/src/semantic/cache.ts`; no call site changes.

| Change | Effect |
|---|---|
| `CacheManifest` gains `binHash`; `saveCache` sets it to `binHashOf(bin)` | the manifest now names the binary it describes |
| `loadCache` rejects when `binHashOf(buf) !== manifest.binHash`, after the existing byte-length check | a manifest paired with any other binary invalidates the cache instead of loading it |
| `saveCache` collects one `rows` array instead of two parallel arrays and sorts it path-ascending | one vault's cache is byte-reproducible instead of following index-build completion order, so two concurrent builds of the same content write identical bytes and a cross-published pair is harmless rather than merely detected. Plain `<`/`>`, not `localeCompare`, so the layout can't vary by locale |
| new `tempPathFor(absPath)` → `<absPath>.<pid>.<seq>.seekstone-cache-tmp`, used by `atomicWriteBytes` | write-then-rename is atomic between processes, not only within one. pid plus a monotonic counter, no RNG |
| `CACHE_VERSION` 2 → 3 | existing caches — the ones that may already be corrupt — invalidate once and re-embed on next boot |

## How it was tested

Four new tests in `packages/server/src/semantic/cache.test.ts`, each written failing first:

- a binary of the correct byte length that is not the one the manifest describes is rejected (same paths, same chunk counts, different vectors)
- identical content saved in two different insertion orders produces a byte-identical binary and manifest
- two writers never receive the same temp path
- existing round-trip, partial-save, version, model/dim and truncation tests pass unchanged

End-to-end on a synthetic 40-note vault with `potion-retrieval-32M` and 40 low-overlap paraphrase queries, comparing each manifest entry's vectors against a fresh embedding of the note it names:

| | before | after |
|---|---|---|
| entry order across two independent builds | 31–36 of 40 positions differ | identical; both binaries share one sha256 |
| three concurrent boots on one cache dir | 4 of 8 rounds corrupt (2, 13, 22, 22 of 40 wrong) | 0 of 8 rounds corrupt |
| r@1 on a corrupt cache | 0.475 (22 of 40 wrong), unchanged after two further boots | not reachable |
| r@1 warm on a healthy cache | 0.675 | 0.675, binary not rewritten |