### PR TITLE
SHA-332: direct download links for both .mcpb bundles in the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ If you use Claude Code, Cursor, or another coding agent, you don't need to follo
 
 ### Option 1 — One-click (Claude Desktop, no terminal needed)
 
-1. Download `seekstone.mcpb` from [GitHub Releases](https://github.com/shaqmughal/seekstone/releases/latest)
+1. Download [`seekstone.mcpb`](https://github.com/shaqmughal/seekstone/releases/latest/download/seekstone.mcpb) (direct link, always the latest release)
 2. Open it with Claude Desktop — double-click in Finder, or right-click → Open With → Claude Desktop
 3. Pick your Obsidian vault folder when prompted
 
 You'll know it worked when seekstone appears in Claude's toolbar. No JSON editing, no terminal, no Node.js required.
 
-Want semantic search? Grab **`seekstone-semantic.mcpb`** instead — same server with the local embedding model shipped inside the bundle (~28 MB bigger), so meaning-based search works out of the box: still no terminal, and nothing is downloaded at runtime.
+Want semantic search? Grab [**`seekstone-semantic.mcpb`**](https://github.com/shaqmughal/seekstone/releases/latest/download/seekstone-semantic.mcpb) instead — same server with the local embedding model shipped inside the bundle (~28 MB bigger), so meaning-based search works out of the box: still no terminal, and nothing is downloaded at runtime.
 
 <img src="docs/mcpb-install-dialog.png" width="420" alt="Claude Desktop showing the seekstone installation dialog" />
 
@@ -419,7 +419,7 @@ Seekstone has been profiled against vaults with thousands of notes. On the commi
 It reads Obsidian's own vault registry (`obsidian.json`) — the same file Obsidian uses to track your known vaults. If you have one vault, it's selected automatically. If you have multiple, it lists them and asks you to pick with `--vault`.
 
 **What is the `.mcpb` file?**
-An MCP Bundle — a self-contained zip with the server and its manifest. To install: double-click in Finder (or right-click → Open With → Claude Desktop), pick your vault, and you're done. No terminal or Node.js required. Two variants ship with every release: `seekstone.mcpb` (standard) and `seekstone-semantic.mcpb` (same server with the local embedding model inside, semantic search on out of the box).
+An MCP Bundle — a self-contained zip with the server and its manifest. To install: double-click in Finder (or right-click → Open With → Claude Desktop), pick your vault, and you're done. No terminal or Node.js required. Two variants ship with every release: [`seekstone.mcpb`](https://github.com/shaqmughal/seekstone/releases/latest/download/seekstone.mcpb) (standard) and [`seekstone-semantic.mcpb`](https://github.com/shaqmughal/seekstone/releases/latest/download/seekstone-semantic.mcpb) (same server with the local embedding model inside, semantic search on out of the box).
 
 ---
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -24,7 +24,7 @@ If you use Claude Code, Cursor, or another coding agent, paste this prompt and t
 
 ### Option 1 — One-click (Claude Desktop, no terminal needed)
 
-Download `seekstone.mcpb` from [GitHub Releases](https://github.com/shaqmughal/seekstone/releases/latest), double-click it in Claude Desktop, and pick your Obsidian vault folder when prompted. No JSON editing, no terminal, no Node.js setup required.
+Download [`seekstone.mcpb`](https://github.com/shaqmughal/seekstone/releases/latest/download/seekstone.mcpb), double-click it in Claude Desktop, and pick your Obsidian vault folder when prompted. No JSON editing, no terminal, no Node.js setup required. Want semantic search out of the box? Grab [`seekstone-semantic.mcpb`](https://github.com/shaqmughal/seekstone/releases/latest/download/seekstone-semantic.mcpb) instead — the local embedding model ships inside the bundle, and nothing is downloaded at runtime.
 
 ### Option 2 — Guided setup (recommended for CLI users)
 


### PR DESCRIPTION
Follow-up to seekstone#318 / seekstone.dev#49: the README content about the two bundles was accurate, but Option 1 linked to the releases *page* and the semantic paragraph had no link at all. Both READMEs now carry direct `releases/latest/download/…` links for `seekstone.mcpb` and `seekstone-semantic.mcpb` (Option 1, FAQ, and the npm-facing server README) — the latest-release URLs never need updating per version. `check-docs-sync` passes.

Docs-only; no changeset needed (matches SHA-327 precedent of README-only patches riding the next release — actually including none since no package behavior changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALxmRYGBvFdGcp5a9P9Dys